### PR TITLE
ENG-1095 - Portal Connect Provider & Portal helper functions

### DIFF
--- a/Example/PortalSwift/AppDelegate.swift
+++ b/Example/PortalSwift/AppDelegate.swift
@@ -46,8 +46,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, PortalExampleAppDelegate 
       connect != nil
       && ((connect?.connected) != nil)
       && connect?.client != nil
-      && connect?.client.isConnected != nil
-      && !(connect?.client.isConnected)!
+      && connect?.client?.isConnected != nil
+      && !(connect?.client?.isConnected)!
       && connect?.uri != nil
     {
       let uri = connect?.uri ?? nil
@@ -60,8 +60,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, PortalExampleAppDelegate 
       connect2 != nil
       && ((connect2?.connected) != nil)
       && connect2?.client != nil
-      && connect2?.client.isConnected != nil
-      && !(connect2?.client.isConnected)!
+      && connect2?.client?.isConnected != nil
+      && !(connect2?.client?.isConnected)!
     {
       let uri = connect2?.uri ?? nil
       if uri != nil {

--- a/Example/PortalSwift/ConnectViewController.swift
+++ b/Example/PortalSwift/ConnectViewController.swift
@@ -50,14 +50,18 @@ class ConnectViewController: UIViewController {
     let LOCAL_CONNECT_SERVER_URL = "localhost:3003"
     let CONNECT_URL = ENV == "prod" ? PROD_CONNECT_SERVER_URL : ENV == "staging" ? STAGING_CONNECT_SERVER_URL : LOCAL_CONNECT_SERVER_URL
 
-    connect = PortalConnect(portal!, CONNECT_URL)
-    connect2 = PortalConnect(portal!, CONNECT_URL)
+    do {
+      connect = try portal!.createPortalConnectInstance(webSocketServer: CONNECT_URL)
+      connect2 = try portal!.createPortalConnectInstance(webSocketServer: CONNECT_URL)
 
-    app.connect = connect
-    app.connect2 = connect2
+      app.connect = connect
+      app.connect2 = connect2
 
-    initPortalConnect(portalConnect: connect!, button: connectButton, label: "connect1")
-    initPortalConnect(portalConnect: connect2!, button: connectButton2, label: "connect2", autoApprove: false)
+      initPortalConnect(portalConnect: connect!, button: connectButton, label: "connect1")
+      initPortalConnect(portalConnect: connect2!, button: connectButton2, label: "connect2", autoApprove: false)
+    } catch {
+      print("[ConnectViewController] Unable to create PortalConnect instances \(error)")
+    }
   }
 
   func initPortalConnect(portalConnect: PortalConnect, button: UIButton, label: String, autoApprove: Bool = true) {

--- a/Example/PortalSwift/Portal.swift
+++ b/Example/PortalSwift/Portal.swift
@@ -157,7 +157,7 @@ class PortalWrapper {
   }
 
   func generate(completion: @escaping (Result<String>) -> Void) {
-    portal?.mpc.generate { addressResult in
+    portal?.createWallet { addressResult in
       guard addressResult.error == nil else {
         return completion(Result(error: addressResult.error!))
       }
@@ -169,7 +169,7 @@ class PortalWrapper {
   }
 
   func backup(backupMethod: BackupMethods.RawValue, user: UserResult, completion: @escaping (Result<Bool>) -> Void) {
-    portal?.mpc.backup(method: backupMethod) { (result: Result<String>) in
+    portal?.backupWallet(method: backupMethod) { (result: Result<String>) in
       guard result.error == nil else {
         return completion(Result(error: result.error!))
       }
@@ -206,7 +206,7 @@ class PortalWrapper {
 
       let cipherText = result.data!.cipherText
 
-      self.portal?.mpc.recover(cipherText: cipherText, method: backupMethod) { (result: Result<String>) in
+      self.portal?.recoverWallet(cipherText: cipherText, method: backupMethod) { (result: Result<String>) in
         guard result.error == nil else {
           print("❌ handleRecover(): Error fetching cipherText:", result.error!)
           return completion(Result(error: result.error!))

--- a/Example/PortalSwift/ViewController.swift
+++ b/Example/PortalSwift/ViewController.swift
@@ -285,8 +285,8 @@ class ViewController: UIViewController {
 
   func deleteKeychain() {
     do {
-      try portal?.keychain.deleteAddress()
-      try portal?.keychain.deleteSigningShare()
+      try portal?.deleteAddress()
+      try portal?.deleteSigningShare()
       print("✅ Deleted keychain")
     } catch {
       print("❌ Delete keychain error:", error)
@@ -303,7 +303,7 @@ class ViewController: UIViewController {
 
   func populateAddressInformation() {
     do {
-      let address = try portal?.keychain.getAddress()
+      let address = portal?.address
       print("Address", address)
 
       DispatchQueue.main.async {
@@ -371,7 +371,7 @@ class ViewController: UIViewController {
 
   func populateEthBalance() {
     do {
-      let address = try portal?.keychain.getAddress()
+      let address = portal?.address
       guard address != nil else {
         print("❌ populateEthBalance(): Error getting address")
         return
@@ -417,7 +417,7 @@ class ViewController: UIViewController {
 
   @IBAction func handleSign() {
     do {
-      let address = try portal?.keychain.getAddress()
+      let address = try portal?.address
 
       let payload = ETHRequestPayload(
         method: ETHRequestMethods.PersonalSign.rawValue,
@@ -441,7 +441,7 @@ class ViewController: UIViewController {
   func sendTransaction(ethEstimate: String) {
     let payload = ETHTransactionPayload(
       method: ETHRequestMethods.SendTransaction.rawValue,
-      params: [ETHTransactionParam(from: portal!.mpc.getAddress(), to: sendAddress.text!, gas: ethEstimate, gasPrice: ethEstimate, value: "0x10", data: "")]
+      params: [ETHTransactionParam(from: portal!.address!, to: sendAddress.text!, gas: ethEstimate, gasPrice: ethEstimate, value: "0x10", data: "")]
       // Test EIP-1559 Transactions with these params
       // params: [ETHTransactionParam(from: portal!.mpc.getAddress(), to: sendAddress.text!,  gas:"0x5208", value: "0x10", data: "", maxPriorityFeePerGas: ethEstimate, maxFeePerGas: ethEstimate)]
     )
@@ -475,7 +475,7 @@ class ViewController: UIViewController {
           do {
             self.generateButton.isEnabled = true
 
-            let address = try self.portal?.keychain.getAddress()
+            let address = try self.portal?.address
             let hasAddress = address?.count ?? 0 > 0
 
             self.backupButton.isEnabled = hasAddress
@@ -579,7 +579,7 @@ class ViewController: UIViewController {
   func testSignerRequests() {
     print("Testing Signer Methods:\n")
     do {
-      let fromAddress = try portal?.keychain.getAddress()
+      let fromAddress = try portal?.address
       guard fromAddress != nil else {
         print("❌ Error testing signer provider requests: address is nil")
         return
@@ -629,7 +629,7 @@ class ViewController: UIViewController {
   func testOtherRequests() {
     print("\nTesting Other Requests:\n")
     do {
-      let fromAddress = try portal?.keychain.getAddress()
+      let fromAddress = try portal?.address
       guard fromAddress != nil else {
         print("❌ Error testing other provider requests: address is nil")
         return
@@ -671,7 +671,7 @@ class ViewController: UIViewController {
   func testTransactionRequests() {
     print("\nTesting Transaction Requests:\n")
     do {
-      let fromAddress = try portal?.keychain.getAddress()
+      let fromAddress = try portal?.address
       let toAddress = "0x4cd042bba0da4b3f37ea36e8a2737dce2ed70db7"
       let fakeTransaction = ETHTransactionParam(
         from: fromAddress!,
@@ -714,7 +714,7 @@ class ViewController: UIViewController {
     ]
 
     do {
-      let address = try portal?.keychain.getAddress()
+      let address = try portal?.address
       guard address != nil else {
         print("❌ testUnsupportedSignerRequests(): Error getting address")
         return

--- a/Example/Tests/ICloudStorageTests.swift
+++ b/Example/Tests/ICloudStorageTests.swift
@@ -6,15 +6,17 @@
 //  Copyright © 2022 Portal Labs, Inc. All rights reserved.
 //
 
-import XCTest
 @testable import PortalSwift
+import XCTest
 
 final class ICloudStorageTests: XCTestCase {
   var storage: ICloudStorage?
 
   override func setUpWithError() throws {
+    let provider = try MockPortalProvider(apiKey: "", chainId: 5, gatewayConfig: [5: "https://example.com"], keychain: MockPortalKeychain(), autoApprove: true)
+
     storage = ICloudStorage()
-    storage?.api = MockPortalApi(address:"", apiKey: "", chainId: 5)
+    storage?.api = MockPortalApi(apiKey: "", apiHost: "", provider: provider)
   }
 
   override func tearDownWithError() throws {
@@ -25,18 +27,18 @@ final class ICloudStorageTests: XCTestCase {
     let expectation = XCTestExpectation(description: "Delete")
     let privateKey = "privateKey"
 
-    storage!.write(privateKey: privateKey) { (result: Result<Bool>) -> Void in
-      if (result.error != nil) {
+    storage!.write(privateKey: privateKey) { (result: Result<Bool>) in
+      if result.error != nil {
         XCTFail("Failed to write private key to storage. Make sure you are signed into iCloud on your simulator before running tests.")
       }
 
-      self.storage!.read() { (result: Result<String>) -> Void in
+      self.storage!.read { (result: Result<String>) in
         XCTAssert(result.data! == privateKey)
 
-        self.storage!.delete() { (result: Result<Bool>) -> Void in
+        self.storage!.delete { (result: Result<Bool>) in
           XCTAssert(result.data! == true)
 
-          self.storage!.read() { (result: Result<String>) -> Void in
+          self.storage!.read { (result: Result<String>) in
             XCTAssert(result.data! == "")
             expectation.fulfill()
           }
@@ -50,7 +52,7 @@ final class ICloudStorageTests: XCTestCase {
   func testRead() throws {
     let expectation = XCTestExpectation(description: "Read")
 
-    storage!.read() { (result: Result<String>) -> Void in
+    storage!.read { (result: Result<String>) in
       XCTAssert(result.data! == "")
       expectation.fulfill()
     }
@@ -62,10 +64,10 @@ final class ICloudStorageTests: XCTestCase {
     let expectation = XCTestExpectation(description: "Write")
     let privateKey = "privateKey"
 
-    storage!.write(privateKey: privateKey) { (result: Result<Bool>) -> Void in
+    storage!.write(privateKey: privateKey) { (result: Result<Bool>) in
       XCTAssert(result.data! == true)
 
-      self.storage!.read() { (result: Result<String>) -> Void in
+      self.storage!.read { (result: Result<String>) in
         XCTAssert(result.data! == privateKey)
         expectation.fulfill()
       }

--- a/Example/Tests/MpcSignerTests.swift
+++ b/Example/Tests/MpcSignerTests.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2022 Portal Labs, Inc. All rights reserved.
 //
 
-import XCTest
 @testable import PortalSwift
+import XCTest
 
 final class MpcSignerTests: XCTestCase {
   var keychain: PortalKeychain?
@@ -17,12 +17,12 @@ final class MpcSignerTests: XCTestCase {
   override func setUpWithError() throws {
     do {
       keychain = MockPortalKeychain()
-      keychain!.setSigningShare(signingShare: mockSigningShare) { result in }
-      signer = MpcSigner(keychain: keychain!)
+      keychain!.setSigningShare(signingShare: mockSigningShare) { _ in }
+      signer = MpcSigner(apiKey: "API_KEY", keychain: keychain!)
       provider = try MockPortalProvider(
         apiKey: "API_KEY",
         chainId: Chains.Goerli.rawValue,
-        gatewayUrl: "https://eth-goerli.g.alchemy.com/v2/API_KEY",
+        gatewayConfig: [Chains.Goerli.rawValue: "https://eth-goerli.g.alchemy.com/v2/API_KEY"],
         keychain: MockPortalKeychain(),
         autoApprove: true
       )

--- a/Example/Tests/PortalApiTests.swift
+++ b/Example/Tests/PortalApiTests.swift
@@ -6,14 +6,21 @@
 //  Copyright © 2022 Portal Labs, Inc. All rights reserved.
 //
 
-import XCTest
 @testable import PortalSwift
+import XCTest
 
 final class PortalApiTests: XCTestCase {
   var api: PortalApi?
 
   override func setUpWithError() throws {
-    api = PortalApi(address: "", apiKey: "test", chainId: 5, apiHost: "api.portalhq.io", mockRequests: true)
+    let provider = try MockPortalProvider(
+      apiKey: "API_KEY",
+      chainId: 5,
+      gatewayConfig: [5: "https://example.com"],
+      keychain: MockPortalKeychain(),
+      autoApprove: true
+    )
+    api = PortalApi(apiKey: "test", apiHost: "api.portalhq.io", provider: provider, mockRequests: true)
   }
 
   override func tearDownWithError() throws {
@@ -22,7 +29,7 @@ final class PortalApiTests: XCTestCase {
 
   func testGetClient() throws {
     let expectation = XCTestExpectation(description: "Get client")
-    try api?.getClient() { result in
+    try api?.getClient { result in
       XCTAssert(result.data as! String == mockBackupShare)
       expectation.fulfill()
     }
@@ -31,7 +38,7 @@ final class PortalApiTests: XCTestCase {
 
   func testGetEnabledDapps() throws {
     let expectation = XCTestExpectation(description: "Get enabled dapps")
-    try api?.getEnabledDapps() { result in
+    try api?.getEnabledDapps { result in
       XCTAssert(result.data as! String == mockBackupShare)
       expectation.fulfill()
     }
@@ -40,7 +47,7 @@ final class PortalApiTests: XCTestCase {
 
   func testGetSupportedNetworks() throws {
     let expectation = XCTestExpectation(description: "Get supported networks")
-    try api?.getSupportedNetworks() { result in
+    try api?.getSupportedNetworks { result in
       XCTAssert(result.data as! String == mockBackupShare)
       expectation.fulfill()
     }

--- a/Example/Tests/PortalMpcTests.swift
+++ b/Example/Tests/PortalMpcTests.swift
@@ -6,14 +6,32 @@
 //  Copyright © 2022 Portal Labs, Inc. All rights reserved.
 //
 
-import XCTest
 @testable import PortalSwift
+import XCTest
 
 final class PortalMpcTests: XCTestCase {
   var mpc: PortalMpc?
 
   override func setUpWithError() throws {
-    mpc = MockPortalMpc(apiKey: "test", chainId: 5, keychain: MockPortalKeychain(), storage: BackupOptions(icloud: MockICloudStorage()), gatewayUrl: "testurl", api: MockPortalApi(address: "", apiKey: "test", chainId: 5))
+    let provider = try MockPortalProvider(
+      apiKey: "API_KEY",
+      chainId: 5,
+      gatewayConfig: [5: "https://example.com"],
+      keychain: MockPortalKeychain(),
+      autoApprove: true
+    )
+
+    mpc = MockPortalMpc(
+      apiKey: "test",
+      api: MockPortalApi(
+        apiKey: "test",
+        apiHost: "test",
+        provider: provider,
+        mockRequests: true
+      ),
+      keychain: MockPortalKeychain(),
+      storage: BackupOptions(icloud: MockICloudStorage())
+    )
   }
 
   override func tearDownWithError() throws {
@@ -30,7 +48,7 @@ final class PortalMpcTests: XCTestCase {
   }
 
   func testGenerate() throws {
-    mpc?.generate() { addressResult in
+    mpc?.generate { addressResult in
       XCTAssert(addressResult.data == mockAddress)
     }
   }

--- a/Example/Tests/PortalProviderTests.swift
+++ b/Example/Tests/PortalProviderTests.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2022 Portal Labs, Inc. All rights reserved.
 //
 
-import XCTest
 @testable import PortalSwift
+import XCTest
 
 final class PortalProviderTests: XCTestCase {
   var provider: PortalProvider?
@@ -17,10 +17,10 @@ final class PortalProviderTests: XCTestCase {
     provider = try PortalProvider(
       apiKey: "test",
       chainId: 5,
-      gatewayUrl: "test",
+      gatewayConfig: [5: "test"],
       keychain: MockPortalKeychain(),
-      apiHost: "test",
-      autoApprove: true
+      autoApprove: true,
+      apiHost: "test"
     )
   }
 
@@ -54,7 +54,7 @@ final class PortalProviderTests: XCTestCase {
   }
 
   func testGetApiKey() throws {
-    let apiKey = provider!.getApiKey()
+    let apiKey = provider!.apiKey
     XCTAssertEqual(apiKey, "test")
   }
 
@@ -97,7 +97,7 @@ final class PortalProviderTests: XCTestCase {
     let expectation = XCTestExpectation(description: "testEmit")
 
     // Listen for the event.
-    let _ = provider!.on(event: "test-remove", callback: { data in
+    let _ = provider!.on(event: "test-remove", callback: { _ in
       // Expect not to be called.
       XCTFail()
     })
@@ -126,13 +126,8 @@ final class PortalProviderTests: XCTestCase {
     wait(for: [expectation], timeout: 5.0)
   }
 
-  func testSetAddress() throws {
-    let _ = provider!.setAddress(value: "test")
-    XCTAssert(true)
-  }
-
   func testSetChainId() throws {
-    let _ = provider!.setChainId(value: 5)
+    let _ = try provider!.setChainId(value: 5)
     XCTAssertEqual(provider!.chainId, 5)
   }
 }

--- a/PortalSwift/Classes/Components/PortalWebView.swift
+++ b/PortalSwift/Classes/Components/PortalWebView.swift
@@ -115,8 +115,13 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
   ///   - webView: The WKWebView instance.
   ///   - navigation: The WKNavigation instance.
   public func webView(_: WKWebView, didFinish _: WKNavigation!) {
+    guard let address = portal.address else {
+      print("[PortalWebView] No address found for user. Cannot inject provider into web page.")
+      return
+    }
+
     let javascript = injectPortal(
-      address: portal.mpc.getAddress(),
+      address: address,
       apiKey: portal.apiKey,
       chainId: String(portal.chainId),
       gatewayConfig: portal.gatewayConfig[portal.chainId]!,

--- a/PortalSwift/Classes/Connect/PortalConnect.swift
+++ b/PortalSwift/Classes/Connect/PortalConnect.swift
@@ -18,29 +18,58 @@ public var signMethods: [ETHRequestMethods.RawValue] = [
 ]
 
 public class PortalConnect: EventBus {
-  public var client: WebSocketClient
+  public var address: String? {
+    return provider.address
+  }
+
+  public var chainId: Int {
+    return provider.chainId
+  }
+
+  public var client: WebSocketClient? = nil
   public var connected: Bool = false
   public var uri: String?
 
-  private var address: String?
-  private var portal: Portal
+  private let apiKey: String
+  private let webSocketServer: String
+  private let provider: PortalProvider
   private var topic: String?
 
   public init(
-    _ portal: Portal,
-    _ webSocketServer: String = "connect.portalhq.io"
-  ) {
+    _ apiKey: String,
+    _ chainId: Int,
+    _ keychain: PortalKeychain,
+    _ gatewayConfig: [Int: String],
+    _ webSocketServer: String = "connect.portalhq.io",
+    _ autoApprove: Bool = false,
+    _ apiHost: String = "api.portalhq.io",
+    _ mpcHost: String = "mpc.portalhq.io",
+    _ version: String = "v4"
+  ) throws {
+    self.apiKey = apiKey
+    self.webSocketServer = webSocketServer
+
+    // Initialize the PortalProvider
+    provider = try PortalProvider(
+      apiKey: apiKey,
+      chainId: chainId,
+      gatewayConfig: gatewayConfig,
+      keychain: keychain,
+      autoApprove: autoApprove,
+      apiHost: apiHost,
+      mpcHost: mpcHost,
+      version: version
+    )
+
+    super.init(label: "PortalConnect")
+
     // Set up webSocketClient
     let connectionString = webSocketServer.starts(with: "localhost") ? "ws://\(webSocketServer)" : "wss://\(webSocketServer)"
     client = WebSocketClient(
-      portal: portal,
+      apiKey: apiKey,
+      connect: self,
       webSocketServer: connectionString
     )
-
-    self.portal = portal
-    address = portal.mpc.getAddress()
-
-    super.init(label: "PortalConnect")
 
     guard address != nil else {
       print("[PortalConnect] ⚠️ Address not found in Keychain. This may cause some features not to work as expected.")
@@ -48,47 +77,49 @@ public class PortalConnect: EventBus {
     }
 
     // Fired by the Provider
-
     on(event: Events.PortalConnectSigningRequested.rawValue) { payload in
       self.emit(event: Events.PortalSigningRequested.rawValue, data: payload)
     }
 
     // Fired by SDK Consumers
-
     on(event: Events.PortalSigningApproved.rawValue) { payload in
-      _ = self.portal.provider.emit(event: Events.PortalSigningApproved.rawValue, data: payload)
+      _ = self.provider.emit(event: Events.PortalSigningApproved.rawValue, data: payload)
     }
 
     on(event: Events.PortalSigningRejected.rawValue) { payload in
-      _ = self.portal.provider.emit(event: Events.PortalSigningRejected.rawValue, data: payload)
+      _ = self.provider.emit(event: Events.PortalSigningRejected.rawValue, data: payload)
     }
   }
 
   deinit {
-    client.sendFinalMessageAndDisconnect()
+    client?.sendFinalMessageAndDisconnect()
   }
 
   public func connect(_ uri: String) {
+    if client == nil {
+      client = WebSocketClient(apiKey: apiKey, connect: self, webSocketServer: webSocketServer)
+    }
+
     self.uri = uri
 
-    client.resetEventBus()
+    client?.resetEventBus()
 
-    client.on("close", handleClose)
-    client.on("portal_dappSessionRequested", handleDappSessionRequested)
-    client.on("portal_dappSessionRequestedV1", handleDappSessionRequestedV1)
-    client.on("connected", handleConnected)
-    client.on("connectedV1", handleConnectedV1)
-    client.on("disconnected", handleDisconnected)
-    client.on("error", handleError)
-    client.on("session_request", handleSessionRequest)
-    client.on("session_request_address", handleSessionRequestAddress)
-    client.on("session_request_transaction", handleSessionRequestTransaction)
+    client?.on("close", handleClose)
+    client?.on("portal_dappSessionRequested", handleDappSessionRequested)
+    client?.on("portal_dappSessionRequestedV1", handleDappSessionRequestedV1)
+    client?.on("connected", handleConnected)
+    client?.on("connectedV1", handleConnectedV1)
+    client?.on("disconnected", handleDisconnected)
+    client?.on("error", handleError)
+    client?.on("session_request", handleSessionRequest)
+    client?.on("session_request_address", handleSessionRequestAddress)
+    client?.on("session_request_transaction", handleSessionRequestTransaction)
 
-    client.connect(uri: uri)
+    client?.connect(uri: uri)
   }
 
   public func disconnect(_ userInitiated: Bool = false) {
-    client.disconnect(userInitiated)
+    client?.disconnect(userInitiated)
   }
 
   func handleDappSessionRequested(data: ConnectData) {
@@ -102,7 +133,7 @@ public class PortalConnect: EventBus {
           id: data.id,
           topic: data.topic,
           address: self.address!,
-          chainId: String(self.portal.chainId),
+          chainId: String(chainId),
           params: data.params
         )
       )
@@ -110,7 +141,7 @@ public class PortalConnect: EventBus {
       do {
         let message = try JSONEncoder().encode(event)
 
-        self.client.send(message)
+        self.client?.send(message)
       } catch {
         print("[PortalConnect] Error encoding DappSessionRequestApprovedMessage: \(error)")
       }
@@ -126,14 +157,14 @@ public class PortalConnect: EventBus {
           id: data.id,
           topic: data.topic,
           address: self.address!,
-          chainId: String(self.portal.chainId),
+          chainId: String(chainId),
           params: data.params
         )
       )
 
       do {
         let message = try JSONEncoder().encode(event)
-        self.client.send(message)
+        self.client?.send(message)
       } catch {
         print("[PortalConnect] Error encoding DappSessionRequestRejectedMessage: \(error)")
       }
@@ -153,13 +184,13 @@ public class PortalConnect: EventBus {
           id: data.id,
           topic: data.topic,
           address: self.address!,
-          chainId: String(self.portal.chainId)
+          chainId: String(chainId)
         )
       )
 
       do {
         let message = try JSONEncoder().encode(event)
-        self.client.send(message)
+        self.client?.send(message)
       } catch {
         print("[PortalConnect] Error encoding DappSessionRequestApprovedMessage: \(error)")
       }
@@ -175,13 +206,13 @@ public class PortalConnect: EventBus {
           id: data.id,
           topic: data.topic,
           address: self.address!,
-          chainId: String(self.portal.chainId)
+          chainId: String(chainId)
         )
       )
 
       do {
         let message = try JSONEncoder().encode(event)
-        self.client.send(message)
+        self.client?.send(message)
       } catch {
         print("[PortalConnect] Error encoding DappSessionRequestRejectedMessage: \(error)")
       }
@@ -193,15 +224,15 @@ public class PortalConnect: EventBus {
   func handleClose() {
     connected = false
     topic = nil
-    client.topic = nil
+    client?.topic = nil
 
-    client.close()
+    client?.close()
   }
 
   func handleConnected(data: ConnectedData) {
     connected = true
     topic = data.topic
-    client.topic = data.topic
+    client?.topic = data.topic
 
     emit(event: Events.Connect.rawValue, data: data)
   }
@@ -209,7 +240,7 @@ public class PortalConnect: EventBus {
   func handleConnectedV1(data: ConnectedV1Data) {
     connected = true
     topic = data.topic
-    client.topic = data.topic
+    client?.topic = data.topic
 
     emit(event: Events.Connect.rawValue, data: data)
   }
@@ -217,9 +248,9 @@ public class PortalConnect: EventBus {
   func handleDisconnected(data: DisconnectData) {
     connected = false
     topic = nil
-    client.topic = nil
+    client?.topic = nil
 
-    client.close()
+    client?.close()
     emit(event: Events.Disconnect.rawValue, data: data)
   }
 
@@ -249,7 +280,7 @@ public class PortalConnect: EventBus {
 
       do {
         let message = try JSONEncoder().encode(event)
-        self.client.send(message)
+        self.client?.send(message)
       } catch {
         print("[PortalConnect] Error encoding SignatureReceivedMessage: \(error)")
       }
@@ -276,7 +307,7 @@ public class PortalConnect: EventBus {
 
       do {
         let message = try JSONEncoder().encode(event)
-        self.client.send(message)
+        self.client?.send(message)
 
         // emit the PortalSignatureReceived event on the PortalConnect EventBus as a convenience
         if signMethods.contains(method) {
@@ -310,7 +341,7 @@ public class PortalConnect: EventBus {
 
       do {
         let message = try JSONEncoder().encode(event)
-        self.client.send(message)
+        self.client?.send(message)
       } catch {
         print("[PortalConnect] Error encoding SignatureReceivedMessage: \(error)")
       }
@@ -336,7 +367,7 @@ public class PortalConnect: EventBus {
 
       do {
         let message = try JSONEncoder().encode(event)
-        self.client.send(message)
+        self.client?.send(message)
 
         // emit the PortalSignatureReceived event on the PortalConnect EventBus as a convenience
         if signMethods.contains(method) {
@@ -370,7 +401,7 @@ public class PortalConnect: EventBus {
 
       do {
         let message = try JSONEncoder().encode(event)
-        self.client.send(message)
+        self.client?.send(message)
       } catch {
         print("[PortalConnect] Error encoding SignatureReceivedMessage: \(error)")
       }
@@ -397,7 +428,7 @@ public class PortalConnect: EventBus {
       do {
         let message = try JSONEncoder().encode(event)
 
-        self.client.send(message)
+        self.client?.send(message)
 
         // emit the PortalSignatureReceived event on the PortalConnect EventBus as a convenience
         if signMethods.contains(method) {
@@ -410,11 +441,11 @@ public class PortalConnect: EventBus {
   }
 
   public func viewWillDisappear() {
-    client.sendFinalMessageAndDisconnect()
+    client?.sendFinalMessageAndDisconnect()
   }
 
   private func handleProviderRequest(method: String, params: [ETHAddressParam], completion: @escaping (Result<Any>) -> Void) {
-    portal.provider.request(payload: ETHAddressPayload(method: method, params: params), connect: self) { result in
+    provider.request(payload: ETHAddressPayload(method: method, params: params), connect: self) { result in
       guard result.error == nil else {
         return completion(Result(error: result.error!))
       }
@@ -423,7 +454,7 @@ public class PortalConnect: EventBus {
   }
 
   private func handleProviderRequest(method: String, params: [ETHTransactionParam], completion: @escaping (Result<Any>) -> Void) {
-    portal.provider.request(payload: ETHTransactionPayload(method: method, params: params), connect: self) { (result: Result<TransactionCompletionResult>) in
+    provider.request(payload: ETHTransactionPayload(method: method, params: params), connect: self) { (result: Result<TransactionCompletionResult>) in
       guard result.error == nil else {
         return completion(Result(error: result.error!))
       }
@@ -432,7 +463,7 @@ public class PortalConnect: EventBus {
   }
 
   private func handleProviderRequest(method: String, params: [Any], completion: @escaping (Result<Any>) -> Void) {
-    portal.provider.request(payload: ETHRequestPayload(method: method, params: params), connect: self) { result in
+    provider.request(payload: ETHRequestPayload(method: method, params: params), connect: self) { result in
       guard result.error == nil else {
         return completion(Result(error: result.error!))
       }

--- a/PortalSwift/Classes/Core/PortalApi.swift
+++ b/PortalSwift/Classes/Core/PortalApi.swift
@@ -7,199 +7,36 @@
 
 import Foundation
 
-/// A client from the Portal API.
-public struct Client: Codable {
-  public var id: String
-  public var address: String
-  public var clientApiKey: String
-  public var custodian: Custodian
-}
-
-/// A contract that belongs to a Dapp.
-public struct Contract: Codable {
-  public var id: String
-  public var contractAddress: String
-  public var clientUrl: String
-  public var network: ContractNetwork
-}
-
-/// A custodian that belongs to a Client.
-public struct Custodian: Codable {
-  public var id: String
-  public var name: String
-}
-
-/// A Dapp that has many Contracts.
-public struct Dapp: Codable {
-  public var id: String
-  public var contracts: [Contract]
-  public var image: DappImage
-  public var name: String
-}
-
-/// A Dapp's profile image.
-public struct DappImage: Codable {
-  public var id: String
-  public var data: String
-  public var filename: String
-}
-
-/// A contract network. For example, chainId 5 is the Goerli network.
-public struct ContractNetwork: Codable {
-  public var id: String
-  public var chainId: String
-  public var name: String
-}
-
-/// Represents an NFT smart contract.
-public struct NFTContract: Codable {
-  public var address: String
-}
-
-/// Represents an NFT owned by the client.
-public struct NFT: Codable {
-  public var contract: NFTContract
-  public var id: TokenId
-  public var balance: String
-  public var title: String
-  public var description: String
-  public var tokenUri: TokenUri
-  public var media: [Media]
-  public var metadata: NFTMetadata
-  public var timeLastUpdated: String
-  public var contractMetadata: ContractMetadata
-}
-
-/// Represents the id of an NFT.
-public struct TokenId: Codable {
-  public var tokenId: String
-  public var tokenMetadata: TokenMetadata
-}
-
-/// Represents the metadata of an NFT's id.
-public struct TokenMetadata: Codable {
-  public var tokenType: String
-}
-
-/// Represents the URI of an NFT.
-public struct TokenUri: Codable {
-  public var gateway: String
-  public var raw: String
-}
-
-/// Represents the media of an NFT.
-public struct Media: Codable {
-  public var gateway: String
-  public var thumbnail: String
-  public var raw: String
-  public var format: String
-  public var bytes: Int
-}
-
-/// Represents the metadata of an NFT.
-public struct NFTMetadata: Codable {
-  public var name: String
-  public var description: String
-  public var image: String
-  public var external_url: String?
-}
-
-/// Represents the contract metadata of an NFT.
-public struct ContractMetadata: Codable {
-  public var name: String
-  public var symbol: String
-  public var tokenType: String
-  public var contractDeployer: String
-  public var deployedBlockNumber: Int
-  public var openSea: OpenSeaMetadata?
-}
-
-/// Represents the OpenSea metadata of an NFT.
-public struct OpenSeaMetadata: Codable {
-  public var collectionName: String
-  public var safelistRequestStatus: String
-  public var imageUrl: String?
-  public var description: String
-  public var externalUrl: String
-  public var lastIngestedAt: String
-  public var floorPrice: Float?
-  public var twitterUsername: String?
-  public var discordUrl: String?
-}
-
-/// Represents a blockchain transaction
-public struct Transaction: Codable {
-  /// Block number in which the transaction was included
-  public var blockNum: String
-  /// Unique identifier of the transaction
-  public var uniqueId: String
-  /// Hash of the transaction
-  public var hash: String
-  /// Address that initiated the transaction
-  public var from: String
-  /// Address that the transaction was sent to
-  public var to: String
-  /// Value transferred in the transaction
-  public var value: Float
-  /// Token Id of an ERC721 token, if applicable
-  public var erc721TokenId: String?
-  /// Metadata of an ERC1155 token, if applicable
-  public var erc1155Metadata: String?
-  /// Token Id, if applicable
-  public var tokenId: String?
-  /// Type of asset involved in the transaction (e.g., ETH)
-  public var asset: String
-  /// Category of the transaction (e.g., external)
-  public var category: String
-  /// Contract details related to the transaction
-  public var rawContract: RawContract
-}
-
-/// Represents the contract details of a transaction
-public struct RawContract: Codable {
-  /// Value involved in the contract
-  public var value: String
-  /// Address of the contract, if applicable
-  public var address: String?
-  /// Decimal representation of the contract value
-  public var decimal: String
-}
-
-/// A representation of a client's balance.
-///
-/// This struct is used to parse the JSON response from the "/api/v1/clients/me/balances" endpoint.
-public struct Balance: Codable {
-  /// The contract address of the token.
-  public var contractAddress: String
-  /// The balance of the token.
-  public var balance: String
-}
-
 /// The class to interface with Portal's REST API.
 public class PortalApi {
-  public var address: String
-  public var apiHost: String
-  public var apiKey: String
-  public var chainId: Int
-  public var requests: HttpRequester
+  private var apiKey: String
+  private var provider: PortalProvider
+  private var requests: HttpRequester
+
+  private var address: String? {
+    return provider.address
+  }
+
+  private var chainId: Int {
+    return provider.chainId
+  }
 
   /// Create an instance of a PortalApi class.
   /// - Parameters:
   ///   - apiKey: The Client API key. You can create one using Portal's REST API.
   ///   - apiHost: (optional) The Portal API hostname.
-  ///   - chainId: The chain ID of the EVM network.
+  ///   - provider: The PortalProvider instance to use for stateful Provider info (chainId, address)
   init(
-    address: String,
     apiKey: String,
-    chainId: Int,
     apiHost: String = "api.portalhq.io",
+    provider: PortalProvider,
     mockRequests: Bool = false
   ) {
-    self.address = address
     self.apiKey = apiKey
-    self.apiHost = apiHost.starts(with: "localhost") ? "http://\(apiHost)" : "https://\(apiHost)"
-    self.chainId = chainId
-    requests = mockRequests ? MockHttpRequester(baseUrl: self.apiHost) : HttpRequester(baseUrl: self.apiHost)
+    self.provider = provider
+
+    let baseUrl = apiHost.starts(with: "localhost") ? "http://\(apiHost)" : "https://\(apiHost)"
+    requests = mockRequests ? MockHttpRequester(baseUrl: baseUrl) : HttpRequester(baseUrl: baseUrl)
   }
 
   /// Retrieve the client by API key.
@@ -405,4 +242,176 @@ public class PortalApi {
       completion(result)
     }
   }
+}
+
+/**********************************
+ * Supporting Structs
+ **********************************/
+
+/// A client from the Portal API.
+public struct Client: Codable {
+  public var id: String
+  public var address: String
+  public var clientApiKey: String
+  public var custodian: Custodian
+}
+
+/// A contract that belongs to a Dapp.
+public struct Contract: Codable {
+  public var id: String
+  public var contractAddress: String
+  public var clientUrl: String
+  public var network: ContractNetwork
+}
+
+/// A custodian that belongs to a Client.
+public struct Custodian: Codable {
+  public var id: String
+  public var name: String
+}
+
+/// A Dapp that has many Contracts.
+public struct Dapp: Codable {
+  public var id: String
+  public var contracts: [Contract]
+  public var image: DappImage
+  public var name: String
+}
+
+/// A Dapp's profile image.
+public struct DappImage: Codable {
+  public var id: String
+  public var data: String
+  public var filename: String
+}
+
+/// A contract network. For example, chainId 5 is the Goerli network.
+public struct ContractNetwork: Codable {
+  public var id: String
+  public var chainId: String
+  public var name: String
+}
+
+/// Represents an NFT smart contract.
+public struct NFTContract: Codable {
+  public var address: String
+}
+
+/// Represents an NFT owned by the client.
+public struct NFT: Codable {
+  public var contract: NFTContract
+  public var id: TokenId
+  public var balance: String
+  public var title: String
+  public var description: String
+  public var tokenUri: TokenUri
+  public var media: [Media]
+  public var metadata: NFTMetadata
+  public var timeLastUpdated: String
+  public var contractMetadata: ContractMetadata
+}
+
+/// Represents the id of an NFT.
+public struct TokenId: Codable {
+  public var tokenId: String
+  public var tokenMetadata: TokenMetadata
+}
+
+/// Represents the metadata of an NFT's id.
+public struct TokenMetadata: Codable {
+  public var tokenType: String
+}
+
+/// Represents the URI of an NFT.
+public struct TokenUri: Codable {
+  public var gateway: String
+  public var raw: String
+}
+
+/// Represents the media of an NFT.
+public struct Media: Codable {
+  public var gateway: String
+  public var thumbnail: String
+  public var raw: String
+  public var format: String
+  public var bytes: Int
+}
+
+/// Represents the metadata of an NFT.
+public struct NFTMetadata: Codable {
+  public var name: String
+  public var description: String
+  public var image: String
+  public var external_url: String?
+}
+
+/// Represents the contract metadata of an NFT.
+public struct ContractMetadata: Codable {
+  public var name: String
+  public var symbol: String
+  public var tokenType: String
+  public var contractDeployer: String
+  public var deployedBlockNumber: Int
+  public var openSea: OpenSeaMetadata?
+}
+
+/// Represents the OpenSea metadata of an NFT.
+public struct OpenSeaMetadata: Codable {
+  public var collectionName: String
+  public var safelistRequestStatus: String
+  public var imageUrl: String?
+  public var description: String
+  public var externalUrl: String
+  public var lastIngestedAt: String
+  public var floorPrice: Float?
+  public var twitterUsername: String?
+  public var discordUrl: String?
+}
+
+/// Represents a blockchain transaction
+public struct Transaction: Codable {
+  /// Block number in which the transaction was included
+  public var blockNum: String
+  /// Unique identifier of the transaction
+  public var uniqueId: String
+  /// Hash of the transaction
+  public var hash: String
+  /// Address that initiated the transaction
+  public var from: String
+  /// Address that the transaction was sent to
+  public var to: String
+  /// Value transferred in the transaction
+  public var value: Float
+  /// Token Id of an ERC721 token, if applicable
+  public var erc721TokenId: String?
+  /// Metadata of an ERC1155 token, if applicable
+  public var erc1155Metadata: String?
+  /// Token Id, if applicable
+  public var tokenId: String?
+  /// Type of asset involved in the transaction (e.g., ETH)
+  public var asset: String
+  /// Category of the transaction (e.g., external)
+  public var category: String
+  /// Contract details related to the transaction
+  public var rawContract: RawContract
+}
+
+/// Represents the contract details of a transaction
+public struct RawContract: Codable {
+  /// Value involved in the contract
+  public var value: String
+  /// Address of the contract, if applicable
+  public var address: String?
+  /// Decimal representation of the contract value
+  public var decimal: String
+}
+
+/// A representation of a client's balance.
+///
+/// This struct is used to parse the JSON response from the "/api/v1/clients/me/balances" endpoint.
+public struct Balance: Codable {
+  /// The contract address of the token.
+  public var contractAddress: String
+  /// The balance of the token.
+  public var balance: String
 }

--- a/PortalSwift/Classes/Mocks/Provider/MockPortalProvider.swift
+++ b/PortalSwift/Classes/Mocks/Provider/MockPortalProvider.swift
@@ -13,10 +13,6 @@ public class MockPortalProvider: PortalProvider {
     return self
   }
 
-  override public func getApiKey() -> String {
-    return "mockApiKey"
-  }
-
   override public func on(
     event _: Events.RawValue,
     callback _: @escaping (_ data: Any) -> Void
@@ -85,8 +81,6 @@ public class MockPortalProvider: PortalProvider {
       )
     )
   }
-
-  override public func setAddress(value _: String) {}
 
   override public func setChainId(value _: Int) -> PortalProvider {
     return self

--- a/PortalSwift/Classes/Provider/MpcSigner.swift
+++ b/PortalSwift/Classes/Provider/MpcSigner.swift
@@ -19,16 +19,26 @@ public struct SignerResult: Codable {
 }
 
 class MpcSigner {
-  public var address: String?
-  public var keychain: PortalKeychain
-  private var mpcUrl: String
-  private var version: String
+  private var address: String? {
+    do {
+      return try keychain.getAddress()
+    } catch {
+      return nil
+    }
+  }
+
+  private let apiKey: String
+  private let keychain: PortalKeychain
+  private let mpcUrl: String
+  private let version: String
 
   init(
+    apiKey: String,
     keychain: PortalKeychain,
     mpcUrl: String = "mpc.portalhq.io",
     version: String = "v4"
   ) {
+    self.apiKey = apiKey
     self.keychain = keychain
     self.mpcUrl = mpcUrl
     self.version = version
@@ -55,7 +65,7 @@ class MpcSigner {
       let signingShare = try keychain.getSigningShare()
       let formattedParams = try formatParams(payload: payload)
       let clientSignResult = MobileSign(
-        provider.getApiKey(),
+        apiKey,
         mpcUrl,
         signingShare,
         payload.method,
@@ -94,7 +104,7 @@ class MpcSigner {
     var clientSignResult = mockClientSignResult
     if !mockClientSign {
       clientSignResult = MobileSign(
-        provider.getApiKey(),
+        apiKey,
         mpcUrl,
         signingShare,
         payload.method,

--- a/PortalSwift/Classes/Provider/PortalProvider.swift
+++ b/PortalSwift/Classes/Provider/PortalProvider.swift
@@ -7,6 +7,626 @@
 
 import Foundation
 
+/// Portal's EVM blockchain provider.
+public class PortalProvider {
+  public var address: String? {
+    do {
+      return try keychain.getAddress()
+    } catch {
+      return nil
+    }
+  }
+
+  public let apiKey: String
+  public let autoApprove: Bool
+  public var chainId: Chains.RawValue
+  public var gatewayUrl: String
+
+  private var events: [Events.RawValue: [RegisteredEventHandler]] = [:]
+  private var gateway: HttpRequester
+  private let gatewayConfig: [Int: String]
+  private var keychain: PortalKeychain
+  private var mpcQueue: DispatchQueue
+  private var portalApi: HttpRequester
+  private let signer: MpcSigner
+
+  private var walletMethods: [ETHRequestMethods.RawValue] = [
+    ETHRequestMethods.WalletAddEthereumChain.rawValue,
+    ETHRequestMethods.WalletGetPermissions.rawValue,
+    ETHRequestMethods.WalletRegisterOnboarding.rawValue,
+    ETHRequestMethods.WalletRequestPermissions.rawValue,
+    ETHRequestMethods.WalletSwitchEthereumChain.rawValue,
+    ETHRequestMethods.WalletWatchAsset.rawValue,
+  ]
+
+  /// Creates an instance of PortalProvider.
+  /// - Parameters:
+  ///   - apiKey: The client API key. You can obtain this via Portal's REST API.
+  ///   - chainId: The ID of the EVM network you are using.
+  ///   - gatewayUrl: The gateway URL, such as Infura or Alchemy.
+  ///   - apiHost: The hostname of the API to use.
+  ///   - autoApprove: Auto approves all transactions.
+  public init(
+    apiKey: String,
+    chainId: Chains.RawValue,
+    gatewayConfig: [Int: String],
+    keychain: PortalKeychain,
+    autoApprove: Bool,
+    apiHost: String = "api.portalhq.io",
+    mpcHost: String = "mpc.portalhq.io",
+    version: String = "v4"
+  ) throws {
+    // User-defined instance variables
+    self.apiKey = apiKey
+    self.chainId = chainId
+    self.gatewayConfig = gatewayConfig
+    self.keychain = keychain
+    self.autoApprove = autoApprove
+
+    // Other instance variables
+    let apiUrl = apiHost.starts(with: "localhost") ? "http://\(apiHost)" : "https://\(apiHost)"
+    portalApi = HttpRequester(baseUrl: apiUrl)
+
+    signer = MpcSigner(apiKey: apiKey, keychain: keychain, mpcUrl: mpcHost, version: version)
+    // Create a serial dispatch queue with a unique label
+    mpcQueue = DispatchQueue.global(qos: .background)
+
+    do {
+      gatewayUrl = try PortalProvider.getGatewayUrl(gatewayConfig: gatewayConfig, chainId: chainId)
+      gateway = HttpRequester(baseUrl: gatewayUrl)
+    }
+
+    dispatchConnect()
+  }
+
+  // ------ Public Functions
+
+  /// Emits an event from the provider to registered event handlers.
+  /// - Parameters:
+  ///   - event: The event to be emitted.
+  ///   - data: The data to pass to registered event handlers.
+  /// - Returns: The Portal Provider instance.
+  public func emit(event: Events.RawValue, data: Any) -> PortalProvider {
+    let registeredEventHandlers = events[event]
+
+    if registeredEventHandlers == nil {
+      print(String(format: "[Portal] Could not find any bindings for event '%@'. Ignoring...", event))
+      return self
+    } else {
+      // Invoke all registered handlers for the event
+      do {
+        for registeredEventHandler in registeredEventHandlers! {
+          try registeredEventHandler.handler(data)
+        }
+      } catch {
+        print("[Portal] Error invoking registered handlers", error)
+      }
+
+      // Remove once instances
+      events[event] = registeredEventHandlers?.filter(removeOnce)
+
+      return self
+    }
+  }
+
+  /// Registers a callback for an event.
+  /// - Parameters:
+  ///   - event: The event to register a callback.
+  ///   - callback: The function to be invoked whenever the event fires.
+  /// - Returns: The Portal Provider instance.
+  public func on(
+    event: Events.RawValue,
+    callback: @escaping (_ data: Any) -> Void
+  ) -> PortalProvider {
+    if events[event] == nil {
+      events[event] = []
+    }
+
+    events[event]?.append(RegisteredEventHandler(
+      handler: callback,
+      once: false
+    ))
+
+    return self
+  }
+
+  /// Registers a callback for an event. Deletes the registered callback after it's fired once.
+  /// - Parameters:
+  ///   - event: The event to register a callback.
+  ///   - callback: The function to be invoked whenever the event fires.
+  /// - Returns: The Portal Provider instance.
+  public func once(
+    event: Events.RawValue,
+    callback: @escaping (_ data: Any) throws -> Void
+  ) -> PortalProvider {
+    if events[event] == nil {
+      events[event] = []
+    }
+
+    events[event]?.append(RegisteredEventHandler(
+      handler: callback,
+      once: true
+    ))
+
+    return self
+  }
+
+  /// Removes the callback for the specified event.
+  /// - Parameters:
+  ///   - event: A specific event from the list of Events.
+  /// - Returns: An instance of Portal Provider.
+  public func removeListener(
+    event: Events.RawValue
+  ) -> PortalProvider {
+    if events[event] == nil {
+      print(String(format: "[Portal] Could not find any bindings for event '%@'. Ignoring...", event))
+    }
+
+    events[event] = nil
+
+    return self
+  }
+
+  /// Makes a request.
+  /// - Parameters:
+  ///   - payload: A normal payload whose params are of type [Any].
+  ///   - completion: Resolves with a Result.
+  /// - Returns: Void
+  public func request(
+    payload: ETHRequestPayload,
+    completion: @escaping (Result<RequestCompletionResult>) -> Void,
+    connect: PortalConnect? = nil
+  ) {
+    let isSignerMethod = signerMethods.contains(payload.method)
+    let id = UUID().uuidString
+
+    let payloadWithId = ETHRequestPayload(method: payload.method, params: payload.params, id: id)
+
+    if !isSignerMethod, !payloadWithId.method.starts(with: "wallet_") {
+      handleGatewayRequest(payload: payloadWithId, connect: connect) { (method: String, params: [Any], result: Result<Any>, id: String) in
+        if id == payloadWithId.id {
+          if result.data != nil {
+            return completion(Result(data: RequestCompletionResult(method: method, params: params, result: result.data!, id: id)))
+          } else {
+            return completion(Result(error: result.error!))
+          }
+        }
+      }
+    } else if isSignerMethod {
+      handleSigningRequest(payload: payloadWithId, connect: connect) { (result: Result<SignerResult>, id: String) in
+        if id == payloadWithId.id {
+          guard result.error == nil else {
+            return completion(Result(error: result.error!))
+          }
+
+          // Trigger `portal_signatureReceived` event
+          _ = self.emit(
+            event: Events.PortalSignatureReceived.rawValue,
+            data: RequestCompletionResult(
+              method: payloadWithId.method,
+              params: payloadWithId.params,
+              result: result,
+              id: id
+            )
+          )
+
+          // Trigger completion handler
+          return completion(Result(data: RequestCompletionResult(method: payloadWithId.method, params: payloadWithId.params, result: result, id: id)))
+        }
+      }
+    } else {
+      return completion(Result(error: ProviderRpcError.unsupportedMethod))
+    }
+  }
+
+  /// Makes a request.
+  /// - Parameters:
+  ///   - payload: A transaction payload.
+  ///   - completion: Resolves with a Result.
+  /// - Returns: Void
+  public func request(
+    payload: ETHTransactionPayload,
+    completion: @escaping (Result<TransactionCompletionResult>) -> Void,
+    connect: PortalConnect? = nil
+  ) {
+    let isSignerMethod = signerMethods.contains(payload.method)
+    let id = UUID().uuidString
+
+    let payloadWithId = ETHTransactionPayload(method: payload.method, params: payload.params, id: id)
+
+    if !isSignerMethod, !payloadWithId.method.starts(with: "wallet_") {
+      handleGatewayRequest(payload: payloadWithId, connect: connect) {
+        (method: String, params: [ETHTransactionParam], result: Result<Any>, id: String) in
+        if id == payloadWithId.id {
+          guard result.error == nil else {
+            return completion(Result(error: result.error!))
+          }
+          if result.data != nil {
+            return completion(Result(data: TransactionCompletionResult(method: method, params: params, result: result.data!, id: payloadWithId.id!)))
+          }
+        }
+      }
+    } else if isSignerMethod {
+      handleSigningRequest(payload: payloadWithId, connect: connect) { (result: Result<Any>, id: String) in
+        if id == payloadWithId.id {
+          guard result.error == nil else {
+            return completion(Result(error: result.error!))
+          }
+
+          // Trigger `portal_signatureReceived` event
+          _ = self.emit(
+            event: Events.PortalSignatureReceived.rawValue,
+            data: RequestCompletionResult(
+              method: payloadWithId.method,
+              params: payloadWithId.params,
+              result: result,
+              id: payloadWithId.id!
+            )
+          )
+
+          // Trigger completion handler
+          return completion(Result(data: TransactionCompletionResult(method: payloadWithId.method, params: payloadWithId.params, result: result, id: payloadWithId.id!)))
+        }
+      }
+    } else {
+      return completion(Result(error: ProviderRpcError.unsupportedMethod))
+    }
+  }
+
+  /// Makes a request.
+  /// - Parameters:
+  ///   - payload: An address payload.
+  ///   - completion: Resolves with a Result.
+  /// - Returns: Void
+  public func request(
+    payload: ETHAddressPayload,
+    completion: @escaping (Result<AddressCompletionResult>) -> Void,
+    connect: PortalConnect? = nil
+  ) {
+    let isSignerMethod = signerMethods.contains(payload.method)
+    let id = UUID().uuidString
+
+    let payloadWithId = ETHAddressPayload(method: payload.method, params: payload.params, id: id)
+
+    if !isSignerMethod, !payloadWithId.method.starts(with: "wallet_") {
+      handleGatewayRequest(payload: payloadWithId, connect: connect) {
+        (method: String, params: [ETHAddressParam], result: Result<Any>, id: String) in
+        if id == payloadWithId.id {
+          if result.data != nil {
+            return completion(Result(data: AddressCompletionResult(method: method, params: params, result: result.data!, id: id)))
+          } else {
+            return completion(Result(error: result.error!))
+          }
+        }
+      }
+    } else {
+      return completion(Result(error: ProviderRpcError.unsupportedMethod))
+    }
+  }
+
+  /// Sets the EVM network chainId.
+  /// - Parameter value: The chainId.
+  /// - Returns: An instance of Portal Provider.
+  public func setChainId(value: Int) throws -> PortalProvider {
+    chainId = value
+    let hexChainId = String(format: "%02x", value)
+
+    let provider = emit(event: Events.ChainChanged.rawValue, data: ["chainId": hexChainId])
+
+    do {
+      let gatewayUrl = try PortalProvider.getGatewayUrl(gatewayConfig: gatewayConfig, chainId: value)
+      gateway = HttpRequester(baseUrl: gatewayUrl)
+    } catch {
+      throw ProviderInvalidArgumentError.invalidGatewayUrl
+    }
+    return provider
+  }
+
+  // ------ Private Functions
+  private func getApproval(
+    payload: ETHRequestPayload,
+    completion: @escaping (Result<Bool>) -> Void,
+    connect: PortalConnect? = nil
+  ) {
+    if autoApprove {
+      return completion(Result(data: true))
+    } else if connect == nil, events[Events.PortalSigningRequested.rawValue] == nil {
+      return completion(Result(error: ProviderSigningError.noBindingForSigningApprovalFound))
+    }
+
+    // Bind to signing approval callbacks
+    _ = on(event: Events.PortalSigningApproved.rawValue, callback: { approved in
+      if approved is ETHRequestPayload {
+        let approvedPayload = approved as! ETHRequestPayload
+
+        if approvedPayload.id == payload.id {
+          // If the approved event is fired
+          return completion(Result(data: true))
+        }
+      }
+    }).on(event: Events.PortalSigningRejected.rawValue, callback: { approved in
+      if approved is ETHRequestPayload {
+        let rejectedPayload = approved as! ETHRequestPayload
+
+        if rejectedPayload.id == payload.id {
+          // If the rejected event is fired
+          return completion(Result(data: false))
+        }
+      }
+    })
+
+    if connect != nil {
+      connect!.emit(event: Events.PortalConnectSigningRequested.rawValue, data: payload)
+    } else {
+      // Execute event handlers
+      let handlers = events[Events.PortalSigningRequested.rawValue]
+
+      // Fail if there are no handlers
+      if handlers == nil || handlers!.isEmpty {
+        return completion(Result(data: false))
+      }
+
+      do {
+        // Loop over the event handlers
+        for eventHandler in handlers! {
+          try eventHandler.handler(payload)
+        }
+      } catch {
+        return completion(Result(error: error))
+      }
+    }
+  }
+
+  private func getApproval(
+    payload: ETHTransactionPayload,
+    completion: @escaping (Result<Bool>) -> Void,
+    connect: PortalConnect? = nil
+  ) {
+    if autoApprove {
+      return completion(Result(data: true))
+    } else if connect == nil, events[Events.PortalSigningRequested.rawValue] == nil {
+      return completion(Result(error: ProviderSigningError.noBindingForSigningApprovalFound))
+    }
+
+    // Bind to signing approval callbacks
+    _ = on(event: Events.PortalSigningApproved.rawValue, callback: { approved in
+      if approved is ETHTransactionPayload {
+        let approvedPayload = approved as! ETHTransactionPayload
+
+        if approvedPayload.id == payload.id {
+          // If the approved event is fired
+          return completion(Result(data: true))
+        }
+      }
+    }).on(event: Events.PortalSigningRejected.rawValue, callback: { approved in
+      if approved is ETHTransactionPayload {
+        let rejectedPayload = approved as! ETHTransactionPayload
+
+        if rejectedPayload.id == payload.id {
+          // If the rejected event is fired
+          return completion(Result(data: false))
+        }
+      }
+    })
+
+    if connect != nil {
+      connect!.emit(event: Events.PortalConnectSigningRequested.rawValue, data: payload)
+    } else {
+      // Execute event handlers
+      let handlers = events[Events.PortalSigningRequested.rawValue]
+
+      // Fail if there are no handlers
+      if handlers == nil || handlers!.isEmpty {
+        return completion(Result(data: false))
+      }
+
+      do {
+        // Loop over the event handlers
+        for eventHandler in handlers! {
+          try eventHandler.handler(payload)
+        }
+      } catch {
+        return completion(Result(error: error))
+      }
+    }
+  }
+
+  private func handleGatewayRequest(
+    payload: ETHTransactionPayload,
+    completion: @escaping (String, [ETHTransactionParam], Result<Any>, String) -> Void,
+    connect _: PortalConnect? = nil
+  ) {
+    // Create the body of the request.
+    let body: [String: Any] = [
+      "method": payload.method,
+      "params": payload.params.map { (p: ETHTransactionParam) in
+        [
+          "from": p.from,
+          "to": p.to,
+          "gas": p.gas,
+          "gasPrice": p.gasPrice,
+          "value": p.value,
+          "data": p.data,
+        ]
+      },
+    ]
+
+    do {
+      try gateway.post(
+        path: "/",
+        body: body,
+        headers: ["Content-Type": "application/json"],
+        requestType: HttpRequestType.GatewayRequest
+      ) { (result: Result<ETHGatewayResponse>) in
+        if result.data != nil {
+          return completion(payload.method, payload.params, Result(data: result.data!), payload.id!)
+        } else {
+          return completion(payload.method, payload.params, Result(error: result.error!), payload.id!)
+        }
+      }
+    } catch {
+      completion(payload.method, payload.params, Result(error: error), payload.id!)
+    }
+  }
+
+  private func handleGatewayRequest(
+    payload: ETHAddressPayload,
+    completion: @escaping (String, [ETHAddressParam], Result<Any>, String) -> Void,
+    connect _: PortalConnect? = nil
+  ) {
+    // Create the body of the request.
+    let body: [String: Any] = [
+      "method": payload.method,
+      "params": payload.params.map { (p: ETHAddressParam) in
+        ["address": p.address]
+      },
+    ]
+
+    do {
+      try gateway.post(
+        path: "/",
+        body: body,
+        headers: ["Content-Type": "application/json"],
+        requestType: HttpRequestType.GatewayRequest
+      ) { (result: Result<ETHGatewayResponse>) in
+        if result.data != nil {
+          return completion(payload.method, payload.params, Result(data: result.data!), payload.id!)
+        } else {
+          return completion(payload.method, payload.params, Result(error: result.error!), payload.id!)
+        }
+      }
+    } catch {
+      completion(payload.method, payload.params, Result(error: error), payload.id!)
+    }
+  }
+
+  private func handleGatewayRequest(
+    payload: ETHRequestPayload,
+    completion: @escaping (String, [Any], Result<Any>, String) -> Void,
+    connect _: PortalConnect? = nil
+  ) {
+    // Create the body of the request.
+    let body: [String: Any] = [
+      "method": payload.method,
+      "params": payload.params,
+    ]
+
+    do {
+      try gateway.post(
+        path: "/",
+        body: body,
+        headers: ["Content-Type": "application/json"],
+        requestType: HttpRequestType.GatewayRequest
+      ) { (result: Result<ETHGatewayResponse>) in
+        if result.data != nil {
+          return completion(payload.method, payload.params, Result(data: result.data!), payload.id!)
+        } else {
+          return completion(payload.method, payload.params, Result(error: result.error!), payload.id!)
+        }
+      }
+    } catch {
+      completion(payload.method, payload.params, Result(error: error), payload.id!)
+    }
+  }
+
+  private func handleSigningRequest(
+    payload: ETHRequestPayload,
+    completion: @escaping (Result<SignerResult>, String) -> Void,
+    connect: PortalConnect? = nil
+  ) {
+    getApproval(payload: payload, connect: connect) { result in
+      guard result.error == nil else {
+        return completion(Result(error: result.error!), payload.id!)
+      }
+      if result.data != true {
+        return completion(Result(error: ProviderSigningError.userDeclinedApproval), payload.id!)
+      } else {
+        self.mpcQueue.async {
+          // This code will be executed in a background thread
+          var signResult = SignerResult()
+          do {
+            signResult = try self.signer.sign(
+              payload: payload,
+              provider: self
+            )
+            // When the work is done, call the completion handler
+            DispatchQueue.main.async {
+              completion(Result(data: signResult), payload.id!)
+            }
+
+          } catch {
+            DispatchQueue.main.async {
+              completion(Result(error: error), payload.id!)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private func handleSigningRequest(
+    payload: ETHTransactionPayload,
+    completion: @escaping (Result<Any>, String) -> Void,
+    connect: PortalConnect? = nil
+  ) {
+    getApproval(payload: payload, connect: connect) { result in
+      guard result.error == nil else {
+        return completion(Result(error: result.error!), payload.id!)
+      }
+
+      if !result.data! {
+        return completion(Result(error: ProviderSigningError.userDeclinedApproval), payload.id!)
+      } else {
+        self.mpcQueue.async {
+          // This code will be executed in a background thread
+          var signResult = SignerResult()
+          do {
+            signResult = try self.signer.sign(
+              payload: payload,
+              provider: self
+            )
+            // When the work is done, call the completion handler
+            DispatchQueue.main.async {
+              completion(Result(data: signResult.signature!), payload.id!)
+            }
+          } catch {
+            DispatchQueue.main.async {
+              completion(Result(error: error), payload.id!)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private func removeOnce(registeredEventHandler: RegisteredEventHandler) -> Bool {
+    return !registeredEventHandler.once
+  }
+
+  private func dispatchConnect() {
+    let hexChainId = String(format: "%02x", chainId)
+    _ = emit(event: Events.Connect.rawValue, data: ["chainId": hexChainId])
+  }
+
+  /// Determines the appropriate Gateway URL to use for the current chainId
+  /// - Parameters:
+  ///   - gatewayConfig: A dictionary of chainIds (keys) and gateway URLs (values).
+  ///   - chainId: The chainId we should use, such as 5 (Goerli).
+  /// - Throws: PortalArgumentError.noGatewayConfigForChain with the chainId.
+  /// - Returns: The URL to be used for Gateway requests.
+  static func getGatewayUrl(gatewayConfig: [Int: String], chainId: Int) throws -> String {
+    if gatewayConfig[chainId] == nil {
+      throw PortalArgumentError.noGatewayConfigForChain(chainId: chainId)
+    }
+
+    return gatewayConfig[chainId]!
+  }
+}
+
+/**********************************
+ * Supporting Structs
+ **********************************/
+
 /// A list of EVM networks.
 public enum Chains: Int {
   case Mainnet = 1
@@ -315,613 +935,4 @@ public struct AddressCompletionResult {
   public var params: [ETHAddressParam]
   public var result: Any
   public var id: String
-}
-
-/// Portal's EVM blockchain provider.
-public class PortalProvider {
-  public var autoApprove: Bool = false
-  public var chainId: Chains.RawValue
-  public var gatewayUrl: String
-  public var keychain: PortalKeychain
-  public var portal: HttpRequester
-  public var rpc: HttpRequester
-
-  private var apiKey: String = "NO_API_KEY_PROVIDED"
-  private var apiUrl: String = "https://api.portalhq.io"
-  private var alchemyId: String = ""
-  private var events: [Events.RawValue: [RegisteredEventHandler]] = [:]
-  private var httpHost: String = "https://api.portalhq.io"
-  private var infuraId: String = ""
-  private var signer: MpcSigner
-  private var address: String = ""
-  private var mpcHost: String = "mpc.portalhq.io"
-  private var version: String = "v4"
-  private var mpcQueue: DispatchQueue
-
-  private var walletMethods: [ETHRequestMethods.RawValue] = [
-    ETHRequestMethods.WalletAddEthereumChain.rawValue,
-    ETHRequestMethods.WalletGetPermissions.rawValue,
-    ETHRequestMethods.WalletRegisterOnboarding.rawValue,
-    ETHRequestMethods.WalletRequestPermissions.rawValue,
-    ETHRequestMethods.WalletSwitchEthereumChain.rawValue,
-    ETHRequestMethods.WalletWatchAsset.rawValue,
-  ]
-
-  /// Creates an instance of PortalProvider.
-  /// - Parameters:
-  ///   - apiKey: The client API key. You can obtain this via Portal's REST API.
-  ///   - chainId: The ID of the EVM network you are using.
-  ///   - gatewayUrl: The gateway URL, such as Infura or Alchemy.
-  ///   - apiHost: The hostname of the API to use.
-  ///   - autoApprove: Auto approves all transactions.
-  public init(
-    apiKey: String,
-    chainId: Chains.RawValue,
-    gatewayUrl: String,
-    keychain: PortalKeychain,
-    apiHost: String = "api.portalhq.io",
-    autoApprove: Bool,
-    mpcHost: String = "mpc.portalhq.io",
-    version: String = "v4"
-  ) throws {
-    // User-defined instance variables
-    self.apiKey = apiKey
-    self.chainId = chainId
-    self.gatewayUrl = gatewayUrl
-    self.keychain = keychain
-    self.autoApprove = autoApprove
-    rpc = HttpRequester(baseUrl: gatewayUrl)
-    self.mpcHost = mpcHost
-    self.version = version
-
-    // Other instance variables
-    portal = HttpRequester(baseUrl: apiUrl)
-
-    if gatewayUrl.isEmpty {
-      throw ProviderInvalidArgumentError.invalidGatewayUrl
-    }
-
-    portal = HttpRequester(baseUrl: String(format: "https://%@", apiHost))
-    signer = MpcSigner(keychain: keychain, mpcUrl: self.mpcHost, version: version)
-    // Create a serial dispatch queue with a unique label
-    mpcQueue = DispatchQueue.global(qos: .background)
-    dispatchConnect()
-  }
-
-  // ------ Public Functions
-
-  /// Emits an event from the provider to registered event handlers.
-  /// - Parameters:
-  ///   - event: The event to be emitted.
-  ///   - data: The data to pass to registered event handlers.
-  /// - Returns: The Portal Provider instance.
-  public func emit(event: Events.RawValue, data: Any) -> PortalProvider {
-    let registeredEventHandlers = events[event]
-
-    if registeredEventHandlers == nil {
-      print(String(format: "[Portal] Could not find any bindings for event '%@'. Ignoring...", event))
-      return self
-    } else {
-      // Invoke all registered handlers for the event
-      do {
-        for registeredEventHandler in registeredEventHandlers! {
-          try registeredEventHandler.handler(data)
-        }
-      } catch {
-        print("[Portal] Error invoking registered handlers", error)
-      }
-
-      // Remove once instances
-      events[event] = registeredEventHandlers?.filter(removeOnce)
-
-      return self
-    }
-  }
-
-  /// Retrieves the API key.
-  /// - Returns: The client API key.
-  public func getApiKey() -> String {
-    return apiKey
-  }
-
-  /// Registers a callback for an event.
-  /// - Parameters:
-  ///   - event: The event to register a callback.
-  ///   - callback: The function to be invoked whenever the event fires.
-  /// - Returns: The Portal Provider instance.
-  public func on(
-    event: Events.RawValue,
-    callback: @escaping (_ data: Any) -> Void
-  ) -> PortalProvider {
-    if events[event] == nil {
-      events[event] = []
-    }
-
-    events[event]?.append(RegisteredEventHandler(
-      handler: callback,
-      once: false
-    ))
-
-    return self
-  }
-
-  /// Registers a callback for an event. Deletes the registered callback after it's fired once.
-  /// - Parameters:
-  ///   - event: The event to register a callback.
-  ///   - callback: The function to be invoked whenever the event fires.
-  /// - Returns: The Portal Provider instance.
-  public func once(
-    event: Events.RawValue,
-    callback: @escaping (_ data: Any) throws -> Void
-  ) -> PortalProvider {
-    if events[event] == nil {
-      events[event] = []
-    }
-
-    events[event]?.append(RegisteredEventHandler(
-      handler: callback,
-      once: true
-    ))
-
-    return self
-  }
-
-  /// Removes the callback for the specified event.
-  /// - Parameters:
-  ///   - event: A specific event from the list of Events.
-  /// - Returns: An instance of Portal Provider.
-  public func removeListener(
-    event: Events.RawValue
-  ) -> PortalProvider {
-    if events[event] == nil {
-      print(String(format: "[Portal] Could not find any bindings for event '%@'. Ignoring...", event))
-    }
-
-    events[event] = nil
-
-    return self
-  }
-
-  /// Makes a request.
-  /// - Parameters:
-  ///   - payload: A normal payload whose params are of type [Any].
-  ///   - completion: Resolves with a Result.
-  /// - Returns: Void
-  public func request(
-    payload: ETHRequestPayload,
-    completion: @escaping (Result<RequestCompletionResult>) -> Void,
-    connect: PortalConnect? = nil
-  ) {
-    let isSignerMethod = signerMethods.contains(payload.method)
-    let id = UUID().uuidString
-
-    let payloadWithId = ETHRequestPayload(method: payload.method, params: payload.params, id: id)
-
-    if !isSignerMethod, !payloadWithId.method.starts(with: "wallet_") {
-      handleGatewayRequest(payload: payloadWithId, connect: connect) { (method: String, params: [Any], result: Result<Any>, id: String) in
-        if id == payloadWithId.id {
-          if result.data != nil {
-            return completion(Result(data: RequestCompletionResult(method: method, params: params, result: result.data!, id: id)))
-          } else {
-            return completion(Result(error: result.error!))
-          }
-        }
-      }
-    } else if isSignerMethod {
-      handleSigningRequest(payload: payloadWithId, connect: connect) { (result: Result<SignerResult>, id: String) in
-        if id == payloadWithId.id {
-          guard result.error == nil else {
-            return completion(Result(error: result.error!))
-          }
-
-          // Trigger `portal_signatureReceived` event
-          _ = self.emit(
-            event: Events.PortalSignatureReceived.rawValue,
-            data: RequestCompletionResult(
-              method: payloadWithId.method,
-              params: payloadWithId.params,
-              result: result,
-              id: id
-            )
-          )
-
-          // Trigger completion handler
-          return completion(Result(data: RequestCompletionResult(method: payloadWithId.method, params: payloadWithId.params, result: result, id: id)))
-        }
-      }
-    } else {
-      return completion(Result(error: ProviderRpcError.unsupportedMethod))
-    }
-  }
-
-  /// Makes a request.
-  /// - Parameters:
-  ///   - payload: A transaction payload.
-  ///   - completion: Resolves with a Result.
-  /// - Returns: Void
-  public func request(
-    payload: ETHTransactionPayload,
-    completion: @escaping (Result<TransactionCompletionResult>) -> Void,
-    connect: PortalConnect? = nil
-  ) {
-    let isSignerMethod = signerMethods.contains(payload.method)
-    let id = UUID().uuidString
-
-    let payloadWithId = ETHTransactionPayload(method: payload.method, params: payload.params, id: id)
-
-    if !isSignerMethod, !payloadWithId.method.starts(with: "wallet_") {
-      handleGatewayRequest(payload: payloadWithId, connect: connect) {
-        (method: String, params: [ETHTransactionParam], result: Result<Any>, id: String) in
-        if id == payloadWithId.id {
-          guard result.error == nil else {
-            return completion(Result(error: result.error!))
-          }
-          if result.data != nil {
-            return completion(Result(data: TransactionCompletionResult(method: method, params: params, result: result.data!, id: payloadWithId.id!)))
-          }
-        }
-      }
-    } else if isSignerMethod {
-      handleSigningRequest(payload: payloadWithId, connect: connect) { (result: Result<Any>, id: String) in
-        if id == payloadWithId.id {
-          guard result.error == nil else {
-            return completion(Result(error: result.error!))
-          }
-
-          // Trigger `portal_signatureReceived` event
-          _ = self.emit(
-            event: Events.PortalSignatureReceived.rawValue,
-            data: RequestCompletionResult(
-              method: payloadWithId.method,
-              params: payloadWithId.params,
-              result: result,
-              id: payloadWithId.id!
-            )
-          )
-
-          // Trigger completion handler
-          return completion(Result(data: TransactionCompletionResult(method: payloadWithId.method, params: payloadWithId.params, result: result, id: payloadWithId.id!)))
-        }
-      }
-    } else {
-      return completion(Result(error: ProviderRpcError.unsupportedMethod))
-    }
-  }
-
-  /// Makes a request.
-  /// - Parameters:
-  ///   - payload: An address payload.
-  ///   - completion: Resolves with a Result.
-  /// - Returns: Void
-  public func request(
-    payload: ETHAddressPayload,
-    completion: @escaping (Result<AddressCompletionResult>) -> Void,
-    connect: PortalConnect? = nil
-  ) {
-    let isSignerMethod = signerMethods.contains(payload.method)
-    let id = UUID().uuidString
-
-    let payloadWithId = ETHAddressPayload(method: payload.method, params: payload.params, id: id)
-
-    if !isSignerMethod, !payloadWithId.method.starts(with: "wallet_") {
-      handleGatewayRequest(payload: payloadWithId, connect: connect) {
-        (method: String, params: [ETHAddressParam], result: Result<Any>, id: String) in
-        if id == payloadWithId.id {
-          if result.data != nil {
-            return completion(Result(data: AddressCompletionResult(method: method, params: params, result: result.data!, id: id)))
-          } else {
-            return completion(Result(error: result.error!))
-          }
-        }
-      }
-    } else {
-      return completion(Result(error: ProviderRpcError.unsupportedMethod))
-    }
-  }
-
-  /// Sets the public address.
-  /// - Parameter value: The public address.
-  /// - Returns: Void
-  public func setAddress(value: String) {
-    address = value
-  }
-
-  /// Sets the EVM network chainId.
-  /// - Parameter value: The chainId.
-  /// - Returns: An instance of Portal Provider.
-  public func setChainId(value: Int) -> PortalProvider {
-    chainId = value
-    let hexChainId = String(format: "%02x", value)
-    let provider = emit(event: Events.ChainChanged.rawValue, data: ["chainId": hexChainId])
-    return provider
-  }
-
-  // ------ Private Functions
-  private func getApproval(
-    payload: ETHRequestPayload,
-    completion: @escaping (Result<Bool>) -> Void,
-    connect: PortalConnect? = nil
-  ) {
-    if autoApprove {
-      return completion(Result(data: true))
-    } else if connect == nil, events[Events.PortalSigningRequested.rawValue] == nil {
-      return completion(Result(error: ProviderSigningError.noBindingForSigningApprovalFound))
-    }
-
-    // Bind to signing approval callbacks
-    _ = on(event: Events.PortalSigningApproved.rawValue, callback: { approved in
-      if approved is ETHRequestPayload {
-        let approvedPayload = approved as! ETHRequestPayload
-
-        if approvedPayload.id == payload.id {
-          // If the approved event is fired
-          return completion(Result(data: true))
-        }
-      }
-    }).on(event: Events.PortalSigningRejected.rawValue, callback: { approved in
-      if approved is ETHRequestPayload {
-        let rejectedPayload = approved as! ETHRequestPayload
-
-        if rejectedPayload.id == payload.id {
-          // If the rejected event is fired
-          return completion(Result(data: false))
-        }
-      }
-    })
-
-    if connect != nil {
-      connect!.emit(event: Events.PortalConnectSigningRequested.rawValue, data: payload)
-    } else {
-      // Execute event handlers
-      let handlers = events[Events.PortalSigningRequested.rawValue]
-
-      // Fail if there are no handlers
-      if handlers == nil || handlers!.isEmpty {
-        return completion(Result(data: false))
-      }
-
-      do {
-        // Loop over the event handlers
-        for eventHandler in handlers! {
-          try eventHandler.handler(payload)
-        }
-      } catch {
-        return completion(Result(error: error))
-      }
-    }
-  }
-
-  private func getApproval(
-    payload: ETHTransactionPayload,
-    completion: @escaping (Result<Bool>) -> Void,
-    connect: PortalConnect? = nil
-  ) {
-    if autoApprove {
-      return completion(Result(data: true))
-    } else if connect == nil, events[Events.PortalSigningRequested.rawValue] == nil {
-      return completion(Result(error: ProviderSigningError.noBindingForSigningApprovalFound))
-    }
-
-    // Bind to signing approval callbacks
-    _ = on(event: Events.PortalSigningApproved.rawValue, callback: { approved in
-      if approved is ETHTransactionPayload {
-        let approvedPayload = approved as! ETHTransactionPayload
-
-        if approvedPayload.id == payload.id {
-          // If the approved event is fired
-          return completion(Result(data: true))
-        }
-      }
-    }).on(event: Events.PortalSigningRejected.rawValue, callback: { approved in
-      if approved is ETHTransactionPayload {
-        let rejectedPayload = approved as! ETHTransactionPayload
-
-        if rejectedPayload.id == payload.id {
-          // If the rejected event is fired
-          return completion(Result(data: false))
-        }
-      }
-    })
-
-    if connect != nil {
-      connect!.emit(event: Events.PortalConnectSigningRequested.rawValue, data: payload)
-    } else {
-      // Execute event handlers
-      let handlers = events[Events.PortalSigningRequested.rawValue]
-
-      // Fail if there are no handlers
-      if handlers == nil || handlers!.isEmpty {
-        return completion(Result(data: false))
-      }
-
-      do {
-        // Loop over the event handlers
-        for eventHandler in handlers! {
-          try eventHandler.handler(payload)
-        }
-      } catch {
-        return completion(Result(error: error))
-      }
-    }
-  }
-
-  private func handleGatewayRequest(
-    payload: ETHTransactionPayload,
-    completion: @escaping (String, [ETHTransactionParam], Result<Any>, String) -> Void,
-    connect _: PortalConnect? = nil
-  ) {
-    // Create the body of the request.
-    let body: [String: Any] = [
-      "method": payload.method,
-      "params": payload.params.map { (p: ETHTransactionParam) in
-        [
-          "from": p.from,
-          "to": p.to,
-          "gas": p.gas,
-          "gasPrice": p.gasPrice,
-          "value": p.value,
-          "data": p.data,
-        ]
-      },
-    ]
-
-    // Create the request.
-    let request = HttpRequest<ETHGatewayResponse, [String: Any]>(
-      url: rpc.baseUrl,
-      method: "POST",
-      body: body,
-      headers: ["Content-Type": "application/json"],
-      requestType: HttpRequestType.GatewayRequest
-    )
-
-    // Attempt to send the request.
-    request.send { (result: Result<ETHGatewayResponse>) in
-      if result.data != nil {
-        return completion(payload.method, payload.params, Result(data: result.data!), payload.id!)
-      } else {
-        return completion(payload.method, payload.params, Result(error: result.error!), payload.id!)
-      }
-    }
-  }
-
-  private func handleGatewayRequest(
-    payload: ETHAddressPayload,
-    completion: @escaping (String, [ETHAddressParam], Result<Any>, String) -> Void,
-    connect _: PortalConnect? = nil
-  ) {
-    // Create the body of the request.
-    let body: [String: Any] = [
-      "method": payload.method,
-      "params": payload.params.map { (p: ETHAddressParam) in
-        ["address": p.address]
-      },
-    ]
-
-    // Create the request.
-    let request = HttpRequest<ETHGatewayResponse, [String: Any]>(
-      url: rpc.baseUrl,
-      method: "POST",
-      body: body,
-      headers: ["Content-Type": "application/json"],
-      requestType: HttpRequestType.GatewayRequest
-    )
-
-    // Attempt to send the request.
-    request.send { (result: Result<ETHGatewayResponse>) in
-      if result.data != nil {
-        return completion(payload.method, payload.params, Result(data: result.data!), payload.id!)
-      } else {
-        return completion(payload.method, payload.params, Result(error: result.error!), payload.id!)
-      }
-    }
-  }
-
-  private func handleGatewayRequest(
-    payload: ETHRequestPayload,
-    completion: @escaping (String, [Any], Result<Any>, String) -> Void,
-    connect _: PortalConnect? = nil
-  ) {
-    // Create the body of the request.
-    let body: [String: Any] = [
-      "method": payload.method,
-      "params": payload.params,
-    ]
-
-    // Create the request.
-    let request = HttpRequest<ETHGatewayResponse, [String: Any]>(
-      url: rpc.baseUrl,
-      method: "POST",
-      body: body,
-      headers: ["Content-Type": "application/json"],
-      requestType: HttpRequestType.GatewayRequest
-    )
-
-    // Attempt to send the request.
-    request.send { (result: Result<ETHGatewayResponse>) in
-      if result.data != nil {
-        return completion(payload.method, payload.params, Result(data: result.data!), payload.id!)
-      } else {
-        return completion(payload.method, payload.params, Result(error: result.error!), payload.id!)
-      }
-    }
-  }
-
-  private func handleSigningRequest(
-    payload: ETHRequestPayload,
-    completion: @escaping (Result<SignerResult>, String) -> Void,
-    connect: PortalConnect? = nil
-  ) {
-    getApproval(payload: payload, connect: connect) { result in
-      guard result.error == nil else {
-        return completion(Result(error: result.error!), payload.id!)
-      }
-      if result.data != true {
-        return completion(Result(error: ProviderSigningError.userDeclinedApproval), payload.id!)
-      } else {
-        self.mpcQueue.async {
-          // This code will be executed in a background thread
-          var signResult = SignerResult()
-          do {
-            signResult = try self.signer.sign(
-              payload: payload,
-              provider: self
-            )
-            // When the work is done, call the completion handler
-            DispatchQueue.main.async {
-              completion(Result(data: signResult), payload.id!)
-            }
-
-          } catch {
-            DispatchQueue.main.async {
-              completion(Result(error: error), payload.id!)
-            }
-          }
-        }
-      }
-    }
-  }
-
-  private func handleSigningRequest(
-    payload: ETHTransactionPayload,
-    completion: @escaping (Result<Any>, String) -> Void,
-    connect: PortalConnect? = nil
-  ) {
-    getApproval(payload: payload, connect: connect) { result in
-      guard result.error == nil else {
-        return completion(Result(error: result.error!), payload.id!)
-      }
-
-      if !result.data! {
-        return completion(Result(error: ProviderSigningError.userDeclinedApproval), payload.id!)
-      } else {
-        self.mpcQueue.async {
-          // This code will be executed in a background thread
-          var signResult = SignerResult()
-          do {
-            signResult = try self.signer.sign(
-              payload: payload,
-              provider: self
-            )
-            // When the work is done, call the completion handler
-            DispatchQueue.main.async {
-              completion(Result(data: signResult.signature!), payload.id!)
-            }
-          } catch {
-            DispatchQueue.main.async {
-              completion(Result(error: error), payload.id!)
-            }
-          }
-        }
-      }
-    }
-  }
-
-  private func removeOnce(registeredEventHandler: RegisteredEventHandler) -> Bool {
-    return !registeredEventHandler.once
-  }
-
-  private func dispatchConnect() {
-    let hexChainId = String(format: "%02x", chainId)
-    _ = emit(event: Events.Connect.rawValue, data: ["chainId": hexChainId])
-  }
 }


### PR DESCRIPTION
- Adds Provider helper methods to `Portal` for:
  - `ethSendTransaction()`
  - `ethSignTransaction()`
  - `ethSignTypedData()`
  - `personalSign()`
  - `request()`
- Adds wallet helper methods to `Portal` for:
  - `backupWallet()`
  - `createWallet()`
  - `recoverWallet()`
- Adds keychain helper methods to `Portal` for:
  - `deleteAddress()
  - `deleteSigningShare()
- Updates `PortalConnect` to manage its own `Provider` instance
- Updates child instance references so `Provider` is the only class to manage `chainId` and all others use the `Provider` instance to get `chainId`
- Updates child instance references so `Keychain` is the only class to manage `address` and all others use the `Keychain` instance to get `address`