### PR TITLE
Change conditional to check if user has icloud kv storage enabled

### DIFF
--- a/PortalSwift/Classes/Storage/ICloudStorage.swift
+++ b/PortalSwift/Classes/Storage/ICloudStorage.swift
@@ -138,7 +138,7 @@ We highly recommend using real devices to test the recovery process.
     }
 
     // Check if the user has iCloud Key-Value Storage enabled.
-    if FileManager.default.url(forUbiquityContainerIdentifier: nil) == nil {
+    if NSUbiquitousKeyValueStore.default.synchronize() == false {
       return ICloudStatus.noAccess.rawValue
     }
 


### PR DESCRIPTION
# Description

This PR changes the implementation of our check to see if the user has iCloud enabled after proving that they are signed into their iCloud account.