### PR TITLE
ENG-1653 - Enable websiteDataStore on MKWebView configuration

### DIFF
--- a/PortalSwift/Classes/Components/PortalWebView.swift
+++ b/PortalSwift/Classes/Components/PortalWebView.swift
@@ -59,6 +59,8 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
 
       let configuration = WKWebViewConfiguration()
       configuration.userContentController = contentController
+      configuration.websiteDataStore = WKWebsiteDataStore.default() // Allows for data persistence across sessions
+
       let webView = WKWebView(frame: .zero, configuration: configuration)
       webView.scrollView.bounces = false
       webView.navigationDelegate = self


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
In order to allow for manual connections to WebView dApps to persist on future loads, this PR enables the `websiteDataStore` on the `MKWebView` configuration. This will allow dApps that do not auto-connect to do so after an initial manual connection has been made.

## Details

### Code
- Checked against coding style guide: Yes
  <!-- - Deviations from the style guide: [List any deviations] -->
  <!-- - Potential style guide updates: [Any suggestions?] -->
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: Yes|No
  <!-- - If no, reason: [Reason here] -->
- Manual tests in staging: N/A
  <!-- - ![Screenshot or video link here if applicable] -->
- E2E tests in Datadog: N/A
  <!-- ![Screenshot of e2e tests passing] -->

### Misc.
- Metrics, logs, or traces added: No
<!-- - Other notes: [Any other relevant notes] -->
