### PR TITLE
Parsa/add nonce to transaction payload

### DIFF
--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Provider/PortalProvider.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Provider/PortalProvider.swift
@@ -925,14 +925,16 @@ public struct ETHTransactionParam: Codable {
   public var maxFeePerGas: String?
   public var value: String?
   public var data: String?
+  public var nonce: String?
 
-  public init(from: String, to: String, gas: String, gasPrice: String, value: String, data: String) {
+  public init(from: String, to: String, gas: String, gasPrice: String, value: String, data: String, nonce: String?) {
     self.from = from
     self.to = to
     self.gas = gas
     self.gasPrice = gasPrice
     self.value = value
     self.data = data
+    self.nonce = nonce
   }
 
   public init(from: String, to: String, value: String, data: String) {
@@ -960,7 +962,7 @@ public struct ETHTransactionParam: Codable {
   }
 
   // Below is the variation for EIP-1559
-  public init(from: String, to: String, gas: String, value: String, data: String, maxPriorityFeePerGas: String?, maxFeePerGas: String?) {
+  public init(from: String, to: String, gas: String, value: String, data: String, maxPriorityFeePerGas: String?, maxFeePerGas: String?, nonce: String?) {
     self.from = from
     self.to = to
     self.gas = gas
@@ -968,6 +970,7 @@ public struct ETHTransactionParam: Codable {
     self.data = data
     self.maxPriorityFeePerGas = maxPriorityFeePerGas
     self.maxFeePerGas = maxFeePerGas
+    self.nonce = nonce
   }
 }
 

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Provider/PortalProvider.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Provider/PortalProvider.swift
@@ -925,12 +925,21 @@ public struct ETHTransactionParam: Codable {
   public var maxFeePerGas: String?
   public var value: String?
   public var data: String?
-  public var nonce: String?
+  public var nonce: String? = nil
 
-  public init(from: String, to: String, gas: String, gasPrice: String, value: String, data: String, nonce: String?) {
+  public init(from: String, to: String, gas: String, gasPrice: String, value: String, data: String, nonce: String? = nil) {
     self.from = from
     self.to = to
     self.gas = gas
+    self.gasPrice = gasPrice
+    self.value = value
+    self.data = data
+    self.nonce = nonce
+  }
+
+  public init(from: String, to: String, gasPrice: String, value: String, data: String, nonce: String? = nil) {
+    self.from = from
+    self.to = to
     self.gasPrice = gasPrice
     self.value = value
     self.data = data
@@ -962,7 +971,7 @@ public struct ETHTransactionParam: Codable {
   }
 
   // Below is the variation for EIP-1559
-  public init(from: String, to: String, gas: String, value: String, data: String, maxPriorityFeePerGas: String?, maxFeePerGas: String?, nonce: String?) {
+  public init(from: String, to: String, gas: String, value: String, data: String, maxPriorityFeePerGas: String?, maxFeePerGas: String?, nonce: String? = nil) {
     self.from = from
     self.to = to
     self.gas = gas

--- a/Cocoapods Example/PortalSwift/ViewController.swift
+++ b/Cocoapods Example/PortalSwift/ViewController.swift
@@ -570,7 +570,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
   func sendTransaction(ethEstimate: String) {
     let payload = ETHTransactionPayload(
       method: ETHRequestMethods.SendTransaction.rawValue,
-      params: [ETHTransactionParam(from: self.portal?.address ?? "", to: self.sendAddress?.text ?? "", gas: ethEstimate, gasPrice: ethEstimate, value: "0x10", data: "")]
+      params: [ETHTransactionParam(from: self.portal?.address ?? "", to: self.sendAddress?.text ?? "", gasPrice: ethEstimate, value: "0x10", data: "")]
       // Test EIP-1559 Transactions with these params
       // params: [ETHTransactionParam(from: portal?.mpc.getAddress(), to: sendAddress.text!,  gas:"0x5208", value: "0x10", data: "", maxPriorityFeePerGas: ethEstimate, maxFeePerGas: ethEstimate)]
     )

--- a/Sources/PortalSwift/Provider/PortalProvider.swift
+++ b/Sources/PortalSwift/Provider/PortalProvider.swift
@@ -925,9 +925,9 @@ public struct ETHTransactionParam: Codable {
   public var maxFeePerGas: String?
   public var value: String?
   public var data: String?
-  public var nonce: String?
+  public var nonce: String? = nil
 
-  public init(from: String, to: String, gas: String, gasPrice: String, value: String, data: String, nonce: String?) {
+  public init(from: String, to: String, gas: String, gasPrice: String, value: String, data: String, nonce: String? = nil) {
     self.from = from
     self.to = to
     self.gas = gas
@@ -936,6 +936,14 @@ public struct ETHTransactionParam: Codable {
     self.data = data
     self.nonce = nonce
   }
+    public init(from: String, to: String, gasPrice: String, value: String, data: String, nonce: String? = nil) {
+      self.from = from
+      self.to = to
+      self.gasPrice = gasPrice
+      self.value = value
+      self.data = data
+      self.nonce = nonce
+    }
 
   public init(from: String, to: String, value: String, data: String) {
     self.from = from
@@ -962,7 +970,7 @@ public struct ETHTransactionParam: Codable {
   }
 
   // Below is the variation for EIP-1559
-  public init(from: String, to: String, gas: String, value: String, data: String, maxPriorityFeePerGas: String?, maxFeePerGas: String?, nonce: String?) {
+  public init(from: String, to: String, gas: String, value: String, data: String, maxPriorityFeePerGas: String?, maxFeePerGas: String?, nonce: String? = nil) {
     self.from = from
     self.to = to
     self.gas = gas

--- a/Sources/PortalSwift/Provider/PortalProvider.swift
+++ b/Sources/PortalSwift/Provider/PortalProvider.swift
@@ -925,14 +925,16 @@ public struct ETHTransactionParam: Codable {
   public var maxFeePerGas: String?
   public var value: String?
   public var data: String?
+  public var nonce: String?
 
-  public init(from: String, to: String, gas: String, gasPrice: String, value: String, data: String) {
+  public init(from: String, to: String, gas: String, gasPrice: String, value: String, data: String, nonce: String?) {
     self.from = from
     self.to = to
     self.gas = gas
     self.gasPrice = gasPrice
     self.value = value
     self.data = data
+    self.nonce = nonce
   }
 
   public init(from: String, to: String, value: String, data: String) {
@@ -960,7 +962,7 @@ public struct ETHTransactionParam: Codable {
   }
 
   // Below is the variation for EIP-1559
-  public init(from: String, to: String, gas: String, value: String, data: String, maxPriorityFeePerGas: String?, maxFeePerGas: String?) {
+  public init(from: String, to: String, gas: String, value: String, data: String, maxPriorityFeePerGas: String?, maxFeePerGas: String?, nonce: String?) {
     self.from = from
     self.to = to
     self.gas = gas
@@ -968,6 +970,7 @@ public struct ETHTransactionParam: Codable {
     self.data = data
     self.maxPriorityFeePerGas = maxPriorityFeePerGas
     self.maxFeePerGas = maxFeePerGas
+    self.nonce = nonce
   }
 }
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR adds the field `nonce` to the `EthTransactionPayload` object so that customers are able to pass in custom nonces.

## Visuals
The screen shot below is showing my successful test of setting the wrong nonce and seeing the error from xcode 
<img width="977" alt="Screenshot 2023-11-17 at 8 27 13 PM" src="https://github.com/portal-hq/PortalSwift/assets/11202447/bdca82c5-45e6-448b-a89a-1178475ec4e4">

## Details

### Code
- Checked against coding style guide: No
  <!-- - Deviations from the style guide: [List any deviations] -->
  <!-- - Potential style guide updates: [Any suggestions?] -->
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->
- Manual tests in staging: Yes
  <!-- - ![Screenshot or video link here if applicable] -->
- E2E tests in Datadog: No
  <!-- ![Screenshot of e2e tests passing] -->

### Misc.
- Metrics, logs, or traces added: No
- Changelog updated: No
  <!-- - If no, reason: [Reason here] -->
<!-- - Other notes: [Any other relevant notes] -->
