### PR TITLE
Ensure most buttons are disabled until you have a wallet, add new btn

### DIFF
--- a/Example/PortalSwift/Base.lproj/Main.storyboard
+++ b/Example/PortalSwift/Base.lproj/Main.storyboard
@@ -202,15 +202,27 @@
                                     <segue destination="7fk-LF-non" kind="presentation" id="suo-jY-leB"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="nftsTrxsBalancesButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zxl-zt-jSZ">
+                                <rect key="frame" x="17" y="648" width="342" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="NFTs, Trxs, + Balances">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" red="0.027450980390000001" green="0.054901960780000002" blue="0.086274509799999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="fetchNFTsAndTrxsAndBalances" destination="vXZ-lx-hvc" eventType="touchUpInside" id="QIN-fx-x7c"/>
+                                </connections>
+                            </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NGV-LW-69G">
                                 <rect key="frame" x="16" y="468" width="343" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Sign">
-                                    <backgroundConfiguration key="background">
-                                        <color key="backgroundColor" red="0.027450980390000001" green="0.054901960780000002" blue="0.086274509799999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    </backgroundConfiguration>
+                                    <backgroundConfiguration key="background"/>
                                     <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </buttonConfiguration>
                                 <connections>
                                     <action selector="handleSign" destination="vXZ-lx-hvc" eventType="touchUpInside" id="esz-nG-srg"/>
@@ -235,6 +247,7 @@
                         <outlet property="signInButton" destination="Ojs-ji-UfQ" id="c9X-B9-99T"/>
                         <outlet property="signUpButton" destination="um8-uX-tq6" id="b5D-14-Cen"/>
                         <outlet property="testButton" destination="jgr-2k-ChE" id="Iwz-Qk-mgO"/>
+                        <outlet property="testNFTsTrxsBalancesButton" destination="zxl-zt-jSZ" id="Ges-6t-8md"/>
                         <outlet property="url" destination="5Yb-DH-Pnv" id="kdn-BV-aGw"/>
                         <outlet property="username" destination="Ysr-eH-5f6" id="lgr-mF-HfE"/>
                     </connections>

--- a/Example/PortalSwift/ViewController.swift
+++ b/Example/PortalSwift/ViewController.swift
@@ -47,6 +47,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
   @IBOutlet var signUpButton: UIButton!
   @IBOutlet var testButton: UIButton!
   @IBOutlet var deleteKeychainButton: UIButton!
+  @IBOutlet var testNFTsTrxsBalancesButton: UIButton!
 
   // Send form
   @IBOutlet public var sendAddress: UITextField!
@@ -101,10 +102,13 @@ class ViewController: UIViewController, UITextFieldDelegate {
       self.logoutButton.isEnabled = false
       self.portalConnectButton.isEnabled = false
       self.recoverButton.isEnabled = false
+      self.signButton.isEnabled = false
       self.signInButton.isEnabled = false
       self.signUpButton.isEnabled = false
       self.testButton.isEnabled = false
       self.deleteKeychainButton.isEnabled = false
+      self.testNFTsTrxsBalancesButton.isEnabled = false
+      self.sendButton.isEnabled = false
     }
   }
 
@@ -142,7 +146,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
       self.user = result.data!
       self.registerPortalUi(apiKey: result.data!.clientApiKey)
       self.portal = self.PortalWrapper.portal
-      self.updateStaticContent()
+      self.populateAddressInformation()
 
       DispatchQueue.main.async {
         self.logoutButton.isEnabled = true
@@ -161,7 +165,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
       self.user = result.data
       self.registerPortalUi(apiKey: result.data!.clientApiKey)
       self.portal = self.PortalWrapper.portal
-      self.updateStaticContent()
+      self.populateAddressInformation()
 
       DispatchQueue.main.async {
         self.logoutButton.isEnabled = true
@@ -186,7 +190,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
         return
       }
       print("✅ handleGenerate(): Address:", result.data ?? "N/A")
-      self.updateStaticContent()
+      self.populateAddressInformation()
 
       DispatchQueue.main.async {
         self.backupButton.isEnabled = true
@@ -194,7 +198,10 @@ class ViewController: UIViewController, UITextFieldDelegate {
         self.portalConnectButton.isEnabled = true
         self.recoverButton.isEnabled = true
         self.testButton.isEnabled = true
+        self.signButton.isEnabled = true
         self.deleteKeychainButton.isEnabled = true
+        self.testNFTsTrxsBalancesButton.isEnabled = true
+        self.sendButton.isEnabled = true
       }
     }
   }
@@ -226,7 +233,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
             return
           }
 
-          self.updateStaticContent()
+          self.populateAddressInformation()
           print("✅ handleBackup(): Successfully sent custodian cipherText")
         }
       } catch {
@@ -260,7 +267,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
             return
           }
 
-          self.updateStaticContent()
+          self.populateAddressInformation()
           print("✅ handleRecover(): Successfully recovered")
         }
       } catch {
@@ -292,7 +299,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
 
   @IBAction func handleDeleteKeychain(_: Any) {
     self.deleteKeychain()
-    self.updateStaticContent()
+    self.populateAddressInformation()
   }
 
   func deleteKeychain() {
@@ -305,12 +312,10 @@ class ViewController: UIViewController, UITextFieldDelegate {
     }
   }
 
-  func updateStaticContent() {
-    self.populateAddressInformation()
+  @IBAction func fetchNFTsAndTrxsAndBalances() {
     self.retrieveNFTs()
     self.getTransactions()
     self.getBalances()
-//     populateEthBalance()
   }
 
   func populateAddressInformation() {
@@ -495,7 +500,10 @@ class ViewController: UIViewController, UITextFieldDelegate {
             self.portalConnectButton.isEnabled = hasAddress
             self.recoverButton.isEnabled = hasAddress
             self.testButton.isEnabled = hasAddress
+            self.signButton.isEnabled = hasAddress
             self.deleteKeychainButton.isEnabled = hasAddress
+            self.testNFTsTrxsBalancesButton.isEnabled = hasAddress
+            self.sendButton.isEnabled = hasAddress
           } catch {
             print("Error fetching address: \(error)")
           }


### PR DESCRIPTION
# Description

This PR adds a separate button `NFTs, Trxs, + Balances`. It also removes the `updateStaticContent` helper function (since now it would only retrieve the address). It also updates most of the buttons to be disabled until you have a wallet.

<img width="1180" alt="image" src="https://github.com/portal-hq/PortalSwift/assets/12773166/992b7290-4d80-4225-b719-2ff4d0a7c997">

<img width="1186" alt="image" src="https://github.com/portal-hq/PortalSwift/assets/12773166/1b76074b-a837-4017-b768-fbe0acf24b48">

## How can you test this?

1. Start the app in XCode.
2. Sign up with a random user.
3. Generate a wallet.
4. Click `NFTs, Trxs, + Balances` button.

**Expected behavior**:
`200` response x 3 for endpoints:
`/me/nfts`
`/me/transactions`
`/me/balances`