### PR TITLE
Add tracking + identify for all api methods and portal init

### DIFF
--- a/PortalSwift/Classes/Core/Portal.swift
+++ b/PortalSwift/Classes/Core/Portal.swift
@@ -115,6 +115,14 @@ public class Portal {
       mobile: self.binary,
       apiHost: self.apiHost
     )
+
+    // Capture analytics.
+    do {
+      try self.api.identify { _ in }
+      self.api.track(event: MetricsEvents.portalInitialized.rawValue, properties: [:])
+    } catch {
+      // Do nothing.
+    }
   }
 
   /// Create a Portal instance.
@@ -200,6 +208,14 @@ public class Portal {
       version: version,
       mobile: self.binary
     )
+
+    // Capture analytics.
+    do {
+      try self.api.identify { _ in }
+      self.api.track(event: MetricsEvents.portalInitialized.rawValue, properties: [:])
+    } catch {
+      // Do nothing.
+    }
   }
 
   /**********************************


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR adds `track` and `identify` to `PortalApi`. It also makes tracking calls to all `api` module methods for analytics purposes.

## Details

### Code
- Checked against coding style guide: Yes
- Deviations from the style guide: None
- Potential style guide updates: No
- Documentation updated: No

### Impact
- Breaking Changes: No
  - Migration steps: [If yes, describe]
  - Backwards compatible: [Yes/No]
- Performance impact: [Describe if there's any]

### Testing
- Unit tests added: No
  - If no, reason: Just analytics calls
- E2E tests added: No
  - If no, reason: Just analytics calls
- Manual tests in staging: [Yes/No]
  - ![Screenshot or video link here if applicable]
- E2E tests in Datadog: [Passed/Failed]

### Misc.
- Metrics, logs, or traces added: Yes
- Other notes: [Any other relevant notes]
