### PR TITLE
Add api.storedClientSigningShare check in generate + recover/signing

### DIFF
--- a/PortalSwift/Classes/Core/PortalApi.swift
+++ b/PortalSwift/Classes/Core/PortalApi.swift
@@ -358,4 +358,22 @@ public class PortalApi {
       completion(result)
     }
   }
+  
+  /// Updates the client's wallet state to be stored on the client.
+  /// - Parameter completion: The callback that contains the response status.
+  /// - Returns: Void.
+  public func storedClientSigningShare(
+    completion: @escaping (Result<String>) -> Void
+  ) throws -> Void {
+    try requests.put(
+        path: "/api/v1/clients/me/wallet/stored-on-client",
+        body: [:],
+        headers: [
+          "Authorization": String(format: "Bearer %@", apiKey)
+        ],
+        requestType: HttpRequestType.CustomRequest
+    ) { (result: Result<String>) -> Void in
+      completion(result)
+    }
+  }
 }

--- a/PortalSwift/Classes/Core/PortalKeychain.swift
+++ b/PortalSwift/Classes/Core/PortalKeychain.swift
@@ -33,14 +33,13 @@ public class PortalKeychain: MobileStorageAdapter {
   /// - Returns: The client's signing share.
   override public func getSigningShare() throws -> String {
     return try getItem(item: SigningShare)
-    
   }
   
   /// Sets the address in the client's keychain.
   /// - Parameter address: The public address of the client's wallet.
-  override public func setAddress(
+  public func setAddress(
     address: String,
-    completion: (Result<OSStatus>) -> Void
+    completion: @escaping (Result<OSStatus>) -> Void
   ) {
     setItem(key: Address, value: address) { result in
       // Handle errors
@@ -54,9 +53,9 @@ public class PortalKeychain: MobileStorageAdapter {
   
   /// Sets the signing share in the client's keychain.
   /// - Parameter signingShare: A dkg object.
-  override public func setSigningShare(
+  public func setSigningShare(
     signingShare: String,
-    completion: (Result<OSStatus>) -> Void
+    completion: @escaping (Result<OSStatus>) -> Void
   ) -> Void {
     setItem(key: SigningShare, value: signingShare) { result in
       // Handle errors
@@ -81,7 +80,7 @@ public class PortalKeychain: MobileStorageAdapter {
   }
   
   /// Tests `setItem` in the client's keychain.
-  public func testSetItem(completion: (Result<OSStatus>) -> Void) {
+  public func testSetItem(completion: @escaping (Result<OSStatus>) -> Void) {
     let testKey = "answer"
     setItem(key: testKey, value: "42") { [weak self] result in
       // Handle errors.
@@ -130,7 +129,7 @@ public class PortalKeychain: MobileStorageAdapter {
   private func setItem(
     key: String,
     value: String,
-    completion: (Result<OSStatus>) -> Void
+    completion: @escaping (Result<OSStatus>) -> Void
   ) -> Void {
     do {
       // Construct the query to set the keychain item.

--- a/PortalSwift/Classes/Utils/HttpRequester.swift
+++ b/PortalSwift/Classes/Utils/HttpRequester.swift
@@ -80,4 +80,26 @@ public class HttpRequester {
       completion(result)
     }
   }
+  
+  func put<T: Codable>(
+    path: String,
+    body: Dictionary<String, Any>?,
+    headers: Dictionary<String, String>,
+    requestType: HttpRequestType,
+    completion: @escaping (Result<T>) -> Void
+  ) throws -> Void {
+    // Create the request.
+    let request = HttpRequest<T, Dictionary<String, Any>?>(
+      url: String(format:"%@%@", self.baseUrl, path),
+      method: "PUT",
+      body: body,
+      headers: headers,
+      requestType: requestType
+    )
+
+    // Attempt to send the request.
+    request.send() { (result: Result<T>) -> Void in
+      completion(result)
+    }
+  }
 }


### PR DESCRIPTION
# Description

This PR adds `portal.api.storedClientSigningShare` and uses it after successfully storing the client signing share in keychain on `generate` and `recover/signing` in `PortalMpc`.