### PR TITLE
Use the completion/result model in `generate` function

### DIFF
--- a/Example/PortalSwift/ViewController.swift
+++ b/Example/PortalSwift/ViewController.swift
@@ -92,13 +92,16 @@ class ViewController: UIViewController {
   }
 
   @IBAction func handleGenerate(_ sender: UIButton!) {
-    do {
-      let address = try portal?.mpc.generate()
-      print("✅ handleGenerate(): Address:", address ?? "N/A")
-    } catch {
-      print("❌ Error generating address:", error)
+    portal?.mpc.generate() { (addressResult) -> Void in
+      if (addressResult.error != nil) {
+        print("❌ handleGenerate():", addressResult.error!)
+      }
+      
+      print("✅ handleGenerate(): Address:", addressResult.data ?? "N/A")
+      
+      
+      self.updateStaticContent()
     }
-    updateStaticContent()
   }
 
   @IBAction func handleBackup(_ sender: UIButton!) {

--- a/Example/Tests/PortalMpcTests.swift
+++ b/Example/Tests/PortalMpcTests.swift
@@ -30,8 +30,9 @@ final class PortalMpcTests: XCTestCase {
   }
 
   func testGenerate() throws {
-    let address = try mpc?.generate()
-    XCTAssert(address == mockAddress)
+    mpc?.generate() { addressResult in
+      XCTAssert(addressResult.data == mockAddress)
+    }
   }
 
   func testRecover() throws {

--- a/PortalSwift/Classes/Mocks/Core/MockPortalMpc.swift
+++ b/PortalSwift/Classes/Mocks/Core/MockPortalMpc.swift
@@ -13,8 +13,8 @@ public class MockPortalMpc: PortalMpc {
     completion(Result(data: mockBackupShare))
   }
 
-  public override func generate() throws -> String {
-    return mockAddress
+  public override func generate(completion: @escaping (Result<String>) -> Void) -> Void {
+    completion(Result(data: mockAddress))
   }
 
   public override func recover(cipherText: String, method: BackupMethods.RawValue, completion: @escaping (Result<String>) -> Void) -> Void {


### PR DESCRIPTION
- Updates `generate` to use the `completion`/`Result<T>` model
- Updates tests to support the new model
- Updates the example app `ViewController` to support the new model