### PR TITLE
Fix Connected Event handler

### DIFF
--- a/PortalSwift/Classes/Connect/PortalConnect.swift
+++ b/PortalSwift/Classes/Connect/PortalConnect.swift
@@ -172,7 +172,7 @@ public class PortalConnect {
     client.close()
   }
   
-  func handleConnected(data: ConnectData) {
+  func handleConnected(data: ConnectedData) {
     connected = true
     _ = portal.provider.emit(event: Events.Connect.rawValue, data: data)
   }


### PR DESCRIPTION
- Replaces the data type for the handler so it registers it correctly in the `PortalConnect` class.