### PR TITLE
Kelsonic/eng 1930 fix inspecting safari ios simulator webview

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run Tests
         run: |
           cd ${{ github.workspace }}/main/
-          xcodebuild -quiet -scheme Unit\ Tests -workspace PortalSwift.xcworkspace test -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.4'
+          xcodebuild -quiet -scheme Unit\ Tests -workspace PortalSwift.xcworkspace test -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2'
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.2.1

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run Tests
         run: |
           cd ${{ github.workspace }}/main/
-          xcodebuild -quiet -scheme Unit\ Tests -workspace PortalSwift.xcworkspace test -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2'
+          xcodebuild -quiet -scheme Unit\ Tests -workspace PortalSwift.xcworkspace test -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.4'
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.2.1

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Components/PortalWebView.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Components/PortalWebView.swift
@@ -99,7 +99,7 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
     self.onPageComplete = onPageComplete
 
     super.init(nibName: nil, bundle: nil)
-    
+
     self.webView = {
       let contentController = WKUserContentController()
 
@@ -164,7 +164,7 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
   /// - Parameters:
   ///   - webView: The WKWebView instance that started loading.
   ///   - navigation: The navigation information associated with the event.
-  public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+  public func webView(_: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
     self.onPageStart?()
   }
 

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Components/PortalWebView.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Components/PortalWebView.swift
@@ -74,7 +74,7 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
       #if canImport(UIKit)
         #if targetEnvironment(simulator)
           if #available(iOS 16.4, *) {
-              webView.isInspectable = true
+            webView.isInspectable = true
           }
         #endif
       #endif

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Components/PortalWebView.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Components/PortalWebView.swift
@@ -69,6 +69,16 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
       webView.scrollView.bounces = false
       webView.navigationDelegate = self
 
+      // Enable debugging the webview in Safari.
+      // #if directive used  to start a conditional compilation block.
+      #if canImport(UIKit)
+        #if targetEnvironment(simulator)
+          if #available(iOS 16.4, *) {
+              webView.isInspectable = true
+          }
+        #endif
+      #endif
+
       return webView
     }()
   }

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Components/PortalWebView.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Components/PortalWebView.swift
@@ -71,13 +71,14 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
 
       // Enable debugging the webview in Safari.
       // #if directive used  to start a conditional compilation block.
-      #if canImport(UIKit)
-        #if targetEnvironment(simulator)
-          if #available(iOS 16.4, *) {
-            webView.isInspectable = true
-          }
-        #endif
-      #endif
+      // @WARNING: Uncomment this section to enable debugging in Safari.
+//      #if canImport(UIKit)
+//        #if targetEnvironment(simulator)
+//          if #available(iOS 16.4, *) {
+//            webView.isInspectable = true
+//          }
+//        #endif
+//      #endif
 
       return webView
     }()

--- a/Sources/PortalSwift/Components/PortalWebView.swift
+++ b/Sources/PortalSwift/Components/PortalWebView.swift
@@ -101,13 +101,13 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
       let webView = WKWebView(frame: .zero, configuration: configuration)
       webView.scrollView.bounces = false
       webView.navigationDelegate = self
-      
+
       // Enable debugging the webview in Safari.
       // #if directive used  to start a conditional compilation block.
       #if canImport(UIKit)
         #if targetEnvironment(simulator)
           if #available(iOS 16.4, *) {
-              webView.isInspectable = true
+            webView.isInspectable = true
           }
         #endif
       #endif

--- a/Sources/PortalSwift/Components/PortalWebView.swift
+++ b/Sources/PortalSwift/Components/PortalWebView.swift
@@ -104,13 +104,14 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
 
       // Enable debugging the webview in Safari.
       // #if directive used  to start a conditional compilation block.
-      #if canImport(UIKit)
-        #if targetEnvironment(simulator)
-          if #available(iOS 16.4, *) {
-            webView.isInspectable = true
-          }
-        #endif
-      #endif
+      // @WARNING: Uncomment this section to enable debugging in Safari.
+//      #if canImport(UIKit)
+//        #if targetEnvironment(simulator)
+//          if #available(iOS 16.4, *) {
+//            webView.isInspectable = true
+//          }
+//        #endif
+//      #endif
 
       return webView
     }()

--- a/Sources/PortalSwift/Components/PortalWebView.swift
+++ b/Sources/PortalSwift/Components/PortalWebView.swift
@@ -101,6 +101,16 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
       let webView = WKWebView(frame: .zero, configuration: configuration)
       webView.scrollView.bounces = false
       webView.navigationDelegate = self
+      
+      // Enable debugging the webview in Safari.
+      // #if directive used  to start a conditional compilation block.
+      #if canImport(UIKit)
+        #if targetEnvironment(simulator)
+          if #available(iOS 16.4, *) {
+              webView.isInspectable = true
+          }
+        #endif
+      #endif
 
       return webView
     }()

--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -283,26 +283,26 @@ public class Portal {
   public func emit(_ event: Events.RawValue, data: Any) {
     _ = self.provider.emit(event: event, data: data)
   }
-  
+
   public func ethEstimateGas(
     transaction: ETHTransactionParam,
-    completion: @escaping(Result<RequestCompletionResult>) -> Void
+    completion: @escaping (Result<RequestCompletionResult>) -> Void
   ) {
     self.provider.request(payload: ETHRequestPayload(
       method: ETHRequestMethods.EstimateGas.rawValue,
       params: [transaction]
     ), completion: completion)
   }
-  
+
   public func ethGasPrice(
-    completion: @escaping(Result<RequestCompletionResult>) -> Void
+    completion: @escaping (Result<RequestCompletionResult>) -> Void
   ) {
     self.provider.request(payload: ETHRequestPayload(
       method: ETHRequestMethods.GasPrice.rawValue,
       params: []
     ), completion: completion)
   }
-  
+
   public func ethGetBalance(
     completion: @escaping (Result<RequestCompletionResult>) -> Void
   ) {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR adds the ability to inspect the iOS simulator's webview in Safari.

## Details

### Code
- Checked against coding style guide: Yes
  <!-- - Deviations from the style guide: [List any deviations] -->
  <!-- - Potential style guide updates: [Any suggestions?] -->
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->
- Manual tests in staging: Pending
  <!-- - ![Screenshot or video link here if applicable] -->
- E2E tests in Datadog: Pending
  <!-- ![Screenshot of e2e tests passing] -->

### Misc.
- Metrics, logs, or traces added: No
- Changelog updated: No
  <!-- - If no, reason: [Reason here] -->
<!-- - Other notes: [Any other relevant notes] -->
