### PR TITLE
Kelsonic/eng 1796 add the ability to show a loading screenindicator for

### DIFF
--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Components/PortalWebView.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Components/PortalWebView.swift
@@ -71,7 +71,7 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
       return webView
     }()
   }
-  
+
   /// The constructor for Portal's WebViewController.
   /// - Parameters:
   ///   - portal: Your Portal instance.
@@ -166,7 +166,7 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
     )
 
     self.evaluateJavascript(javascript, sourceURL: "portal_sign")
-    
+
     self.onLoad?()
   }
 

--- a/Cocoapods Example/PortalSwift/WebViewController.swift
+++ b/Cocoapods Example/PortalSwift/WebViewController.swift
@@ -41,7 +41,7 @@ class WebViewController: UIViewController {
       webViewController.didMove(toParent: self)
     }
   }
-  
+
   func onLoad() {
     print("✅ PortalWebView loaded")
   }

--- a/Cocoapods Example/PortalSwift/WebViewController.swift
+++ b/Cocoapods Example/PortalSwift/WebViewController.swift
@@ -26,16 +26,24 @@ class WebViewController: UIViewController {
         print("WebViewController error: URL could not be derived.")
         return
       }
-      let webViewController = PortalWebView(portal: portal, url: url, onError: onError)
+
+      let webViewController = PortalWebView(portal: portal, url: url, onError: onError, onLoad: onLoad)
+
       // Install the WebViewController as a child view controller.
       addChild(webViewController)
+
       guard let webViewControllerView = webViewController.view else {
         print("WebViewController error: webViewController.view could not be derived.")
         return
       }
+
       view.addSubview(webViewControllerView)
       webViewController.didMove(toParent: self)
     }
+  }
+  
+  func onLoad() {
+    print("✅ PortalWebView loaded")
   }
 
   func onError(result: Result<Any>) {

--- a/SPM Example/PortalSwift/WebViewController.swift
+++ b/SPM Example/PortalSwift/WebViewController.swift
@@ -41,7 +41,7 @@ class WebViewController: UIViewController {
       webViewController.didMove(toParent: self)
     }
   }
-  
+
   func onLoad() {
     print("✅ PortalWebView loaded")
   }

--- a/SPM Example/PortalSwift/WebViewController.swift
+++ b/SPM Example/PortalSwift/WebViewController.swift
@@ -26,16 +26,24 @@ class WebViewController: UIViewController {
         print("WebViewController error: URL could not be derived.")
         return
       }
-      let webViewController = PortalWebView(portal: portal, url: url, onError: onError)
+
+      let webViewController = PortalWebView(portal: portal, url: url, onError: onError, onLoad: onLoad)
+
       // Install the WebViewController as a child view controller.
       addChild(webViewController)
+
       guard let webViewControllerView = webViewController.view else {
         print("WebViewController error: webViewController.view could not be derived.")
         return
       }
+
       view.addSubview(webViewControllerView)
       webViewController.didMove(toParent: self)
     }
+  }
+  
+  func onLoad() {
+    print("✅ PortalWebView loaded")
   }
 
   func onError(result: Result<Any>) {

--- a/Sources/PortalSwift/Components/PortalWebView.swift
+++ b/Sources/PortalSwift/Components/PortalWebView.swift
@@ -71,7 +71,7 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
       return webView
     }()
   }
-  
+
   /// The constructor for Portal's WebViewController.
   /// - Parameters:
   ///   - portal: Your Portal instance.
@@ -166,7 +166,7 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
     )
 
     self.evaluateJavascript(javascript, sourceURL: "portal_sign")
-    
+
     self.onLoad?()
   }
 

--- a/Sources/PortalSwift/Provider/PortalProvider.swift
+++ b/Sources/PortalSwift/Provider/PortalProvider.swift
@@ -936,14 +936,15 @@ public struct ETHTransactionParam: Codable {
     self.data = data
     self.nonce = nonce
   }
-    public init(from: String, to: String, gasPrice: String, value: String, data: String, nonce: String? = nil) {
-      self.from = from
-      self.to = to
-      self.gasPrice = gasPrice
-      self.value = value
-      self.data = data
-      self.nonce = nonce
-    }
+
+  public init(from: String, to: String, gasPrice: String, value: String, data: String, nonce: String? = nil) {
+    self.from = from
+    self.to = to
+    self.gasPrice = gasPrice
+    self.value = value
+    self.data = data
+    self.nonce = nonce
+  }
 
   public init(from: String, to: String, value: String, data: String) {
     self.from = from


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR adds `onLoad` for `PortalWebView` as an optional argument.

## Details

### Code
- Checked against coding style guide: Yes
  <!-- - Deviations from the style guide: [List any deviations] -->
  <!-- - Potential style guide updates: [Any suggestions?] -->
- Documentation updated: Pending
  <!-- - If pending, describe what needs to be updated -->
  - Need to update documentation to include `onLoad` functionality.

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->
- Manual tests in staging: Pending
  <!-- - ![Screenshot or video link here if applicable] -->
- E2E tests in Datadog: Pending
  <!-- ![Screenshot of e2e tests passing] -->

### Misc.
- Metrics, logs, or traces added: No
- Changelog updated: No
  <!-- - If no, reason: [Reason here] -->
<!-- - Other notes: [Any other relevant notes] -->
