### PR TITLE
Generate return type bug

### DIFF
--- a/Example/PortalSwift/ViewController.swift
+++ b/Example/PortalSwift/ViewController.swift
@@ -155,8 +155,9 @@ class ViewController: UIViewController {
 
   @IBAction func handleGenerate(_ sender: UIButton!) {
     portal?.mpc.generate() { (addressResult) -> Void in
-      if (addressResult.error != nil) {
-        print("❌ handleGenerate():", addressResult.error!)
+      guard addressResult.error == nil else {
+        print("❌ handleGenerate():", ((addressResult.error as! PortalMpcError).description))
+        return
       }
       
       print("✅ handleGenerate(): Address:", addressResult.data ?? "N/A")
@@ -180,7 +181,7 @@ class ViewController: UIViewController {
     print("Starting backup...")
     portal?.mpc.backup(method: BackupMethods.GoogleDrive.rawValue)  { (result: Result<String>) -> Void in
       if (result.error != nil) {
-        print("❌ handleBackup():", result.error!)
+        print("❌ handleBackup():",  (result.error as! PortalMpcError).description)
       } else {
         let request = HttpRequest<String, [String : String]>(
           url: self.CUSTODIAN_SERVER_URL! + "/mobile/\(self.user!.exchangeUserId)/cipher-text",
@@ -218,9 +219,9 @@ class ViewController: UIViewController {
       let cipherText = result.data!.cipherText
 
       self.portal?.mpc.recover(cipherText: cipherText, method: BackupMethods.GoogleDrive.rawValue) { (result: Result<String>) -> Void in
-        if (result.error != nil) {
-          print("❌ handleRecover(): portal.mpc.recover", result.error!)
-          return;
+        guard result.error == nil else {
+          print("❌ handleRecover(): Error fetching cipherText:", (result.error as! PortalMpcError).description)
+          return
         }
 
         print("✅ handleRecover(): portal.mpc.recover - cipherText:", result.data!)

--- a/PortalSwift/Classes/Core/PortalMpc.swift
+++ b/PortalSwift/Classes/Core/PortalMpc.swift
@@ -14,15 +14,15 @@ import Mpc
 /// CGGMP shares will contain all fields except: pubkey.
 public struct MpcShare: Codable {
   public var share: String
-  public var allY: PartialPublicKey
-  public var bks: Berkhoffs
+  public var allY: PartialPublicKey?
+  public var bks: Berkhoffs?
   public var p: String
-  public var partialPubkey: PartialPublicKey
-  public var pederson: Pedersons
+  public var partialPubkey: PartialPublicKey?
+  public var pederson: Pedersons?
   public var q: String
   public var ssid: String
   public var clientId: String
-  public var pubkey: PublicKey
+  public var pubkey: PublicKey?
 }
 
 /// In the bks dictionary for an MPC share, Berkhoff is the value.
@@ -33,31 +33,31 @@ public struct Berkhoff: Codable {
 
 /// A partial public key for client and server (x, y)
 public struct PartialPublicKey: Codable {
-  public var client: PublicKey
-  public var server: PublicKey
+  public var client: PublicKey?
+  public var server: PublicKey?
 }
 
 /// A berhkoff coefficient mapping for client and server (x, rank)
 public struct Berkhoffs: Codable {
-  public var client: Berkhoff
-  public var server: Berkhoff
+  public var client: Berkhoff?
+  public var server: Berkhoff?
 }
 
 public struct Pederson: Codable {
-  public var n: String
-  public var s: String
-  public var t: String
+  public var n: String?
+  public var s: String?
+  public var t: String?
 }
 
 public struct Pedersons: Codable {
-  public var client: Pederson
-  public var server: Pederson
+  public var client: Pederson?
+  public var server: Pederson?
 }
 
 /// A public key's coordinates (x, y).
 public struct PublicKey: Codable {
-  public var X: String
-  public var Y: String
+  public var X: String?
+  public var Y: String?
 }
 
 private struct DecryptResult: Codable {
@@ -83,7 +83,7 @@ private struct EncryptResult: Codable {
 /// The data for GenerateResult.
 public struct GenerateData: Codable {
   public var address: String
-  public var dkgResult: MpcShare
+  public var dkgResult: MpcShare?
 }
 
 /// The response from generating.


### PR DESCRIPTION
We discovered that when we run generate twice we get a decoding issue instead of an mpc error. 
That was because of the strict typing of swift and us not having all nested attributes of an optional type in `GenerateResult` be optional. This PR: Sets all the nested types of the data object in the `GenerateResult` as optional as well as improves the error handling in the view controller to properly show those errors 