### PR TITLE
Kelsonic/eng 1180 make request to backupmethod endpoint after backuprecover

### DIFF
--- a/PortalSwift/Classes/Core/PortalApi.swift
+++ b/PortalSwift/Classes/Core/PortalApi.swift
@@ -222,6 +222,27 @@ public class PortalApi {
     }
   }
 
+  /// Updates the client's wallet backup state to have successfully stored the client backup share key in the client's storage (e.g. gdrive, icloud, etc).
+  /// - Parameters:
+  ///   - backupMethod: One of: "ICLOUD", "GDRIVE", or "CUSTOM".
+  ///   - completion: The callback that contains the response status.
+  /// - Returns: Void.
+  public func storedClientBackupShareKey(
+    backupMethod: String,
+    completion: @escaping (Result<String>) -> Void
+  ) throws {
+    try self.requests.put(
+      path: "/api/v1/clients/me/wallet/stored-client-backup-share-key",
+      body: ["backupMethod": backupMethod],
+      headers: [
+        "Authorization": "Bearer \(self.apiKey)",
+      ],
+      requestType: HttpRequestType.CustomRequest
+    ) { (result: Result<String>) in
+      completion(result)
+    }
+  }
+
   /// Updates the client's wallet backup state to have successfully stored the client backup share with the custodian.
   /// - Parameters:
   ///   - success: Boolean indicating whether the storage operation failed.

--- a/PortalSwift/Classes/Core/mpc/PortalMpc.swift
+++ b/PortalSwift/Classes/Core/mpc/PortalMpc.swift
@@ -118,7 +118,7 @@ public class PortalMpc {
           }
           print("iCloud Storage is available, continuing...")
 
-          self.executeBackup(storage: storage!, signingShare: signingShare) { backupResult in
+          self.executeBackup(storage: storage!, signingShare: signingShare, backupMethod: method) { backupResult in
             if backupResult.error != nil {
               self.isWalletModificationInProgress = false
               return completion(Result(error: backupResult.error!))
@@ -142,7 +142,7 @@ public class PortalMpc {
           }
           print("Google Drive Storage is available, starting backup...")
 
-          self.executeBackup(storage: storage!, signingShare: signingShare) { backupResult in
+          self.executeBackup(storage: storage!, signingShare: signingShare, backupMethod: method) { backupResult in
             if backupResult.error != nil {
               self.isWalletModificationInProgress = false
               return completion(Result(error: backupResult.error!))
@@ -157,7 +157,7 @@ public class PortalMpc {
         }
       } else if method == BackupMethods.local.rawValue {
         print("Starting backup...")
-        self.executeBackup(storage: storage!, signingShare: signingShare) { backupResult in
+        self.executeBackup(storage: storage!, signingShare: signingShare, backupMethod: method) { backupResult in
           if backupResult.error != nil {
             self.isWalletModificationInProgress = false
             return completion(Result(error: backupResult.error!))
@@ -427,6 +427,7 @@ public class PortalMpc {
   private func executeBackup(
     storage: Storage,
     signingShare: String,
+    backupMethod: BackupMethods.RawValue,
     completion: @escaping (Result<String>) -> Void,
     progress: ((MpcStatus) -> Void)? = nil
   ) {
@@ -464,8 +465,22 @@ public class PortalMpc {
             return completion(Result(error: result.error!))
           }
 
-          // Return the cipherText.
-          return completion(Result(data: encryptedResult.data!.cipherText))
+          do {
+            // Call api to update backup method + update backup status to `STORED_CLIENT_BACKUP_SHARE_KEY`.
+            let formattedBackupMethod = self.formatBackupMethod(backupMethod: backupMethod)
+            try self.api.storedClientBackupShareKey(backupMethod: formattedBackupMethod) { (result: Result<String>) in
+              // Throw an error if we can't update the backup status + save the backup method.
+              if result.error != nil {
+                return completion(Result(error: result.error!))
+              }
+
+              // Return the cipherText.
+              return completion(Result(data: encryptedResult.data!.cipherText))
+            }
+          } catch {
+            print("Backup Failed: ", error)
+            return completion(Result(error: MpcError.unexpectedErrorOnBackup(message: "Backup failed")))
+          }
         }
       } progress: { status in
         progress?(status)
@@ -533,8 +548,27 @@ public class PortalMpc {
                 }
               }
 
-              // Return the cipherText.
-              return completion(Result(data: encryptedResult.data!.cipherText))
+              do {
+                // Call api to update backup method + update backup status to `STORED_CLIENT_BACKUP_SHARE_KEY`.
+                let formattedBackupMethod = self.formatBackupMethod(backupMethod: method)
+                try self.api.storedClientBackupShareKey(backupMethod: formattedBackupMethod) { (result: Result<String>) in
+                  // Throw an error if we can't update the backup status + save the backup method.
+                  if result.error != nil {
+                    print("Signing shares were successfully replaced, but backup shares were not refreshed. Try running backup again with your new signing shares.")
+                    if let error = result.error {
+                      return completion(Result(error: MpcError.failedToStoreClientBackupShareKey(message: error.localizedDescription)))
+                    } else {
+                      return completion(Result(error: MpcError.failedToStoreClientBackupShareKey(message: "")))
+                    }
+                  }
+
+                  // Return the cipherText.
+                  return completion(Result(data: encryptedResult.data!.cipherText))
+                }
+              } catch {
+                print("Signing shares were successfully replaced, but backup shares were not refreshed. Try running backup again with your new signing shares.")
+                return completion(Result(error: MpcError.failedToStoreClientBackupShareKey(message: "")))
+              }
             }
           } progress: { status in
             progress?(status)
@@ -693,6 +727,17 @@ public class PortalMpc {
     }
 
     return shareJson
+  }
+
+  private func formatBackupMethod(backupMethod: BackupMethods.RawValue) -> String {
+    switch backupMethod {
+    case BackupMethods.GoogleDrive.rawValue:
+      return "GDRIVE"
+    case BackupMethods.iCloud.rawValue:
+      return "ICLOUD"
+    default:
+      return "CUSTOM"
+    }
   }
 }
 


### PR DESCRIPTION
# Description

This PR adds the endpoint `PUT /api/v1/clients/me/wallet/stored-client-backup-share-key` in PortalApi and uses it after writing to storage in PortalMpc (both on backup + recover). This is to record the backup method used and to update the MpcWallet backupStatus to `STORED_CLIENT_BACKUP_SHARE_KEY`.