### PR TITLE
Fix completion handlers and get builds working

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		7B8662965A406B52E017499708C29093 /* GIDMDMPasscodeState.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EB6805673A93176492D6644EDF42CD4 /* GIDMDMPasscodeState.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		7C67CBD15D9B5D0B7769B2F469478332 /* FBSnapshotTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = AE56AE1C4286FD02C7B298A7ED694A18 /* FBSnapshotTestCase.m */; };
 		7D02B5B52AEBDF06DA2B08399F64B418 /* GTMSessionUploadFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F20460EC6633B9230F7E712BFA02097 /* GTMSessionUploadFetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7E06344E29259384004E23CC /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E06344D29259384004E23CC /* Result.swift */; };
 		7EB608DA291EF37800CF1346 /* mpc.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7EB608D9291EF37800CF1346 /* mpc.xcframework */; };
 		7EB608DB291EF38C00CF1346 /* mpc.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7EB608D9291EF37800CF1346 /* mpc.xcframework */; };
 		7EB608DC291EF38C00CF1346 /* mpc.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7EB608D9291EF37800CF1346 /* mpc.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -486,6 +487,7 @@
 		7C86451E8631CBE895ED5A1F8E929DF1 /* PortalSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PortalSwift.release.xcconfig; sourceTree = "<group>"; };
 		7D339CE9034D5E14F8D0FCECBF17C61B /* FBSnapshotTestCasePlatform.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestCasePlatform.m; path = FBSnapshotTestCase/FBSnapshotTestCasePlatform.m; sourceTree = "<group>"; };
 		7DEBE39160786975AF0CB3399DF96A38 /* GIDSignInStrings.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GIDSignInStrings.h; path = GoogleSignIn/Sources/GIDSignInStrings.h; sourceTree = "<group>"; };
+		7E06344D29259384004E23CC /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		7EB608D9291EF37800CF1346 /* mpc.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = mpc.xcframework; sourceTree = "<group>"; };
 		7F0575BE2BA383CEF487DB18CD24E5A6 /* PortalMpc.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PortalMpc.swift; sourceTree = "<group>"; };
 		7F20460EC6633B9230F7E712BFA02097 /* GTMSessionUploadFetcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GTMSessionUploadFetcher.h; path = Sources/Core/Public/GTMSessionFetcher/GTMSessionUploadFetcher.h; sourceTree = "<group>"; };
@@ -1285,6 +1287,7 @@
 			children = (
 				9FAC37A50350CAFC96707C99A92F8F31 /* HttpRequest.swift */,
 				D532CCDA52631126E18676C0D0938B1F /* Requesters */,
+				7E06344D29259384004E23CC /* Result.swift */,
 			);
 			name = Utils;
 			path = PortalSwift/Classes/Utils;
@@ -1847,6 +1850,7 @@
 				3067F903C33980C62862D664AE88ED2E /* HttpRequest.swift in Sources */,
 				1F6AB0DF6788AB72DE2E3A4C94F8873A /* HttpRequester.swift in Sources */,
 				7031BDE2F7891F5EDB9693387E88A896 /* ICloudStorage.swift in Sources */,
+				7E06344E29259384004E23CC /* Result.swift in Sources */,
 				7F6781E460190FC8C5ECDF2CFBB2D7B3 /* MpcSigner.swift in Sources */,
 				CD1035D8A5E30274A3E1DBBC33D41C35 /* Portal.swift in Sources */,
 				479E372E292567740080AEDB /* MockPortalApi.swift in Sources */,

