### PR TITLE
Make the webview + webview content loaded public

### DIFF
--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Components/PortalWebView.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Components/PortalWebView.swift
@@ -35,8 +35,8 @@ enum WebViewControllerErrors: Error {
 
 /// A controller that allows you to create Portal's web view.
 public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMessageHandler {
-  private var webView: WKWebView!
-  private var webViewContentIsLoaded = false
+  public var webView: WKWebView!
+  public var webViewContentIsLoaded = false
   private var portal: Portal
   private var url: URL
   private var onError: (Result<Any>) -> Void

--- a/Sources/PortalSwift/Components/PortalWebView.swift
+++ b/Sources/PortalSwift/Components/PortalWebView.swift
@@ -35,8 +35,8 @@ enum WebViewControllerErrors: Error {
 
 /// A controller that allows you to create Portal's web view.
 public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMessageHandler {
-  private var webView: WKWebView!
-  private var webViewContentIsLoaded = false
+  public var webView: WKWebView!
+  public var webViewContentIsLoaded = false
   private var portal: Portal
   private var url: URL
   private var onError: (Result<Any>) -> Void


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR makes the webView and webViewContentIsLoaded variables `public` in the `PortalWebView` class.

## Details

### Code
- Checked against coding style guide: Yes
  <!-- - Deviations from the style guide: [List any deviations] -->
  <!-- - Potential style guide updates: [Any suggestions?] -->
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->
- Manual tests in staging: Pending
  <!-- - ![Screenshot or video link here if applicable] -->
- E2E tests in Datadog: Pending
  <!-- ![Screenshot of e2e tests passing] -->

### Misc.
- Metrics, logs, or traces added: No
- Changelog updated: No
  <!-- - If no, reason: [Reason here] -->
<!-- - Other notes: [Any other relevant notes] -->
