### PR TITLE
ENG-1687 - Add permissions check to `validateOperations` for GDrive

### DIFF
--- a/PortalSwift/Classes/Storage/GDrive/GDriveClient.swift
+++ b/PortalSwift/Classes/Storage/GDrive/GDriveClient.swift
@@ -219,6 +219,19 @@ class GDriveClient {
         return
       }
 
+      let account = self.auth.getCurrentUser()
+
+      guard let account = account else {
+        callback(Result(error: GDriveClientError.userNotAuthenticated))
+        return
+      }
+
+      let grantedScopes = account.grantedScopes ?? []
+      if !grantedScopes.contains("https://www.googleapis.com/auth/drive.file") {
+        callback(Result(error: GDriveClientError.userNotAuthenticated))
+        return
+      }
+
       // Write
       do {
         try self.write(filename: mockFileName, content: mockContent) { writeResult in


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->

In order to safeguard against users revoking permissions, this PR adds a check to the active scopes on the Google session during the `validateOperations()` check.

## Details

### Code
- Checked against coding style guide: Yes
  <!-- - Deviations from the style guide: [List any deviations] -->
  <!-- - Potential style guide updates: [Any suggestions?] -->
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->
- Manual tests in staging: N/A
  <!-- - ![Screenshot or video link here if applicable] -->
- E2E tests in Datadog: N/A
  <!-- ![Screenshot of e2e tests passing] -->

### Misc.
- Metrics, logs, or traces added: No
<!-- - Other notes: [Any other relevant notes] -->
