### PR TITLE
Add unbindClientEvents method

### DIFF
--- a/PortalSwift/Classes/Connect/PortalConnect.swift
+++ b/PortalSwift/Classes/Connect/PortalConnect.swift
@@ -129,23 +129,15 @@ public class PortalConnect: EventBus {
 
     if self.client == nil {
       self.client = WebSocketClient(apiKey: self.apiKey, connect: self, webSocketServer: self.webSocketServer)
+    } else {
+      self.unbindClientEvents()
     }
 
     self.uri = uri
 
     self.client?.resetEventBus()
 
-    self.client?.on("close", self.handleClose)
-    self.client?.on("portal_dappSessionRequested", self.handleDappSessionRequested)
-    self.client?.on("portal_dappSessionRequestedV1", self.handleDappSessionRequestedV1)
-    self.client?.on("connected", self.handleConnected)
-    self.client?.on("connectedV1", self.handleConnectedV1)
-    self.client?.on("disconnected", self.handleDisconnected)
-    self.client?.on("error", self.handleConnectError)
-    self.client?.on("portal_connectError", self.handleError)
-    self.client?.on("session_request", self.handleSessionRequest)
-    self.client?.on("session_request_address", self.handleSessionRequestAddress)
-    self.client?.on("session_request_transaction", self.handleSessionRequestTransaction)
+    self.bindClientEvents()
 
     self.client?.connect(uri: uri)
   }
@@ -527,6 +519,34 @@ public class PortalConnect: EventBus {
 
   public func viewWillDisappear() {
     self.client?.sendFinalMessageAndDisconnect()
+  }
+
+  private func unbindClientEvents() {
+    self.client?.off("close")
+    self.client?.off("portal_dappSessionRequested")
+    self.client?.off("portal_dappSessionRequestedV1")
+    self.client?.off("connected")
+    self.client?.off("connectedV1")
+    self.client?.off("disconnected")
+    self.client?.off("error")
+    self.client?.off("portal_connectError")
+    self.client?.off("session_request")
+    self.client?.off("session_request_address")
+    self.client?.off("session_request_transaction")
+  }
+
+  private func bindClientEvents() {
+    self.client?.on("close", self.handleClose)
+    self.client?.on("portal_dappSessionRequested", self.handleDappSessionRequested)
+    self.client?.on("portal_dappSessionRequestedV1", self.handleDappSessionRequestedV1)
+    self.client?.on("connected", self.handleConnected)
+    self.client?.on("connectedV1", self.handleConnectedV1)
+    self.client?.on("disconnected", self.handleDisconnected)
+    self.client?.on("error", self.handleConnectError)
+    self.client?.on("portal_connectError", self.handleError)
+    self.client?.on("session_request", self.handleSessionRequest)
+    self.client?.on("session_request_address", self.handleSessionRequestAddress)
+    self.client?.on("session_request_transaction", self.handleSessionRequestTransaction)
   }
 
   private func handleProviderRequest(method: String, params: [ETHAddressParam], chainId: Int, completion: @escaping (Result<Any>) -> Void) {

--- a/PortalSwift/Classes/Utils/WebSocketClient.swift
+++ b/PortalSwift/Classes/Utils/WebSocketClient.swift
@@ -569,6 +569,35 @@ public class WebSocketClient: Starscream.WebSocketDelegate {
     self.events.error.append(handler)
   }
 
+  func off(_ event: String) {
+    switch event {
+    case "close":
+      self.events.close = []
+    case "connected":
+      self.events.connected = []
+    case "connectedV1":
+      self.events.connectedV1 = []
+    case "portal_dappSessionRequested":
+      self.events.dapp_session_requested = []
+    case "portal_dappSessionRequestedV1":
+      self.events.dapp_session_requestedV1 = []
+    case "disconnected":
+      self.events.disconnect = []
+    case "error":
+      self.events.error = []
+    case "portal_connectError":
+      self.events.portal_connect_error = []
+    case "session_request":
+      self.events.session_request = []
+    case "session_request_address":
+      self.events.session_request_address = []
+    case "session_request_transaction":
+      self.events.session_request_transaction = []
+    default:
+      break
+    }
+  }
+
   func send(_ message: String) {
     print("[WebSocketClient] Sending message: \(message)")
     self.socket.write(string: message)


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
It unregisters all ws event handlers on WC reconnect.

## Details

### Code
- Checked against coding style guide: [Yes/No]
- Deviations from the style guide: [List any deviations]
- Potential style guide updates: [Any suggestions?]
- Documentation updated: [Yes/No]

### Impact
- Breaking Changes: [Yes/No]
  - Migration steps: [If yes, describe]
  - Backwards compatible: [Yes/No]
- Performance impact: [Describe if there's any]

### Testing
- Unit tests added: [Yes/No]
  - If no, reason: [Reason here]
- E2E tests added: [Yes/No]
  - If no, reason: [Reason here]
- Manual tests in staging: [Yes/No]
  - ![Screenshot or video link here if applicable]
- E2E tests in Datadog: [Passed/Failed]

### Misc.
- Metrics, logs, or traces added: [Yes/No]
- Other notes: [Any other relevant notes]
