### PR TITLE
Gateway RPC full support

### DIFF
--- a/Example/PortalSwift/Portal.swift
+++ b/Example/PortalSwift/Portal.swift
@@ -100,7 +100,7 @@ class PortalWrapper {
     case cantLoadInfoPlist
   }
 
-  func registerPortal(apiKey: String, backup: BackupOptions, completion: @escaping (Result<Bool>) -> Void) {
+  func registerPortal(apiKey: String, backup: BackupOptions, chainId: Int = 5, completion: @escaping (Result<Bool>) -> Void) {
     do {
       guard let infoDictionary: [String: Any] = Bundle.main.infoDictionary else {
         return completion(Result(error: PortalWrapperError.cantLoadInfoPlist))
@@ -111,21 +111,18 @@ class PortalWrapper {
       }
       let keychain = PortalKeychain()
       // Configure the chain.
-      let chainId = 5
-      let chain = "goerli"
       self.portal = try Portal(
         apiKey: apiKey,
         backup: backup,
         chainId: chainId,
         keychain: keychain,
         gatewayConfig: [
-          chainId: "https://eth-\(chain).g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 1: "https://eth-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 80001: "https://polygon-mumbai.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 137: "https://polygon-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)",
+          5: "https://eth-goerli.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 1: "https://eth-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 80001: "https://polygon-mumbai.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 137: "https://polygon-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)",
         ],
         autoApprove: false,
         apiHost: self.API_URL!,
         mpcHost: self.MPC_URL!
       )
-
       _ = self.portal?.provider.on(event: Events.PortalSigningRequested.rawValue, callback: { [weak self] data in self?.didRequestApproval(data: data) })
       _ = self.portal?.provider.once(event: Events.PortalSignatureReceived.rawValue) { (data: Any) in
         let result = data as! RequestCompletionResult

--- a/Example/PortalSwift/ViewController.swift
+++ b/Example/PortalSwift/ViewController.swift
@@ -546,25 +546,21 @@ class ViewController: UIViewController, UITextFieldDelegate {
       let backup = BackupOptions(icloud: ICloudStorage())
       self.PortalWrapper.registerPortal(apiKey: apiKey, backup: backup) { _ in
         DispatchQueue.main.async {
-          do {
-            self.generateButton.isEnabled = true
+          self.generateButton.isEnabled = true
 
-            let address = try self.portal?.address
-            let hasAddress = address?.count ?? 0 > 0
+          let address = self.portal?.address
+          let hasAddress = address?.count ?? 0 > 0
 
-            self.backupButton.isEnabled = hasAddress
-            self.dappBrowserButton.isEnabled = hasAddress
-            self.portalConnectButton.isEnabled = hasAddress
-            self.recoverButton.isEnabled = hasAddress
-            self.legacyRecoverButton.isEnabled = hasAddress
-            self.testButton.isEnabled = hasAddress
-            self.signButton.isEnabled = hasAddress
-            self.deleteKeychainButton.isEnabled = hasAddress
-            self.testNFTsTrxsBalancesSimTrxButton.isEnabled = hasAddress
-            self.sendButton.isEnabled = hasAddress
-          } catch {
-            print("Error fetching address: \(error)")
-          }
+          self.backupButton.isEnabled = hasAddress
+          self.dappBrowserButton.isEnabled = hasAddress
+          self.portalConnectButton.isEnabled = hasAddress
+          self.recoverButton.isEnabled = hasAddress
+          self.legacyRecoverButton.isEnabled = hasAddress
+          self.testButton.isEnabled = hasAddress
+          self.signButton.isEnabled = hasAddress
+          self.deleteKeychainButton.isEnabled = hasAddress
+          self.testNFTsTrxsBalancesSimTrxButton.isEnabled = hasAddress
+          self.sendButton.isEnabled = hasAddress
         }
       }
     }
@@ -583,6 +579,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
         completion(false)
         return
       }
+
       if signerMethods.contains(method) {
         guard (result.data!.result as! Result<SignerResult>).error == nil else {
           print("❌ Error testing signer request:", method, "Error:", (result.data!.result as! Result<SignerResult>).error)
@@ -713,26 +710,26 @@ class ViewController: UIViewController, UITextFieldDelegate {
         return
       }
       let otherRequests = [
-        ProviderRequest(method: ETHRequestMethods.BlockNumber.rawValue, params: [], skipLoggingResult: false),
-        ProviderRequest(method: ETHRequestMethods.GasPrice.rawValue, params: [], skipLoggingResult: false),
-        ProviderRequest(method: ETHRequestMethods.GetBalance.rawValue, params: [fromAddress!, "latest"], skipLoggingResult: false),
+        //        ProviderRequest(method: ETHRequestMethods.BlockNumber.rawValue, params: [], skipLoggingResult: false),
+//        ProviderRequest(method: ETHRequestMethods.GasPrice.rawValue, params: [], skipLoggingResult: false),
+//        ProviderRequest(method: ETHRequestMethods.GetBalance.rawValue, params: [fromAddress!, "latest"], skipLoggingResult: false),
         ProviderRequest(method: ETHRequestMethods.GetBlockByHash.rawValue, params: ["0xdc0818cf78f21a8e70579cb46a43643f78291264dda342ae31049421c82d21ae", false], skipLoggingResult: false),
-        ProviderRequest(method: ETHRequestMethods.GetBlockTransactionCountByNumber.rawValue, params: ["latest"], skipLoggingResult: false),
-        ProviderRequest(method: ETHRequestMethods.GetCode.rawValue, params: [fromAddress!, "latest"], skipLoggingResult: false),
+//        ProviderRequest(method: ETHRequestMethods.GetBlockTransactionCountByNumber.rawValue, params: ["latest"], skipLoggingResult: false),
+//        ProviderRequest(method: ETHRequestMethods.GetCode.rawValue, params: [fromAddress!, "latest"], skipLoggingResult: false),
         ProviderRequest(method: ETHRequestMethods.GetTransactionByHash.rawValue, params: ["0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b"], skipLoggingResult: false),
         ProviderRequest(method: ETHRequestMethods.GetTransactionCount.rawValue, params: [fromAddress!, "latest"], skipLoggingResult: false),
         ProviderRequest(method: ETHRequestMethods.GetTransactionReceipt.rawValue, params: ["0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b"], skipLoggingResult: false),
         ProviderRequest(method: ETHRequestMethods.GetUncleByBlockHashIndex.rawValue, params: ["0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b", "0x0"], skipLoggingResult: false),
         ProviderRequest(method: ETHRequestMethods.GetUncleCountByBlockHash.rawValue, params: ["0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b"], skipLoggingResult: false),
         ProviderRequest(method: ETHRequestMethods.GetUncleCountByBlockNumber.rawValue, params: ["latest"], skipLoggingResult: false),
-        ProviderRequest(method: ETHRequestMethods.NetVersion.rawValue, params: [], skipLoggingResult: false),
-        ProviderRequest(method: ETHRequestMethods.NewBlockFilter.rawValue, params: [], skipLoggingResult: false),
-        ProviderRequest(method: ETHRequestMethods.NewPendingTransactionFilter.rawValue, params: [], skipLoggingResult: false),
-        ProviderRequest(method: ETHRequestMethods.ProtocolVersion.rawValue, params: [], skipLoggingResult: false),
-        ProviderRequest(method: ETHRequestMethods.SendRawTransaction.rawValue, params: ["0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"], skipLoggingResult: false),
-        ProviderRequest(method: ETHRequestMethods.Web3ClientVersion.rawValue, params: [], skipLoggingResult: false),
-        ProviderRequest(method: ETHRequestMethods.Web3Sha3.rawValue, params: ["0x68656c6c6f20776f726c64"], skipLoggingResult: false),
-        ProviderRequest(method: ETHRequestMethods.GetStorageAt.rawValue, params: [fromAddress, "0x0", "latest"], skipLoggingResult: false),
+//        ProviderRequest(method: ETHRequestMethods.NetVersion.rawValue, params: [], skipLoggingResult: false),
+//        ProviderRequest(method: ETHRequestMethods.NewBlockFilter.rawValue, params: [], skipLoggingResult: false),
+//        ProviderRequest(method: ETHRequestMethods.NewPendingTransactionFilter.rawValue, params: [], skipLoggingResult: false),
+//        ProviderRequest(method: ETHRequestMethods.ProtocolVersion.rawValue, params: [], skipLoggingResult: false),
+//        ProviderRequest(method: ETHRequestMethods.SendRawTransaction.rawValue, params: ["0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"], skipLoggingResult: false),
+//        ProviderRequest(method: ETHRequestMethods.Web3ClientVersion.rawValue, params: [], skipLoggingResult: false),
+//        ProviderRequest(method: ETHRequestMethods.Web3Sha3.rawValue, params: ["0x68656c6c6f20776f726c64"], skipLoggingResult: false),
+//        ProviderRequest(method: ETHRequestMethods.GetStorageAt.rawValue, params: [fromAddress, "0x0", "latest"], skipLoggingResult: false),
       ]
 
       for request in otherRequests {

--- a/Example/Tests/e2e/WalletTests.swift
+++ b/Example/Tests/e2e/WalletTests.swift
@@ -27,7 +27,7 @@ class WalletTests: XCTestCase {
     super.tearDown()
   }
 
-  func testLogin(completion: @escaping (Result<Bool>) -> Void) {
+  func testLogin(chainId _: Int = 5, completion: @escaping (Result<Bool>) -> Void) {
     return XCTContext.runActivity(named: "Login") { _ in
       let registerExpectation = XCTestExpectation(description: "Register")
 
@@ -71,7 +71,7 @@ class WalletTests: XCTestCase {
       let backupOption = LocalFileStorage(fileName: "PORTAL_BACKUP")
       let backup = BackupOptions(local: backupOption)
       print("registering portal")
-      WalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup) {
+      WalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 5) {
         result in
         guard result.error == nil else {
           registerExpectation.fulfill()

--- a/PortalSwift/Classes/Provider/PortalProvider.swift
+++ b/PortalSwift/Classes/Provider/PortalProvider.swift
@@ -572,16 +572,88 @@ public class PortalProvider {
     ]
 
     do {
-      try self.gateway.post(
-        path: "/",
-        body: body,
-        headers: ["Content-Type": "application/json"],
-        requestType: HttpRequestType.GatewayRequest
-      ) { (result: Result<ETHGatewayResponse>) in
-        if result.data != nil {
-          completion(payload.method, payload.params, Result(data: result.data!), payload.id!)
+      switch payload.method {
+      case ETHRequestMethods.GetBlockByHash.rawValue, ETHRequestMethods.GetUncleByBlockHashIndex.rawValue, ETHRequestMethods.GetUncleByBlockNumberAndIndex.rawValue, ETHRequestMethods.GetBlockByNumber.rawValue:
+        if let params = payload.params as? [Any], params.count > 1, let elementAtIndex1 = params[1] as? Bool, elementAtIndex1 {
+          // The element at index 1 is a Bool and evaluates to true
+          try self.gateway.post(
+            path: "/",
+            body: body,
+            headers: ["Content-Type": "application/json"],
+            requestType: HttpRequestType.GatewayRequest
+          ) { (result: Result<BlockDataResponseTrue>) in
+            if result.data != nil {
+              completion(payload.method, payload.params, Result(data: result.data!), payload.id!)
+            } else {
+              completion(payload.method, payload.params, Result(error: result.error!), payload.id!)
+            }
+          }
         } else {
-          completion(payload.method, payload.params, Result(error: result.error!), payload.id!)
+          try self.gateway.post(
+            path: "/",
+            body: body,
+            headers: ["Content-Type": "application/json"],
+            requestType: HttpRequestType.GatewayRequest
+          ) { (result: Result<BlockDataResponseFalse>) in
+            if result.data != nil {
+              completion(payload.method, payload.params, Result(data: result.data!), payload.id!)
+            } else {
+              completion(payload.method, payload.params, Result(error: result.error!), payload.id!)
+            }
+          }
+        }
+      case ETHRequestMethods.GetTransactionReceipt.rawValue, ETHRequestMethods.GetTransactionByHash.rawValue, ETHRequestMethods.GetTransactionByBlockNumberAndIndex.rawValue,
+           ETHRequestMethods.GetTransactionByBlockHashAndIndex.rawValue:
+        try self.gateway.post(
+          path: "/",
+          body: body,
+          headers: ["Content-Type": "application/json"],
+          requestType: HttpRequestType.GatewayRequest
+        ) { (result: Result<EthTransactionResponse>) in
+          if result.data != nil {
+            completion(payload.method, payload.params, Result(data: result.data!), payload.id!)
+          } else {
+            completion(payload.method, payload.params, Result(error: result.error!), payload.id!)
+          }
+        }
+      case ETHRequestMethods.NetListening.rawValue, ETHRequestMethods.UninstallFilter.rawValue:
+        try self.gateway.post(
+          path: "/",
+          body: body,
+          headers: ["Content-Type": "application/json"],
+          requestType: HttpRequestType.GatewayRequest
+        ) { (result: Result<EthBoolResponse>) in
+          if result.data != nil {
+            completion(payload.method, payload.params, Result(data: result.data!), payload.id!)
+          } else {
+            completion(payload.method, payload.params, Result(error: result.error!), payload.id!)
+          }
+        }
+      case ETHRequestMethods.GetLogs.rawValue, ETHRequestMethods.GetFilterLogs.rawValue, ETHRequestMethods.GetFilterChanges.rawValue:
+        try self.gateway.post(
+          path: "/",
+          body: body,
+          headers: ["Content-Type": "application/json"],
+          requestType: HttpRequestType.GatewayRequest
+        ) { (result: Result<LogsResponse>) in
+          if result.data != nil {
+            completion(payload.method, payload.params, Result(data: result.data!), payload.id!)
+          } else {
+            completion(payload.method, payload.params, Result(error: result.error!), payload.id!)
+          }
+        }
+      default:
+        try self.gateway.post(
+          path: "/",
+          body: body,
+          headers: ["Content-Type": "application/json"],
+          requestType: HttpRequestType.GatewayRequest
+        ) { (result: Result<ETHGatewayResponse>) in
+          if result.data != nil {
+            completion(payload.method, payload.params, Result(data: result.data!), payload.id!)
+          } else {
+            completion(payload.method, payload.params, Result(error: result.error!), payload.id!)
+          }
         }
       }
     } catch {
@@ -728,17 +800,11 @@ public enum ETHRequestMethods: String {
   case EstimateGas = "eth_estimateGas"
   case GasPrice = "eth_gasPrice"
   case GetBalance = "eth_getBalance"
-  case GetBlockByHash = "eth_getBlockByHash"
   case GetBlockTransactionCountByNumber = "eth_getBlockTransactionCountByNumber"
   case GetCode = "eth_getCode"
   case GetStorageAt = "eth_getStorageAt"
-  case GetTransactionByHash = "eth_getTransactionByHash"
   case GetTransactionCount = "eth_getTransactionCount"
-  case GetTransactionReceipt = "eth_getTransactionReceipt"
-  case GetUncleByBlockHashIndex = "eth_getUncleByBlockHashAndIndex"
-  case GetUncleCountByBlockHash = "eth_getUncleCountByBlockHash"
   case GetUncleCountByBlockNumber = "eth_getUncleCountByBlockNumber"
-  case NewBlockFilter = "eth_newBlockFilter"
   case NewPendingTransactionFilter = "eth_newPendingTransactionFilter"
   case PersonalSign = "personal_sign"
   case ProtocolVersion = "eth_protocolVersion"
@@ -750,17 +816,23 @@ public enum ETHRequestMethods: String {
   case SignTypedDataV3 = "eth_signTypedData_v3"
   case SignTypedDataV4 = "eth_signTypedData_v4"
 
-  //  case UninstallFilter = "eth_uninstallFilter"
-  //  case NewFilter = "eth_newFilter"
-  //  case GetTransactionByBlockNumberAndIndex = "eth_getTransactionByBlockNumberAndIndex"
-  //  case GetLogs = "eth_getLogs"
-  //  case GetBlockByNumber = "eth_getBlockByNumber"
-  //  case GetFilterLogs = "eth_getFilterLogs"
-  //  case GetBlockTransactionCountByHash = "eth_getBlockTransactionCountByHash"
-  //  case NetListening = "net_listening"
-  //  case GetTransactionByBlockHashAndIndex = "eth_getTransactionByBlockHashAndIndex"
-  //  case GetFilterLogs = "eth_getFilterLogs"
-  //  case GetUncleByBlockNumberAndIndex = "eth_getUncleByBlockNumberAndIndex"
+  case GetBlockByHash = "eth_getBlockByHash"
+  case GetTransactionByHash = "eth_getTransactionByHash"
+  case GetTransactionReceipt = "eth_getTransactionReceipt"
+  case GetUncleByBlockHashIndex = "eth_getUncleByBlockHashAndIndex"
+  case GetUncleCountByBlockHash = "eth_getUncleCountByBlockHash"
+  case GetTransactionByBlockNumberAndIndex = "eth_getTransactionByBlockNumberAndIndex"
+  case GetBlockByNumber = "eth_getBlockByNumber"
+  case GetBlockTransactionCountByHash = "eth_getBlockTransactionCountByHash"
+  case NetListening = "net_listening"
+  case GetTransactionByBlockHashAndIndex = "eth_getTransactionByBlockHashAndIndex"
+  case GetUncleByBlockNumberAndIndex = "eth_getUncleByBlockNumberAndIndex"
+  case GetLogs = "eth_getLogs"
+  case UninstallFilter = "eth_uninstallFilter"
+  case NewFilter = "eth_newFilter"
+  case GetFilterLogs = "eth_getFilterLogs"
+  case GetNewBlockFilter = "eth_newBlockFilter"
+  case GetFilterChanges = "eth_getFilterChanges"
 
   // Wallet Methods (MetaMask stuff)
   case WalletAddEthereumChain = "wallet_addEthereumChain"
@@ -995,4 +1067,139 @@ public struct AddressCompletionResult {
   public var params: [ETHAddressParam]
   public var result: Any
   public var id: String
+}
+
+// The specific return types for the 17 methods from the gateway that don't return strings
+public struct BlockDataResponseFalse: Codable {
+  public var jsonrpc: String = "2.0"
+  public var id: Int?
+  public var result: BlockData?
+  public var error: ETHGatewayErrorResponse?
+}
+
+public struct BlockData: Codable {
+  public var number: String
+  public var hash: String
+  public var transactions: [String]?
+  public var difficulty: String
+  public var extraData: String
+  public var gasLimit: String
+  public var gasUsed: String
+  public var logsBloom: String
+  public var miner: String
+  public var mixHash: String
+  public var nonce: String
+  public var parentHash: String
+  public var receiptsRoot: String
+  public var sha3Uncles: String
+  public var size: String
+  public var stateRoot: String
+  public var timestamp: String
+  public var totalDifficulty: String?
+  public var transactionsRoot: String
+  public var uncles: [String]
+  public var baseFeePerGas: String?
+}
+
+public struct BlockDataResponseTrue: Codable {
+  public var jsonrpc: String = "2.0"
+  public var id: Int?
+  public var result: BlockDataTrue?
+  public var error: ETHGatewayErrorResponse?
+}
+
+public struct EthTransactionResponse: Codable {
+  public var jsonrpc: String = "2.0"
+  public var id: Int?
+  public var result: TransactionData?
+  public var error: ETHGatewayErrorResponse?
+}
+
+public struct EthBoolResponse: Codable {
+  public var jsonrpc: String = "2.0"
+  public var id: Int?
+  public var result: Bool?
+  public var error: ETHGatewayErrorResponse?
+}
+
+public struct BlockDataTrue: Codable {
+  public let number: String
+  public let hash: String
+  public let transactions: [TransactionData]
+  public let difficulty: String
+  public let extraData: String
+  public let gasLimit: String
+  public let gasUsed: String
+  public let logsBloom: String
+  public let miner: String
+  public let mixHash: String
+  public let nonce: String
+  public let parentHash: String
+  public let receiptsRoot: String
+  public let sha3Uncles: String
+  public let size: String
+  public let stateRoot: String
+  public let timestamp: String
+  public let totalDifficulty: String
+  public let transactionsRoot: String
+  public let uncles: [String]
+  public let baseFeePerGas: String
+  public let withdrawalsRoot: String
+  public let withdrawals: [Withdrawal]
+}
+
+public struct TransactionData: Codable {
+  public let blockHash: String
+  public let blockNumber: String
+  public let hash: String?
+  public let chainId: String?
+  public let from: String
+  public let gas: String?
+  public let gasPrice: String?
+  public let input: String?
+  public let nonce: String?
+  public let r: String?
+  public let s: String?
+  public let to: String?
+  public let transactionIndex: String
+  public let type: String
+  public let v: String?
+  public let value: String?
+  public let accessList: [String]?
+  public let maxFeePerGas: String?
+  public let maxPriorityFeePerGas: String?
+  public let transactionHash: String?
+  public let logs: [Log]?
+  public let contractAddress: String?
+  public let effectiveGasPrice: String?
+  public let cumulativeGasUsed: String?
+  public let gasUsed: String?
+  public let logsBloom: String?
+  public let status: String?
+}
+
+public struct Log: Codable {
+  public let transactionHash: String?
+  public let address: String?
+  public let blockHash: String?
+  public let blockNumber: String?
+  public let data: String?
+  public let logIndex: String?
+  public let removed: Bool?
+  public let topics: [String]?
+  public let transactionIndex: String?
+}
+
+public struct Withdrawal: Codable {
+  public let address: String
+  public let amount: String
+  public let index: String
+  public let validatorIndex: String
+}
+
+public struct LogsResponse: Codable {
+  public var jsonrpc: String = "2.0"
+  public var id: Int?
+  public var result: [Log]?
+  public var error: ETHGatewayErrorResponse?
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR is about fixing our provider to support all the gateway methods. Specifically, the rpc methods that return something other than a string. 
- We have added the types for those returns and a long switch statement that determines how to type the request. 
- In the future, we should alter the request model so it doesn't expect the strict type. 

## Visuals
<!-- Attach screenshots or videos of any visual changes. If none, delete this section. -->
![Screenshot here]

## Details

### Code
- Checked against coding style guide: [Yes/No]
I attempted to make the code cleaner but there is a big issue with having the type of the result of the post method defined at the time of making the post. Not only defined but defined and codable. We need to refactor the HTTP Request class to not expect a type in that way.
- Deviations from the style guide: [List any deviations]
- Potential style guide updates: [Any suggestions?]
- Documentation updated: [Yes/No]

### Impact
- Breaking Changes: [No]
  - Migration steps: [If yes, describe]
  - Backwards compatible: [Yes/No]
- Performance impact: [Describe if there's any]

### Testing
- Unit tests added: [No]
  - If no, reason: This work took longer than expected so the e2e tests will have to do for now. 
- E2E tests added: [Yes]
  - If no, reason: [Reason here]
- Manual tests in staging: [No]
  - ![Screenshot or video link here if applicable]

### Misc.
- Metrics, logs, or traces added: [No]
- Other notes: [Any other relevant notes]