--- a/Example/PortalSwift/ViewController.swift
+++ b/Example/PortalSwift/ViewController.swift
@@ -41,7 +41,7 @@ class ViewController: UIViewController {
   
   @IBAction func handleBackup(_ sender: UIButton!) throws -> Void {
     print(String(format: "Tapped button: ", sender))
-    _ = try portal?.mpc.backup(method: BackupMethods.GoogleDrive.rawValue)
+    _ = try portal?.mpc.backup(method: BackupMethods.iCloud.rawValue)
   }
   
   @IBAction func handleGenerate(_ sender: UIButton!) throws -> Void {
@@ -51,7 +51,10 @@ class ViewController: UIViewController {
   
   @IBAction func handleRecover(_ sender: UIButton!) throws -> Void {
     print(String(format: "Tapped button: ", sender))
-    _ = try portal?.mpc.recover(cipherText: "", method: BackupMethods.GoogleDrive.rawValue)
+    portal?.mpc.recover(cipherText: "", method: BackupMethods.iCloud.rawValue) {
+      (result: Result<String>) -> Void in
+      print(result)
+    }
   }
   
   @IBAction func handleSend(_ sender: UIButton!) throws -> Void {
@@ -68,7 +71,7 @@ class ViewController: UIViewController {
   
   func registerPortal() -> Void {
     do {
-      let backup = BackupOptions(gdrive: GDriveStorage())
+      let backup = BackupOptions(icloud: ICloudStorage())
       let keychain = PortalKeychain()
       portal = try Portal(
         apiKey: "31515686-b8c4-48d5-a5e7-1b0f0d876a10",

--- a/Example/Tests/ICloudStorage.swift
+++ b/Example/Tests/ICloudStorage.swift
@@ -22,20 +22,46 @@ final class ICloudStorageTest: XCTestCase {
     }
 
     func testDelete() throws {
-        let privateKey = "privateKey"
-        _ = try storage!.write(privateKey: privateKey)
-        XCTAssert(try storage!.read() == privateKey)
-        _ = try storage!.delete()
-        XCTAssert(try storage!.read() == "")
+      let privateKey = "privateKey"
+      storage!.write(privateKey: privateKey) {
+        (result: Result<Bool>) -> Void in
+        
+        do {
+          self.storage!.read() {
+            (result: Result<String>) -> Void in
+            XCTAssert(result.data! == privateKey)
+            
+            self.storage!.delete() {
+              (result: Result<Bool>) -> Void in
+              XCTAssert(result.data! == true)
+              
+              self.storage!.read() {
+                (result: Result<String>) -> Void in
+                XCTAssert(result.data! == "")
+              }
+            }
+          }
+      }
     }
 
     func testRead() throws {
-        XCTAssert(try storage!.read() == "")
+      storage!.read() {
+        (result: Result<String>) -> Void in
+        XCTAssert(result.data! == "")
+      }
     }
 
     func testWrite() throws {
-        let privateKey = "privateKey"
-        _ = try storage!.write(privateKey: privateKey)
-        XCTAssert(try storage!.read() == privateKey)
+      let privateKey = "privateKey"
+      storage!.write(privateKey: privateKey) {
+        (result: Result<Bool>) -> Void in
+          XCTAssert(result.data! == true)
+          
+          self.storage!.read() {
+            (result: Result<String>) -> Void in
+            XCTAssert(result.data! == privateKey)
+          }
+        }
+      }
     }
 }

--- a/Mocks/Core/MockPortalApi.swift
+++ b/Mocks/Core/MockPortalApi.swift
@@ -13,7 +13,7 @@ public class MockPortalApi: PortalApi {
   public var dapps: [Dapp]?
   public var networks: [ContractNetwork]?
 
-  public override func getClient(completion: @escaping (Client) -> Void) throws -> Void {
+  public override func getClient(completion: @escaping (Result<Client>) -> Void) -> Void {
     // Make an instance of Client.
     let client = Client(
       id: "fakeClientID",
@@ -26,18 +26,18 @@ public class MockPortalApi: PortalApi {
     )
 
     // Call the completion handler.
-    completion(client)
+    completion(Result(data: client))
   }
 
-  public override func getEnabledDapps(completion: @escaping ([Dapp]) -> Void) throws -> Void {
+  public override func getEnabledDapps(completion: @escaping (Result<[Dapp]>) -> Void) -> Void {
     if let dapps = dapps {
-      completion(dapps)
+      completion(Result(data: dapps))
     }
   }
 
-  public override func getSupportedNetworks(completion: @escaping ([ContractNetwork]) -> Void) throws -> Void {
+  public override func getSupportedNetworks(completion: @escaping (Result<[ContractNetwork]>) -> Void) -> Void {
     if let networks = networks {
-      completion(networks)
+      completion(Result(data: networks))
     }
   }
 }

--- a/PortalSwift/Classes/Core/PortalApi.swift
+++ b/PortalSwift/Classes/Core/PortalApi.swift
@@ -70,14 +70,14 @@ public class PortalApi {
   /// ```
   ///
   /// - Returns: Void
-  public func getClient(completion: @escaping (Client) -> Void) throws -> Void {
+  public func getClient(completion: @escaping (Result<Client>) -> Void) throws -> Void {
     try requests.get(
       path: "/api/v1/clients/me",
       headers: [
         "Authorization": String(format: "Bearer %@", apiKey)
       ]
-    ) { (client: Client) -> Void in
-      completion(client)
+    ) { (result: Result<Client>) -> Void in
+      completion(result)
     }
   }
 
@@ -91,14 +91,14 @@ public class PortalApi {
   /// ```
   ///
   /// - Returns: [Dapp]
-  public func getEnabledDapps(completion: @escaping ([Dapp]) -> Void) throws -> Void {
+  public func getEnabledDapps(completion: @escaping (Result<[Dapp]>) -> Void) throws -> Void {
     try requests.get(
       path: "/api/v1/config/dapps",
       headers: [
         "Authorization": String(format: "Bearer %@", apiKey)
       ]
-    ) { (dapps: [Dapp]) -> Void in
-      completion(dapps)
+    ) { (result: Result<[Dapp]>) -> Void in
+      completion(result)
     }
   }
 
@@ -112,14 +112,14 @@ public class PortalApi {
   /// ```
   ///
   /// - Returns: [ContractNetwork]
-  public func getSupportedNetworks(completion: @escaping ([ContractNetwork]) -> Void) throws -> Void {
+  public func getSupportedNetworks(completion: @escaping (Result<[ContractNetwork]>) -> Void) throws -> Void {
     try requests.get(
       path: "/api/v1/config/networks",
       headers: [
         "Authorization": String(format: "Bearer %@", apiKey)
       ]
-    ) { (networks: [ContractNetwork]) -> Void in
-      completion(networks)
+    ) { (result: Result<[ContractNetwork]>) -> Void in
+      completion(result)
     }
   }
 }

--- a/PortalSwift/Classes/Storage/GDriveStorage.swift
+++ b/PortalSwift/Classes/Storage/GDriveStorage.swift
@@ -10,6 +10,10 @@ import Foundation
 
 import GoogleSignIn
 
+public enum GDriveStorageError: Error {
+  case unknownError
+}
+
 public class GDriveStorage: Storage {
   public var accessToken: String?
   public var api: PortalApi?
@@ -23,19 +27,19 @@ public class GDriveStorage: Storage {
 
   }
 
-  public override func delete() throws -> Bool {
-    return true
+  public override func delete(completion: @escaping (Result<Bool>) -> Void) -> Void {
+    return completion(Result(error: GDriveStorageError.unknownError))
   }
 
-  public override func read() throws -> String {
-    return ""
+  public override func read(completion: @escaping (Result<String>) -> Void) -> Void {
+    return completion(Result(data: ""))
   }
 
-  public override func write(privateKey: String) throws -> Bool {
-    return true
+  public override func write(privateKey: String, completion: @escaping (Result<Bool>) -> Void) -> Void {
+    return completion(Result(error: GDriveStorageError.unknownError))
   }
 
-  private func signIn() throws -> Void {
-
+  private func signIn() -> Void {
+    return
   }
 }

--- a/PortalSwift/Classes/Storage/Storage.swift
+++ b/PortalSwift/Classes/Storage/Storage.swift
@@ -13,15 +13,15 @@ private enum StorageError: Error {
 }
 
 public class Storage {
-  public func delete() throws -> Bool {
-    throw StorageError.mustExtendStorageClass
+  public func delete(completion: @escaping (Result<Bool>) -> Void) -> Void {
+    completion(Result(error: StorageError.mustExtendStorageClass))
   }
 
-  public func read() throws -> String {
-    throw StorageError.mustExtendStorageClass
+  public func read(completion: @escaping (Result<String>) -> Void) -> Void {
+    completion(Result(error: StorageError.mustExtendStorageClass))
   }
 
-  public func write(privateKey: String) throws -> Bool {
-    throw StorageError.mustExtendStorageClass
+  public func write(privateKey: String, completion: @escaping (Result<Bool>) -> Void) -> Void {
+    completion(Result(error: StorageError.mustExtendStorageClass))
   }
 }

--- a/PortalSwift/Classes/Utils/Requesters/HttpRequester.swift
+++ b/PortalSwift/Classes/Utils/Requesters/HttpRequester.swift
@@ -25,7 +25,7 @@ public struct HttpRequester {
   func get<T: Codable>(
     path: String,
     headers: Dictionary<String, String>,
-    completion: @escaping (T) -> Void
+    completion: @escaping (Result<T>) -> Void
   ) throws -> Void {
     // Build the HTTPRequest object
     let url = String(format:"%@%@", self.baseUrl, path)
@@ -35,11 +35,10 @@ public struct HttpRequester {
       body: [:],
       headers: headers
     )
-    do {
-      // Send the HTTP request
-      try request.send() { (response: T) -> Void in
-        completion(response)
-      }
+    
+    // Send the HTTP request
+    request.send() { (result: Result<T>) -> Void in
+      return completion(result)
     }
   }
 
@@ -47,7 +46,7 @@ public struct HttpRequester {
     path: String,
     body: U,
     headers: Dictionary<String, String>,
-    completion: @escaping (T) -> Void
+    completion: @escaping (Result<T>) -> Void
   ) throws -> Void {
     // Build the HTTPRequest object
     let request = HttpRequest<T, U>(
@@ -57,11 +56,9 @@ public struct HttpRequester {
       headers: headers
     )
 
-    do {
-      // Send the HTTP request
-      try request.send() { (response: T) -> Void in
-        completion(response)
-      }
+    // Send the HTTP request
+    request.send() { (result: Result<T>) -> Void in
+      completion(result)
     }
   }
 }

--- a/PortalSwift/Classes/Utils/Result.swift
+++ b/PortalSwift/Classes/Utils/Result.swift
@@ -1,0 +1,26 @@
+//
+//  Result.swift
+//  PortalSwift
+//
+//  Created by Blake Williams on 11/16/22.
+//
+
+import Foundation
+
+public struct Result<T: Codable> {
+  public var data: T?
+  public var error: Error?
+  
+  public init(data: T) {
+    self.data = data
+  }
+  
+  public init(error: Error) {
+    self.error = error
+  }
+  
+  public init(data: T, error: Error) {
+    self.data = data
+    self.error = error
+  }
+}


### PR DESCRIPTION
- Uses a new `Result<T: Codable>` struct for all async actions
- Updates consumers of `HttpRequest` to expect `Result` instances and use completion handlers
- Updates `PortalMpc` and `ICloudStorage` to use completion handlers