### PR TITLE
Added success completion handler

### DIFF
--- a/Example/PortalSwift/ViewController.swift
+++ b/Example/PortalSwift/ViewController.swift
@@ -413,10 +413,10 @@ class ViewController: UIViewController {
       
       DispatchQueue.main.async {
         do {
+          self.generateButton.isEnabled = true
+          
           let address = try self.portal?.keychain.getAddress()
           let hasAddress = address?.count ?? 0 > 0
-          
-          self.generateButton.isEnabled = true
           
           self.backupButton.isEnabled = hasAddress
           self.dappBrowserButton.isEnabled = hasAddress

--- a/PortalSwift/Classes/Core/PortalKeychain.swift
+++ b/PortalSwift/Classes/Core/PortalKeychain.swift
@@ -133,6 +133,7 @@ public class PortalKeychain: MobileStorageAdapter {
       guard status == errSecSuccess else {
         return completion(Result(error: KeychainError.unhandledError(status: status)))
       }
+      return completion(Result(data: status))
     } catch {
       return completion(Result(error: error))
     }


### PR DESCRIPTION
We were not testing properly. We should be deleting the keychain as if running on a fresh device to test initial generate.

This PR adds the line for the success case for the keychain storage