### PR TITLE
Recovery - address fix

### DIFF
--- a/Example/PortalSwift.xcodeproj/project.pbxproj
+++ b/Example/PortalSwift.xcodeproj/project.pbxproj
@@ -279,7 +279,7 @@
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
-						DevelopmentTeam = WTQ4Q66FY6;
+						DevelopmentTeam = 9H95QB7A34;
 						LastSwiftMigration = "";
 					};
 					607FACE41AFB9204008FA782 = {
@@ -591,7 +591,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = PortalSwift_Example.entitlements;
-				DEVELOPMENT_TEAM = WTQ4Q66FY6;
+				DEVELOPMENT_TEAM = 9H95QB7A34;
 				INFOPLIST_FILE = PortalSwift/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -609,7 +609,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = PortalSwift_Example.entitlements;
-				DEVELOPMENT_TEAM = WTQ4Q66FY6;
+				DEVELOPMENT_TEAM = 9H95QB7A34;
 				INFOPLIST_FILE = PortalSwift/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Example/PortalSwift/Base.lproj/Main.storyboard
+++ b/Example/PortalSwift/Base.lproj/Main.storyboard
@@ -166,7 +166,7 @@
                                 </connections>
                             </button>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="Address: N/A" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="0fE-Dt-jQE">
-                                <rect key="frame" x="16" y="223" width="343" height="44"/>
+                                <rect key="frame" x="16" y="229" width="343" height="44"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <color key="textColor" systemColor="labelColor"/>
@@ -181,6 +181,20 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QJh-Gs-d32">
+                                <rect key="frame" x="208" y="193" width="153" height="28"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Delete Keychain">
+                                    <backgroundConfiguration key="background">
+                                        <color key="backgroundColor" systemColor="systemPinkColor"/>
+                                    </backgroundConfiguration>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="handleDeleteKeychain:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="t3k-ZL-4Lv"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>

--- a/Example/PortalSwift/ViewController.swift
+++ b/Example/PortalSwift/ViewController.swift
@@ -175,6 +175,7 @@ class ViewController: UIViewController {
             print("✅ handleRecover(): Successfully sent custodian cipherText:", result.data!)
           }
         }
+        self.updateStaticContent()
       }
     }
   }
@@ -197,6 +198,22 @@ class ViewController: UIViewController {
     injectWebView()
   }
 
+  @IBAction func handleDeleteKeychain(_ sender: Any) {
+    deleteKeychain()
+    updateStaticContent()
+  }
+  func deleteKeychain() {
+    do {
+      print("Here is the keychain address: ", try portal?.keychain.getAddress() ?? "")
+      try portal?.keychain.deleteAddress()
+      try portal?.keychain.deleteSigningShare()
+      
+      print("Now its gone: ", try portal?.keychain.getAddress() ?? "")
+    } catch {
+      print(" ✅  Deleted keychain:", error)
+
+    }
+  }
   func updateStaticContent() {
     populateAddressInformation()
     // populateEthBalance()
@@ -209,6 +226,9 @@ class ViewController: UIViewController {
         self.addressInformation.text = "Address: \(address ?? "N/A")"
       }
     } catch {
+      DispatchQueue.main.async {
+        self.addressInformation.text = "Address: N/A"
+      }
       print("❌ Error getting address:", error)
     }
   }

--- a/Example/Tests/PortalMpcTests.swift
+++ b/Example/Tests/PortalMpcTests.swift
@@ -13,7 +13,7 @@ final class PortalMpcTests: XCTestCase {
   var mpc: PortalMpc?
 
   override func setUpWithError() throws {
-    mpc = MockPortalMpc(apiKey: "test", chainId: 5, keychain: MockPortalKeychain(), storage: BackupOptions(icloud: MockICloudStorage()), gatewayUrl: "testurl")
+    mpc = MockPortalMpc(apiKey: "test", chainId: 5, keychain: MockPortalKeychain(), storage: BackupOptions(icloud: MockICloudStorage()), gatewayUrl: "testurl", api: MockPortalApi(apiKey: "test"))
   }
 
   override func tearDownWithError() throws {

--- a/PortalSwift/Classes/Core/Portal.swift
+++ b/PortalSwift/Classes/Core/Portal.swift
@@ -154,6 +154,7 @@ public class Portal {
       keychain: keychain,
       storage: backup,
       gatewayUrl: gatewayUrl,
+      api: self.api,
       isSimulator: isSimulator,
       mpcHost: mpcHost
     )

--- a/PortalSwift/Classes/Core/PortalKeychain.swift
+++ b/PortalSwift/Classes/Core/PortalKeychain.swift
@@ -46,6 +46,19 @@ public class PortalKeychain {
   public func setSigningShare(signingShare: String) throws  {
     try setItem(key: SigningShare, value: signingShare)
   }
+  
+  /// Deletes the address stored in the client's keychain.
+  /// - Returns: The client's address.
+  public func deleteAddress() throws {
+    try deleteItem(key: Address)
+  }
+
+  /// Deletes the signing share stored in the client's keychain.
+  /// - Returns: The client's signing share.
+  public func deleteSigningShare() throws {
+    try deleteItem(key: SigningShare)
+
+  }
 
   private func getItem(item: String) throws -> String {
     // Construct the query to retrieve the keychain item.
@@ -119,5 +132,16 @@ public class PortalKeychain {
     guard status == errSecSuccess else {
       throw KeychainError.unhandledError(status: status)
     }
+  }
+  
+  private func deleteItem(key: String) throws {
+    let query: [String: AnyObject] = [
+      kSecAttrService as String: "PortalMpc.\(key)" as AnyObject,
+      kSecAttrAccount as String: key as AnyObject,
+      kSecClass as String: kSecClassGenericPassword
+    ]
+    
+    let status = SecItemDelete(query as CFDictionary)
+    guard status == errSecSuccess || status == errSecItemNotFound else { throw KeychainError.unhandledError(status: status) }
   }
 }


### PR DESCRIPTION
This PR:
- Adds to the recovery function so that we now reach out to Portal's API in order to set the address properly
- Adds two new keychain functions `deleteAddress` and deleteSigningShare` 
  - this allows us to better test the recovery functionality without needing a new device
- Adds a delete keychain button that uses those functions in the example app