### PR TITLE
Remove goerli references in favor of sepolia

### DIFF
--- a/Cocoapods Example/Pods/PortalSwift/README.md
+++ b/Cocoapods Example/Pods/PortalSwift/README.md
@@ -55,7 +55,7 @@ let portal = try Portal(
   gatewayConfig: [
     // This Gateway Config will dependent on the chains you want to support
     1: "NODE_URL_FOR_MAINNET",
-    5: "NODE_URL_FOR_GOERLI",
+    11155111: "NODE_URL_FOR_SEPOLIA",
     137: "NODE_URL_FOR_POLYGON_MAINNET",
     80001: "NODE_URL_FOR_POLYGON_MUMBAI",
   ],

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Components/PortalWebView.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Components/PortalWebView.swift
@@ -88,7 +88,7 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
     self.onPageComplete = onPageComplete
 
     super.init(nibName: nil, bundle: nil)
-    
+
     self.webView = {
       let contentController = WKUserContentController()
 
@@ -153,7 +153,7 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
   /// - Parameters:
   ///   - webView: The WKWebView instance that started loading.
   ///   - navigation: The navigation information associated with the event.
-  public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+  public func webView(_: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
     self.onPageStart?()
   }
 

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Core/PortalApi.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Core/PortalApi.swift
@@ -420,7 +420,7 @@ public struct DappImage: Codable {
   public var filename: String
 }
 
-/// A contract network. For example, chainId 5 is the Goerli network.
+/// A contract network. For example, chainId 11155111 is the Sepolia network.
 public struct ContractNetwork: Codable {
   public var id: String
   public var chainId: String

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Mocks/Utils/MockHttpRequester.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Mocks/Utils/MockHttpRequester.swift
@@ -71,7 +71,7 @@ public class MockHttpRequester: HttpRequester {
       completion(Result(data: mockResponse as! T))
 
     case "net_version":
-      let mockResponse = ETHGatewayResponse(jsonrpc: "2.0", result: "5")
+      let mockResponse = ETHGatewayResponse(jsonrpc: "2.0", result: "11155111")
       completion(Result(data: mockResponse as! T))
 
     case "eth_newBlockFilter":

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Provider/PortalProvider.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Provider/PortalProvider.swift
@@ -770,7 +770,7 @@ public enum Chains: Int {
   case Ropsten = 3
   case Rinkeby = 4
   case Goerli = 5
-  case Sepolia = 11155111
+  case Sepolia = 11_155_111
   case Kovan = 42
 }
 

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Provider/PortalProvider.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Provider/PortalProvider.swift
@@ -748,7 +748,7 @@ public class PortalProvider {
   /// Determines the appropriate Gateway URL to use for the current chainId
   /// - Parameters:
   ///   - gatewayConfig: A dictionary of chainIds (keys) and gateway URLs (values).
-  ///   - chainId: The chainId we should use, such as 5 (Goerli).
+  ///   - chainId: The chainId we should use, such as 11155111 (Sepolia).
   /// - Throws: PortalArgumentError.noGatewayConfigForChain with the chainId.
   /// - Returns: The URL to be used for Gateway requests.
   static func getGatewayUrl(gatewayConfig: [Int: String], chainId: Int) throws -> String {
@@ -770,6 +770,7 @@ public enum Chains: Int {
   case Ropsten = 3
   case Rinkeby = 4
   case Goerli = 5
+  case Sepolia = 11155111
   case Kovan = 42
 }
 

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Utils/Chains.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Utils/Chains.swift
@@ -11,13 +11,13 @@ class ChainUtils {
   private static let chainIdToName: [Int: String] = [
     1: "mainnet",
     5: "goerli",
-    11155111: "sepolia",
+    11_155_111: "sepolia",
   ]
 
   private static let chainNameToId: [String: Int] = [
     "mainnet": 1,
     "goerli": 5,
-    "sepolia": 11155111,
+    "sepolia": 11_155_111,
   ]
 
   public static func getChainIdForName(_ chainName: String) -> Int? {

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Utils/Chains.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Utils/Chains.swift
@@ -11,11 +11,13 @@ class ChainUtils {
   private static let chainIdToName: [Int: String] = [
     1: "mainnet",
     5: "goerli",
+    11155111: "sepolia",
   ]
 
   private static let chainNameToId: [String: Int] = [
     "mainnet": 1,
     "goerli": 5,
+    "sepolia": 11155111,
   ]
 
   public static func getChainIdForName(_ chainName: String) -> Int? {

--- a/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Core/PortalApiTests.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Core/PortalApiTests.swift
@@ -15,8 +15,8 @@ final class PortalApiTests: XCTestCase {
   override func setUpWithError() throws {
     let provider = try MockPortalProvider(
       apiKey: mockApiKey,
-      chainId: 5,
-      gatewayConfig: [5: mockHost],
+      chainId: 11155111,
+      gatewayConfig: [11155111: mockHost],
       keychain: MockPortalKeychain(),
       autoApprove: true
     )

--- a/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Core/PortalApiTests.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Core/PortalApiTests.swift
@@ -15,8 +15,8 @@ final class PortalApiTests: XCTestCase {
   override func setUpWithError() throws {
     let provider = try MockPortalProvider(
       apiKey: mockApiKey,
-      chainId: 11155111,
-      gatewayConfig: [11155111: mockHost],
+      chainId: 11_155_111,
+      gatewayConfig: [11_155_111: mockHost],
       keychain: MockPortalKeychain(),
       autoApprove: true
     )

--- a/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Core/PortalCoreTests.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Core/PortalCoreTests.swift
@@ -20,8 +20,8 @@ final class PortalCoreTests: XCTestCase {
 
     let provider = try MockPortalProvider(
       apiKey: mockApiKey,
-      chainId: 5,
-      gatewayConfig: [5: mockHost],
+      chainId: 11155111,
+      gatewayConfig: [11155111: mockHost],
       keychain: keychain,
       autoApprove: true
     )
@@ -41,7 +41,7 @@ final class PortalCoreTests: XCTestCase {
       mobile: mobile
     )
 
-    self.portal = try Portal(apiKey: mockApiKey, backup: BackupOptions(icloud: MockICloudStorage()), chainId: 5, keychain: keychain, gatewayConfig: [5: mockHost], mpc: mpc, api: api, binary: mobile)
+    self.portal = try Portal(apiKey: mockApiKey, backup: BackupOptions(icloud: MockICloudStorage()), chainId: 11155111, keychain: keychain, gatewayConfig: [11155111: mockHost], mpc: mpc, api: api, binary: mobile)
   }
 
   override func tearDownWithError() throws {

--- a/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Core/PortalCoreTests.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Core/PortalCoreTests.swift
@@ -20,8 +20,8 @@ final class PortalCoreTests: XCTestCase {
 
     let provider = try MockPortalProvider(
       apiKey: mockApiKey,
-      chainId: 11155111,
-      gatewayConfig: [11155111: mockHost],
+      chainId: 11_155_111,
+      gatewayConfig: [11_155_111: mockHost],
       keychain: keychain,
       autoApprove: true
     )
@@ -41,7 +41,7 @@ final class PortalCoreTests: XCTestCase {
       mobile: mobile
     )
 
-    self.portal = try Portal(apiKey: mockApiKey, backup: BackupOptions(icloud: MockICloudStorage()), chainId: 11155111, keychain: keychain, gatewayConfig: [11155111: mockHost], mpc: mpc, api: api, binary: mobile)
+    self.portal = try Portal(apiKey: mockApiKey, backup: BackupOptions(icloud: MockICloudStorage()), chainId: 11_155_111, keychain: keychain, gatewayConfig: [11_155_111: mockHost], mpc: mpc, api: api, binary: mobile)
   }
 
   override func tearDownWithError() throws {

--- a/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Provider/MpcSignerTests.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Provider/MpcSignerTests.swift
@@ -20,8 +20,8 @@ final class MpcSignerTests: XCTestCase {
     self.signer = MpcSigner(apiKey: mockApiKey, keychain: self.keychain, binary: MockMobileWrapper())
     self.provider = try PortalProvider(
       apiKey: mockApiKey,
-      chainId: 5,
-      gatewayConfig: [5: mockHost],
+      chainId: 11155111,
+      gatewayConfig: [11155111: mockHost],
       keychain: MockPortalKeychain(),
       autoApprove: true,
       gateway: MockHttpRequester(baseUrl: mockHost)

--- a/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Provider/MpcSignerTests.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Provider/MpcSignerTests.swift
@@ -20,8 +20,8 @@ final class MpcSignerTests: XCTestCase {
     self.signer = MpcSigner(apiKey: mockApiKey, keychain: self.keychain, binary: MockMobileWrapper())
     self.provider = try PortalProvider(
       apiKey: mockApiKey,
-      chainId: 11155111,
-      gatewayConfig: [11155111: mockHost],
+      chainId: 11_155_111,
+      gatewayConfig: [11_155_111: mockHost],
       keychain: MockPortalKeychain(),
       autoApprove: true,
       gateway: MockHttpRequester(baseUrl: mockHost)

--- a/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Provider/PortalMpcTests.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Provider/PortalMpcTests.swift
@@ -19,8 +19,8 @@ final class PortalMpcTests: XCTestCase {
 
     self.provider = try MockPortalProvider(
       apiKey: mockApiKey,
-      chainId: 5,
-      gatewayConfig: [5: mockHost],
+      chainId: 11155111,
+      gatewayConfig: [11155111: mockHost],
       keychain: keychain,
       autoApprove: true
     )

--- a/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Provider/PortalMpcTests.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Provider/PortalMpcTests.swift
@@ -19,8 +19,8 @@ final class PortalMpcTests: XCTestCase {
 
     self.provider = try MockPortalProvider(
       apiKey: mockApiKey,
-      chainId: 11155111,
-      gatewayConfig: [11155111: mockHost],
+      chainId: 11_155_111,
+      gatewayConfig: [11_155_111: mockHost],
       keychain: keychain,
       autoApprove: true
     )

--- a/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Provider/PortalProviderTests.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Provider/PortalProviderTests.swift
@@ -264,7 +264,7 @@ final class PortalProviderTests: XCTestCase {
       }
 
       XCTAssert(!version.isEmpty, "Net version (chain id) should not be empty")
-      XCTAssert(version == "11155111", "Net version (chain id) should be empty 11155111 for Sepolia")
+      XCTAssert(version == "11155111", "Net version (chain id) should be 11155111 for Sepolia")
 
       expectation.fulfill()
     }

--- a/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Provider/PortalProviderTests.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Provider/PortalProviderTests.swift
@@ -16,8 +16,8 @@ final class PortalProviderTests: XCTestCase {
     // Put setup code here. This method is called before the invocation of each test method in the class.
     self.provider = try PortalProvider(
       apiKey: mockApiKey,
-      chainId: 11155111,
-      gatewayConfig: [11155111: mockHost],
+      chainId: 11_155_111,
+      gatewayConfig: [11_155_111: mockHost],
       keychain: MockPortalKeychain(),
       autoApprove: true,
       gateway: MockHttpRequester(baseUrl: mockHost)

--- a/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Provider/PortalProviderTests.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Provider/PortalProviderTests.swift
@@ -16,8 +16,8 @@ final class PortalProviderTests: XCTestCase {
     // Put setup code here. This method is called before the invocation of each test method in the class.
     self.provider = try PortalProvider(
       apiKey: mockApiKey,
-      chainId: 5,
-      gatewayConfig: [5: mockHost],
+      chainId: 11155111,
+      gatewayConfig: [11155111: mockHost],
       keychain: MockPortalKeychain(),
       autoApprove: true,
       gateway: MockHttpRequester(baseUrl: mockHost)
@@ -264,7 +264,7 @@ final class PortalProviderTests: XCTestCase {
       }
 
       XCTAssert(!version.isEmpty, "Net version (chain id) should not be empty")
-      XCTAssert(version == "5", "Net version (chain id) should be empty 5 for goerli")
+      XCTAssert(version == "11155111", "Net version (chain id) should be empty 11155111 for Sepolia")
 
       expectation.fulfill()
     }

--- a/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Storage/ICloudStorageTests.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Storage/ICloudStorageTests.swift
@@ -13,7 +13,7 @@ final class ICloudStorageTests: XCTestCase {
   var storage: ICloudStorage?
 
   override func setUpWithError() throws {
-    let provider = try MockPortalProvider(apiKey: "", chainId: 11155111, gatewayConfig: [11155111: "https://example.com"], keychain: MockPortalKeychain(), autoApprove: true)
+    let provider = try MockPortalProvider(apiKey: "", chainId: 11_155_111, gatewayConfig: [11_155_111: "https://example.com"], keychain: MockPortalKeychain(), autoApprove: true)
 
     self.storage = ICloudStorage()
     self.storage?.api = MockPortalApi(apiKey: "", apiHost: "", provider: provider)

--- a/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Storage/ICloudStorageTests.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Tests/PortalSwiftTests/Storage/ICloudStorageTests.swift
@@ -13,7 +13,7 @@ final class ICloudStorageTests: XCTestCase {
   var storage: ICloudStorage?
 
   override func setUpWithError() throws {
-    let provider = try MockPortalProvider(apiKey: "", chainId: 5, gatewayConfig: [5: "https://example.com"], keychain: MockPortalKeychain(), autoApprove: true)
+    let provider = try MockPortalProvider(apiKey: "", chainId: 11155111, gatewayConfig: [11155111: "https://example.com"], keychain: MockPortalKeychain(), autoApprove: true)
 
     self.storage = ICloudStorage()
     self.storage?.api = MockPortalApi(apiKey: "", apiHost: "", provider: provider)

--- a/Cocoapods Example/PortalSwift/Base.lproj/Main.storyboard
+++ b/Cocoapods Example/PortalSwift/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,7 +11,7 @@
         <!--View Controller-->
         <scene sceneID="ufC-wZ-h7g">
             <objects>
-                <viewController storyboardIdentifier="Main" id="vXZ-lx-hvc" customClass="ViewController" customModule="PortalSwift_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Main" id="vXZ-lx-hvc" customClass="ViewController" customModule="Cocoapods_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="jyV-Pf-zRb"/>
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
@@ -273,7 +273,7 @@
         <!--Web View Controller-->
         <scene sceneID="AeA-zC-7Sc">
             <objects>
-                <viewController id="R0A-w7-x9S" customClass="WebViewController" customModule="PortalSwift_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="R0A-w7-x9S" customClass="WebViewController" customModule="Cocoapods_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="fSO-SS-BfH"/>
                         <viewControllerLayoutGuide type="bottom" id="fg1-21-qPe"/>
@@ -291,7 +291,7 @@
         <!--Connect View Controller-->
         <scene sceneID="94S-6a-j1d">
             <objects>
-                <viewController storyboardIdentifier="Connect" useStoryboardIdentifierAsRestorationIdentifier="YES" id="7fk-LF-non" customClass="ConnectViewController" customModule="PortalSwift_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Connect" useStoryboardIdentifierAsRestorationIdentifier="YES" id="7fk-LF-non" customClass="ConnectViewController" customModule="Cocoapods_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="zXS-6W-gVU"/>
                         <viewControllerLayoutGuide type="bottom" id="qa6-Jg-pyi"/>
@@ -384,24 +384,6 @@
                                     <action selector="connect2Pressed" destination="7fk-LF-non" eventType="touchUpInside" id="j4I-Lx-Pxm"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="15d-vL-Ghe">
-                                <rect key="frame" x="115" y="62" width="91" height="48"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="Eth mainnet"/>
-                                <connections>
-                                    <action selector="EthMainnetPressed:" destination="7fk-LF-non" eventType="touchUpInside" id="sq3-D2-eXp"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2at-6a-APP">
-                                <rect key="frame" x="223" y="62" width="75" height="48"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="Goerli"/>
-                                <connections>
-                                    <action selector="GoerliPressed:" destination="7fk-LF-non" eventType="touchUpInside" id="9fk-RW-DRO"/>
-                                </connections>
-                            </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Switch Chain" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2DD-qY-dEP">
                                 <rect key="frame" x="128" y="27" width="100" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -409,32 +391,50 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NAq-3e-gkr">
-                                <rect key="frame" x="19" y="118" width="86" height="48"/>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="trb-y1-ofx">
+                                <rect key="frame" x="16" y="56" width="101" height="48"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="Mumbai"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Ethereum Mainnet"/>
                                 <connections>
-                                    <action selector="MumbaiPressed:" destination="7fk-LF-non" eventType="touchUpInside" id="iZQ-m7-GCk"/>
+                                    <action selector="EthMainnetPressed:" destination="7fk-LF-non" eventType="touchUpInside" id="GoC-th-uE5"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kMQ-14-dCv">
-                                <rect key="frame" x="19" y="62" width="91" height="48"/>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="v4K-Fc-Kpl">
+                                <rect key="frame" x="16" y="112" width="101" height="48"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="Polygon mainnet"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Ethereum Sepolia"/>
                                 <connections>
-                                    <action selector="PolyMainPressed:" destination="7fk-LF-non" eventType="touchUpInside" id="kLQ-Jm-zv4"/>
+                                    <action selector="SepoliaPressed:" destination="7fk-LF-non" eventType="touchUpInside" id="aou-JI-EtN"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="avM-nh-epI">
+                                <rect key="frame" x="125" y="112" width="90" height="48"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Polygon Mumbai"/>
+                                <connections>
+                                    <action selector="MumbaiPressed:" destination="7fk-LF-non" eventType="touchUpInside" id="tv9-L2-QGV"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jtx-1w-8zm">
+                                <rect key="frame" x="125" y="56" width="90" height="48"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Polygon Mainnet"/>
+                                <connections>
+                                    <action selector="PolyMainPressed:" destination="7fk-LF-non" eventType="touchUpInside" id="ciO-mm-ESg"/>
                                 </connections>
                             </button>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <connections>
-                        <outlet property="EthMainnetButton" destination="15d-vL-Ghe" id="U1l-Db-X6w"/>
-                        <outlet property="GoerliButton" destination="2at-6a-APP" id="Lhe-WC-nF1"/>
-                        <outlet property="MumbaiButton" destination="NAq-3e-gkr" id="f2E-j4-R1Z"/>
-                        <outlet property="PolygonMainnetButton" destination="kMQ-14-dCv" id="2c3-C5-QsZ"/>
+                        <outlet property="EthMainnetButton" destination="trb-y1-ofx" id="Izm-7h-aRu"/>
+                        <outlet property="MumbaiButton" destination="avM-nh-epI" id="M8t-wU-7be"/>
+                        <outlet property="PolygonMainnetButton" destination="Jtx-1w-8zm" id="JNi-BV-Dfb"/>
+                        <outlet property="SepoliaButton" destination="v4K-Fc-Kpl" id="KAA-OG-Voj"/>
                         <outlet property="addressTextInput" destination="xEv-Ac-DYF" id="88M-H0-RU1"/>
                         <outlet property="addressTextInput2" destination="aPI-NR-DZw" id="kkj-nO-0AV"/>
                         <outlet property="connectButton" destination="Xyb-ta-tdQ" id="kIP-YV-aqE"/>
@@ -452,7 +452,7 @@
     </scenes>
     <resources>
         <systemColor name="labelColor">
-            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Cocoapods Example/PortalSwift/ConnectViewController.swift
+++ b/Cocoapods Example/PortalSwift/ConnectViewController.swift
@@ -26,7 +26,7 @@ class ConnectViewController: UIViewController, UITextFieldDelegate {
   @IBOutlet var addressTextInput2: UITextField?
   @IBOutlet var PolygonMainnetButton: UIButton?
   @IBOutlet var EthMainnetButton: UIButton?
-  @IBOutlet var GoerliButton: UIButton?
+  @IBOutlet var SepoliaButton: UIButton?
   @IBOutlet var MumbaiButton: UIButton?
 
   required init?(coder: NSCoder) {
@@ -188,8 +188,8 @@ class ConnectViewController: UIViewController, UITextFieldDelegate {
     self.changeChainId(chainId: 137)
   }
 
-  @IBAction func GoerliPressed(_: Any) {
-    self.changeChainId(chainId: 5)
+  @IBAction func SepoliaPressed(_: Any) {
+    self.changeChainId(chainId: 11155111)
   }
 
   @IBAction func EthMainnetPressed(_: Any) {

--- a/Cocoapods Example/PortalSwift/ConnectViewController.swift
+++ b/Cocoapods Example/PortalSwift/ConnectViewController.swift
@@ -189,7 +189,7 @@ class ConnectViewController: UIViewController, UITextFieldDelegate {
   }
 
   @IBAction func SepoliaPressed(_: Any) {
-    self.changeChainId(chainId: 11155111)
+    self.changeChainId(chainId: 11_155_111)
   }
 
   @IBAction func EthMainnetPressed(_: Any) {

--- a/Cocoapods Example/PortalSwift/Portal.swift
+++ b/Cocoapods Example/PortalSwift/Portal.swift
@@ -99,7 +99,7 @@ class PortalWrapper {
     case cantLoadInfoPlist
   }
 
-  func registerPortal(apiKey: String, backup: BackupOptions, chainId: Int = 5, optimized: Bool = false, completion: @escaping (Result<Bool>) -> Void) {
+  func registerPortal(apiKey: String, backup: BackupOptions, chainId: Int = 11155111, optimized: Bool = false, completion: @escaping (Result<Bool>) -> Void) {
     do {
       guard let infoDictionary: [String: Any] = Bundle.main.infoDictionary else {
         return completion(Result(error: PortalWrapperError.cantLoadInfoPlist))
@@ -116,7 +116,7 @@ class PortalWrapper {
         chainId: chainId,
         keychain: keychain,
         gatewayConfig: [
-          5: "https://eth-goerli.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 1: "https://eth-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 80001: "https://polygon-mumbai.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 137: "https://polygon-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)",
+          11155111: "https://eth-sepolia.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 1: "https://eth-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 80001: "https://polygon-mumbai.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 137: "https://polygon-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)",
         ],
         autoApprove: false,
         apiHost: self.API_URL!,

--- a/Cocoapods Example/PortalSwift/Portal.swift
+++ b/Cocoapods Example/PortalSwift/Portal.swift
@@ -99,7 +99,7 @@ class PortalWrapper {
     case cantLoadInfoPlist
   }
 
-  func registerPortal(apiKey: String, backup: BackupOptions, chainId: Int = 11155111, optimized: Bool = false, completion: @escaping (Result<Bool>) -> Void) {
+  func registerPortal(apiKey: String, backup: BackupOptions, chainId: Int = 11_155_111, optimized: Bool = false, completion: @escaping (Result<Bool>) -> Void) {
     do {
       guard let infoDictionary: [String: Any] = Bundle.main.infoDictionary else {
         return completion(Result(error: PortalWrapperError.cantLoadInfoPlist))
@@ -116,7 +116,7 @@ class PortalWrapper {
         chainId: chainId,
         keychain: keychain,
         gatewayConfig: [
-          11155111: "https://eth-sepolia.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 1: "https://eth-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 80001: "https://polygon-mumbai.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 137: "https://polygon-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)",
+          11_155_111: "https://eth-sepolia.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 1: "https://eth-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 80001: "https://polygon-mumbai.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 137: "https://polygon-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)",
         ],
         autoApprove: false,
         apiHost: self.API_URL!,

--- a/Cocoapods Example/PortalSwift/ViewController.swift
+++ b/Cocoapods Example/PortalSwift/ViewController.swift
@@ -431,7 +431,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
 
   func getTransactions() {
     do {
-      try self.portal?.api.getTransactions(limit: 100, offset: 0, order: GetTransactionsOrder.asc, chainId: 11155111) { results in
+      try self.portal?.api.getTransactions(limit: 100, offset: 0, order: GetTransactionsOrder.asc, chainId: 11_155_111) { results in
         guard results.error == nil else {
           print("❌ Unable to get transactions", results.error ?? "")
           return

--- a/Cocoapods Example/PortalSwift/ViewController.swift
+++ b/Cocoapods Example/PortalSwift/ViewController.swift
@@ -431,7 +431,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
 
   func getTransactions() {
     do {
-      try self.portal?.api.getTransactions(limit: 100, offset: 0, order: GetTransactionsOrder.asc, chainId: 5) { results in
+      try self.portal?.api.getTransactions(limit: 100, offset: 0, order: GetTransactionsOrder.asc, chainId: 11155111) { results in
         guard results.error == nil else {
           print("❌ Unable to get transactions", results.error ?? "")
           return

--- a/Cocoapods Example/Tests/e2e/PasswordWalletTests.swift
+++ b/Cocoapods Example/Tests/e2e/PasswordWalletTests.swift
@@ -27,7 +27,7 @@ class PasswordWalletTests: XCTestCase {
     super.tearDown()
   }
 
-  func testLogin(chainId _: Int = 11155111, completion: @escaping (Result<Bool>) -> Void) {
+  func testLogin(chainId _: Int = 11_155_111, completion: @escaping (Result<Bool>) -> Void) {
     XCTContext.runActivity(named: "Login") { _ in
       let registerExpectation = XCTestExpectation(description: "Register")
 
@@ -70,7 +70,7 @@ class PasswordWalletTests: XCTestCase {
       let backupOption = LocalFileStorage(fileName: "PORTAL_BACKUP")
       let backup = BackupOptions(local: backupOption)
       print("registering portal")
-      PasswordWalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11155111, optimized: true) {
+      PasswordWalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11_155_111, optimized: true) {
         result in
         guard result.error == nil else {
           registerExpectation.fulfill()

--- a/Cocoapods Example/Tests/e2e/PasswordWalletTests.swift
+++ b/Cocoapods Example/Tests/e2e/PasswordWalletTests.swift
@@ -27,7 +27,7 @@ class PasswordWalletTests: XCTestCase {
     super.tearDown()
   }
 
-  func testLogin(chainId _: Int = 5, completion: @escaping (Result<Bool>) -> Void) {
+  func testLogin(chainId _: Int = 11155111, completion: @escaping (Result<Bool>) -> Void) {
     XCTContext.runActivity(named: "Login") { _ in
       let registerExpectation = XCTestExpectation(description: "Register")
 
@@ -70,7 +70,7 @@ class PasswordWalletTests: XCTestCase {
       let backupOption = LocalFileStorage(fileName: "PORTAL_BACKUP")
       let backup = BackupOptions(local: backupOption)
       print("registering portal")
-      PasswordWalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 5, optimized: true) {
+      PasswordWalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11155111, optimized: true) {
         result in
         guard result.error == nil else {
           registerExpectation.fulfill()

--- a/Cocoapods Example/Tests/e2e/ProviderTests.swift
+++ b/Cocoapods Example/Tests/e2e/ProviderTests.swift
@@ -43,7 +43,7 @@ class ProviderTests: XCTestCase {
         return expectation.fulfill()
       }
 
-      self.registerPortal(userResult: userResult, chainId: 5) { success in
+      self.registerPortal(userResult: userResult, chainId: 11155111) { success in
         guard success else {
           XCTFail("Failed on registering portal")
           return expectation.fulfill()
@@ -393,7 +393,7 @@ class ProviderTests: XCTestCase {
 
         print("Gateway response for eth_netVersion \(String(describing: version))")
         XCTAssert(!version.isEmpty, "Net version (chain id) should not be empty")
-        XCTAssert(version == "5", "Net version (chain id) should be empty 5 for goerli")
+        XCTAssert(version == "11155111", "Net version (chain id) should be empty 11155111 for Sepolia")
 
         expectation.fulfill()
       }
@@ -947,7 +947,7 @@ class ProviderTests: XCTestCase {
   func testEthGetTransactionBlockHashIndex() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 5) { success in
+    self.testLogin(chainId: 11155111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -971,7 +971,7 @@ class ProviderTests: XCTestCase {
   func testEthGetBlockTransactionCountHash() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 5) { success in
+    self.testLogin(chainId: 11155111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -995,7 +995,7 @@ class ProviderTests: XCTestCase {
   func testEthGetLogs() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 5) { success in
+    self.testLogin(chainId: 11155111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1079,7 +1079,7 @@ class ProviderTests: XCTestCase {
   func testNewFilter() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 5) { success in
+    self.testLogin(chainId: 11155111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1103,7 +1103,7 @@ class ProviderTests: XCTestCase {
   func testUninstallFilter() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 5) { success in
+    self.testLogin(chainId: 11155111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1127,7 +1127,7 @@ class ProviderTests: XCTestCase {
   func testEthGetBlockNumberFalse() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 5) { success in
+    self.testLogin(chainId: 11155111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1151,7 +1151,7 @@ class ProviderTests: XCTestCase {
   func testEthGetBlockNumberTrue() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 5) { success in
+    self.testLogin(chainId: 11155111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1207,7 +1207,7 @@ class ProviderTests: XCTestCase {
     case portalObjectNil
   }
 
-  func testLogin(chainId: Int = 5, completion: @escaping (Bool) -> Void) {
+  func testLogin(chainId: Int = 11155111, completion: @escaping (Bool) -> Void) {
     XCTContext.runActivity(named: "Login") { _ in
       let registerExpectation = XCTestExpectation(description: "Register")
 
@@ -1266,9 +1266,9 @@ class ProviderTests: XCTestCase {
         return completion(false)
       }
       XCTAssertTrue(!address.isEmpty, "The address should not be empty")
-      let goerliChain = 5
+      let sepoliaChainId = 11155111
 
-      ProviderTests.PortalWrap.transferFunds(user: userResult, amount: 0.01, chainId: goerliChain, address: address) { fundResult in
+      ProviderTests.PortalWrap.transferFunds(user: userResult, amount: 0.01, chainId: sepoliaChainId, address: address) { fundResult in
         guard fundResult.error == nil else {
           XCTFail("Could not fund wallet with test eth")
           return completion(false)

--- a/Cocoapods Example/Tests/e2e/ProviderTests.swift
+++ b/Cocoapods Example/Tests/e2e/ProviderTests.swift
@@ -393,7 +393,7 @@ class ProviderTests: XCTestCase {
 
         print("Gateway response for eth_netVersion \(String(describing: version))")
         XCTAssert(!version.isEmpty, "Net version (chain id) should not be empty")
-        XCTAssert(version == "11155111", "Net version (chain id) should be empty 11155111 for Sepolia")
+        XCTAssert(version == "11155111", "Net version (chain id) should be 11155111 for Sepolia")
 
         expectation.fulfill()
       }

--- a/Cocoapods Example/Tests/e2e/ProviderTests.swift
+++ b/Cocoapods Example/Tests/e2e/ProviderTests.swift
@@ -43,7 +43,7 @@ class ProviderTests: XCTestCase {
         return expectation.fulfill()
       }
 
-      self.registerPortal(userResult: userResult, chainId: 11155111) { success in
+      self.registerPortal(userResult: userResult, chainId: 11_155_111) { success in
         guard success else {
           XCTFail("Failed on registering portal")
           return expectation.fulfill()
@@ -947,7 +947,7 @@ class ProviderTests: XCTestCase {
   func testEthGetTransactionBlockHashIndex() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 11155111) { success in
+    self.testLogin(chainId: 11_155_111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -971,7 +971,7 @@ class ProviderTests: XCTestCase {
   func testEthGetBlockTransactionCountHash() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 11155111) { success in
+    self.testLogin(chainId: 11_155_111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -995,7 +995,7 @@ class ProviderTests: XCTestCase {
   func testEthGetLogs() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 11155111) { success in
+    self.testLogin(chainId: 11_155_111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1079,7 +1079,7 @@ class ProviderTests: XCTestCase {
   func testNewFilter() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 11155111) { success in
+    self.testLogin(chainId: 11_155_111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1103,7 +1103,7 @@ class ProviderTests: XCTestCase {
   func testUninstallFilter() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 11155111) { success in
+    self.testLogin(chainId: 11_155_111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1127,7 +1127,7 @@ class ProviderTests: XCTestCase {
   func testEthGetBlockNumberFalse() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 11155111) { success in
+    self.testLogin(chainId: 11_155_111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1151,7 +1151,7 @@ class ProviderTests: XCTestCase {
   func testEthGetBlockNumberTrue() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 11155111) { success in
+    self.testLogin(chainId: 11_155_111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1207,7 +1207,7 @@ class ProviderTests: XCTestCase {
     case portalObjectNil
   }
 
-  func testLogin(chainId: Int = 11155111, completion: @escaping (Bool) -> Void) {
+  func testLogin(chainId: Int = 11_155_111, completion: @escaping (Bool) -> Void) {
     XCTContext.runActivity(named: "Login") { _ in
       let registerExpectation = XCTestExpectation(description: "Register")
 
@@ -1266,7 +1266,7 @@ class ProviderTests: XCTestCase {
         return completion(false)
       }
       XCTAssertTrue(!address.isEmpty, "The address should not be empty")
-      let sepoliaChainId = 11155111
+      let sepoliaChainId = 11_155_111
 
       ProviderTests.PortalWrap.transferFunds(user: userResult, amount: 0.01, chainId: sepoliaChainId, address: address) { fundResult in
         guard fundResult.error == nil else {

--- a/Cocoapods Example/Tests/e2e/WalletTests.swift
+++ b/Cocoapods Example/Tests/e2e/WalletTests.swift
@@ -27,7 +27,7 @@ class WalletTests: XCTestCase {
     super.tearDown()
   }
 
-  func testLogin(chainId _: Int = 5, completion: @escaping (Result<Bool>) -> Void) {
+  func testLogin(chainId _: Int = 11155111, completion: @escaping (Result<Bool>) -> Void) {
     XCTContext.runActivity(named: "Login") { _ in
       let registerExpectation = XCTestExpectation(description: "Register")
 
@@ -75,7 +75,7 @@ class WalletTests: XCTestCase {
       let backupOption = LocalFileStorage(fileName: "PORTAL_BACKUP")
       let backup = BackupOptions(local: backupOption)
       print("registering portal")
-      WalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 5, optimized: true) {
+      WalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11155111, optimized: true) {
         result in
         guard result.error == nil else {
           registerExpectation.fulfill()

--- a/Cocoapods Example/Tests/e2e/WalletTests.swift
+++ b/Cocoapods Example/Tests/e2e/WalletTests.swift
@@ -27,7 +27,7 @@ class WalletTests: XCTestCase {
     super.tearDown()
   }
 
-  func testLogin(chainId _: Int = 11155111, completion: @escaping (Result<Bool>) -> Void) {
+  func testLogin(chainId _: Int = 11_155_111, completion: @escaping (Result<Bool>) -> Void) {
     XCTContext.runActivity(named: "Login") { _ in
       let registerExpectation = XCTestExpectation(description: "Register")
 
@@ -75,7 +75,7 @@ class WalletTests: XCTestCase {
       let backupOption = LocalFileStorage(fileName: "PORTAL_BACKUP")
       let backup = BackupOptions(local: backupOption)
       print("registering portal")
-      WalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11155111, optimized: true) {
+      WalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11_155_111, optimized: true) {
         result in
         guard result.error == nil else {
           registerExpectation.fulfill()

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ let portal = try Portal(
   gatewayConfig: [
     // This Gateway Config will dependent on the chains you want to support
     1: "NODE_URL_FOR_MAINNET",
-    5: "NODE_URL_FOR_GOERLI",
+    11155111: "NODE_URL_FOR_SEPOLIA",
     137: "NODE_URL_FOR_POLYGON_MAINNET",
     80001: "NODE_URL_FOR_POLYGON_MUMBAI",
   ],

--- a/SPM Example/PortalSwift/Base.lproj/Main.storyboard
+++ b/SPM Example/PortalSwift/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,7 +11,7 @@
         <!--View Controller-->
         <scene sceneID="ufC-wZ-h7g">
             <objects>
-                <viewController storyboardIdentifier="Main" id="vXZ-lx-hvc" customClass="ViewController" customModule="PortalSwift_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Main" id="vXZ-lx-hvc" customClass="ViewController" customModule="SPM_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="jyV-Pf-zRb"/>
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
@@ -273,7 +273,7 @@
         <!--Web View Controller-->
         <scene sceneID="AeA-zC-7Sc">
             <objects>
-                <viewController id="R0A-w7-x9S" customClass="WebViewController" customModule="PortalSwift_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="R0A-w7-x9S" customClass="WebViewController" customModule="SPM_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="fSO-SS-BfH"/>
                         <viewControllerLayoutGuide type="bottom" id="fg1-21-qPe"/>
@@ -291,7 +291,7 @@
         <!--Connect View Controller-->
         <scene sceneID="94S-6a-j1d">
             <objects>
-                <viewController storyboardIdentifier="Connect" useStoryboardIdentifierAsRestorationIdentifier="YES" id="7fk-LF-non" customClass="ConnectViewController" customModule="PortalSwift_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Connect" useStoryboardIdentifierAsRestorationIdentifier="YES" id="7fk-LF-non" customClass="ConnectViewController" customModule="SPM_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="zXS-6W-gVU"/>
                         <viewControllerLayoutGuide type="bottom" id="qa6-Jg-pyi"/>
@@ -385,46 +385,46 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="15d-vL-Ghe">
-                                <rect key="frame" x="115" y="62" width="91" height="48"/>
+                                <rect key="frame" x="16" y="62" width="101" height="48"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="Eth mainnet"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Ethereum Mainnet"/>
                                 <connections>
                                     <action selector="EthMainnetPressed:" destination="7fk-LF-non" eventType="touchUpInside" id="sq3-D2-eXp"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2at-6a-APP">
-                                <rect key="frame" x="223" y="62" width="75" height="48"/>
+                                <rect key="frame" x="16" y="118" width="101" height="48"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="Goerli"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Ethereum Sepolia"/>
                                 <connections>
-                                    <action selector="GoerliPressed:" destination="7fk-LF-non" eventType="touchUpInside" id="9fk-RW-DRO"/>
+                                    <action selector="SepoliaPressed:" destination="7fk-LF-non" eventType="touchUpInside" id="eL5-bO-3up"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Switch Chain" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2DD-qY-dEP">
-                                <rect key="frame" x="128" y="27" width="100" height="21"/>
+                                <rect key="frame" x="125" y="33" width="100" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NAq-3e-gkr">
-                                <rect key="frame" x="19" y="118" width="86" height="48"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="Mumbai"/>
-                                <connections>
-                                    <action selector="MumbaiPressed:" destination="7fk-LF-non" eventType="touchUpInside" id="iZQ-m7-GCk"/>
-                                </connections>
-                            </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kMQ-14-dCv">
-                                <rect key="frame" x="19" y="62" width="91" height="48"/>
+                                <rect key="frame" x="125" y="62" width="90" height="48"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="Polygon mainnet"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Polygon Mainnet"/>
                                 <connections>
                                     <action selector="PolyMainPressed:" destination="7fk-LF-non" eventType="touchUpInside" id="kLQ-Jm-zv4"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NAq-3e-gkr">
+                                <rect key="frame" x="125" y="118" width="90" height="48"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Polygon Mumbai"/>
+                                <connections>
+                                    <action selector="MumbaiPressed:" destination="7fk-LF-non" eventType="touchUpInside" id="iZQ-m7-GCk"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -432,9 +432,9 @@
                     </view>
                     <connections>
                         <outlet property="EthMainnetButton" destination="15d-vL-Ghe" id="U1l-Db-X6w"/>
-                        <outlet property="GoerliButton" destination="2at-6a-APP" id="Lhe-WC-nF1"/>
                         <outlet property="MumbaiButton" destination="NAq-3e-gkr" id="f2E-j4-R1Z"/>
                         <outlet property="PolygonMainnetButton" destination="kMQ-14-dCv" id="2c3-C5-QsZ"/>
+                        <outlet property="SepoliaButton" destination="2at-6a-APP" id="bVn-Sv-haa"/>
                         <outlet property="addressTextInput" destination="xEv-Ac-DYF" id="88M-H0-RU1"/>
                         <outlet property="addressTextInput2" destination="aPI-NR-DZw" id="kkj-nO-0AV"/>
                         <outlet property="connectButton" destination="Xyb-ta-tdQ" id="kIP-YV-aqE"/>
@@ -452,7 +452,7 @@
     </scenes>
     <resources>
         <systemColor name="labelColor">
-            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/SPM Example/PortalSwift/ConnectViewController.swift
+++ b/SPM Example/PortalSwift/ConnectViewController.swift
@@ -26,7 +26,7 @@ class ConnectViewController: UIViewController, UITextFieldDelegate {
   @IBOutlet var addressTextInput2: UITextField?
   @IBOutlet var PolygonMainnetButton: UIButton?
   @IBOutlet var EthMainnetButton: UIButton?
-  @IBOutlet var GoerliButton: UIButton?
+  @IBOutlet var SepoliaButton: UIButton?
   @IBOutlet var MumbaiButton: UIButton?
 
   required init?(coder: NSCoder) {
@@ -188,8 +188,8 @@ class ConnectViewController: UIViewController, UITextFieldDelegate {
     self.changeChainId(chainId: 137)
   }
 
-  @IBAction func GoerliPressed(_: Any) {
-    self.changeChainId(chainId: 5)
+  @IBAction func SepoliaPressed(_: Any) {
+    self.changeChainId(chainId: 11155111)
   }
 
   @IBAction func EthMainnetPressed(_: Any) {

--- a/SPM Example/PortalSwift/ConnectViewController.swift
+++ b/SPM Example/PortalSwift/ConnectViewController.swift
@@ -189,7 +189,7 @@ class ConnectViewController: UIViewController, UITextFieldDelegate {
   }
 
   @IBAction func SepoliaPressed(_: Any) {
-    self.changeChainId(chainId: 11155111)
+    self.changeChainId(chainId: 11_155_111)
   }
 
   @IBAction func EthMainnetPressed(_: Any) {

--- a/SPM Example/PortalSwift/Portal.swift
+++ b/SPM Example/PortalSwift/Portal.swift
@@ -98,7 +98,7 @@ class PortalWrapper {
     case cantLoadInfoPlist
   }
 
-  func registerPortal(apiKey: String, backup: BackupOptions, chainId: Int = 11155111, optimized: Bool = false, completion: @escaping (Result<Bool>) -> Void) {
+  func registerPortal(apiKey: String, backup: BackupOptions, chainId: Int = 11_155_111, optimized: Bool = false, completion: @escaping (Result<Bool>) -> Void) {
     do {
       guard let ALCHEMY_API_KEY: String = Bundle.main.infoDictionary?["ALCHEMY_API_KEY"] as? String else {
         print("Error: Do you have `ALCHEMY_API_KEY=$(ALCHEMY_API_KEY)` in your info.plist?")
@@ -112,7 +112,7 @@ class PortalWrapper {
         chainId: chainId,
         keychain: keychain,
         gatewayConfig: [
-          11155111: "https://eth-sepolia.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 1: "https://eth-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 80001: "https://polygon-mumbai.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 137: "https://polygon-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)",
+          11_155_111: "https://eth-sepolia.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 1: "https://eth-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 80001: "https://polygon-mumbai.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 137: "https://polygon-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)",
         ],
         autoApprove: false,
         apiHost: self.API_URL!,

--- a/SPM Example/PortalSwift/Portal.swift
+++ b/SPM Example/PortalSwift/Portal.swift
@@ -98,7 +98,7 @@ class PortalWrapper {
     case cantLoadInfoPlist
   }
 
-  func registerPortal(apiKey: String, backup: BackupOptions, chainId: Int = 5, optimized: Bool = false, completion: @escaping (Result<Bool>) -> Void) {
+  func registerPortal(apiKey: String, backup: BackupOptions, chainId: Int = 11155111, optimized: Bool = false, completion: @escaping (Result<Bool>) -> Void) {
     do {
       guard let ALCHEMY_API_KEY: String = Bundle.main.infoDictionary?["ALCHEMY_API_KEY"] as? String else {
         print("Error: Do you have `ALCHEMY_API_KEY=$(ALCHEMY_API_KEY)` in your info.plist?")
@@ -112,7 +112,7 @@ class PortalWrapper {
         chainId: chainId,
         keychain: keychain,
         gatewayConfig: [
-          5: "https://eth-goerli.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 1: "https://eth-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 80001: "https://polygon-mumbai.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 137: "https://polygon-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)",
+          11155111: "https://eth-sepolia.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 1: "https://eth-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 80001: "https://polygon-mumbai.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 137: "https://polygon-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)",
         ],
         autoApprove: false,
         apiHost: self.API_URL!,

--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -430,7 +430,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
 
   func getTransactions() {
     do {
-      try self.portal?.api.getTransactions(limit: 100, offset: 0, order: GetTransactionsOrder.asc, chainId: 11155111) { results in
+      try self.portal?.api.getTransactions(limit: 100, offset: 0, order: GetTransactionsOrder.asc, chainId: 11_155_111) { results in
         guard results.error == nil else {
           print("❌ Unable to get transactions", results.error ?? "")
           return

--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -430,7 +430,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
 
   func getTransactions() {
     do {
-      try self.portal?.api.getTransactions(limit: 100, offset: 0, order: GetTransactionsOrder.asc, chainId: 5) { results in
+      try self.portal?.api.getTransactions(limit: 100, offset: 0, order: GetTransactionsOrder.asc, chainId: 11155111) { results in
         guard results.error == nil else {
           print("❌ Unable to get transactions", results.error ?? "")
           return

--- a/SPM Example/Tests/e2e/PasswordWalletTests.swift
+++ b/SPM Example/Tests/e2e/PasswordWalletTests.swift
@@ -27,7 +27,7 @@ class PasswordWalletTests: XCTestCase {
     super.tearDown()
   }
 
-  func testLogin(chainId _: Int = 11155111, completion: @escaping (Result<Bool>) -> Void) {
+  func testLogin(chainId _: Int = 11_155_111, completion: @escaping (Result<Bool>) -> Void) {
     XCTContext.runActivity(named: "Login") { _ in
       let registerExpectation = XCTestExpectation(description: "Register")
 
@@ -70,7 +70,7 @@ class PasswordWalletTests: XCTestCase {
       let backupOption = LocalFileStorage(fileName: "PORTAL_BACKUP")
       let backup = BackupOptions(local: backupOption)
       print("registering portal")
-      PasswordWalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11155111, optimized: true) {
+      PasswordWalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11_155_111, optimized: true) {
         result in
         guard result.error == nil else {
           registerExpectation.fulfill()

--- a/SPM Example/Tests/e2e/PasswordWalletTests.swift
+++ b/SPM Example/Tests/e2e/PasswordWalletTests.swift
@@ -27,7 +27,7 @@ class PasswordWalletTests: XCTestCase {
     super.tearDown()
   }
 
-  func testLogin(chainId _: Int = 5, completion: @escaping (Result<Bool>) -> Void) {
+  func testLogin(chainId _: Int = 11155111, completion: @escaping (Result<Bool>) -> Void) {
     XCTContext.runActivity(named: "Login") { _ in
       let registerExpectation = XCTestExpectation(description: "Register")
 
@@ -70,7 +70,7 @@ class PasswordWalletTests: XCTestCase {
       let backupOption = LocalFileStorage(fileName: "PORTAL_BACKUP")
       let backup = BackupOptions(local: backupOption)
       print("registering portal")
-      PasswordWalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 5, optimized: true) {
+      PasswordWalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11155111, optimized: true) {
         result in
         guard result.error == nil else {
           registerExpectation.fulfill()

--- a/SPM Example/Tests/e2e/ProviderTests.swift
+++ b/SPM Example/Tests/e2e/ProviderTests.swift
@@ -43,7 +43,7 @@ class ProviderTests: XCTestCase {
         return expectation.fulfill()
       }
 
-      self.registerPortal(userResult: userResult, chainId: 5) { success in
+      self.registerPortal(userResult: userResult, chainId: 11155111) { success in
         guard success else {
           XCTFail("Failed on registering portal")
           return expectation.fulfill()
@@ -393,7 +393,7 @@ class ProviderTests: XCTestCase {
 
         print("Gateway response for eth_netVersion \(String(describing: version))")
         XCTAssert(!version.isEmpty, "Net version (chain id) should not be empty")
-        XCTAssert(version == "5", "Net version (chain id) should be empty 5 for goerli")
+        XCTAssert(version == "11155111", "Net version (chain id) should be empty 11155111 for Sepolia")
 
         expectation.fulfill()
       }
@@ -947,7 +947,7 @@ class ProviderTests: XCTestCase {
   func testEthGetTransactionBlockHashIndex() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 5) { success in
+    self.testLogin(chainId: 11155111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -971,7 +971,7 @@ class ProviderTests: XCTestCase {
   func testEthGetBlockTransactionCountHash() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 5) { success in
+    self.testLogin(chainId: 11155111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -995,7 +995,7 @@ class ProviderTests: XCTestCase {
   func testEthGetLogs() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 5) { success in
+    self.testLogin(chainId: 11155111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1079,7 +1079,7 @@ class ProviderTests: XCTestCase {
   func testNewFilter() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 5) { success in
+    self.testLogin(chainId: 11155111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1103,7 +1103,7 @@ class ProviderTests: XCTestCase {
   func testUninstallFilter() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 5) { success in
+    self.testLogin(chainId: 11155111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1127,7 +1127,7 @@ class ProviderTests: XCTestCase {
   func testEthGetBlockNumberFalse() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 5) { success in
+    self.testLogin(chainId: 11155111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1151,7 +1151,7 @@ class ProviderTests: XCTestCase {
   func testEthGetBlockNumberTrue() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 5) { success in
+    self.testLogin(chainId: 11155111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1207,7 +1207,7 @@ class ProviderTests: XCTestCase {
     case portalObjectNil
   }
 
-  func testLogin(chainId: Int = 5, completion: @escaping (Bool) -> Void) {
+  func testLogin(chainId: Int = 11155111, completion: @escaping (Bool) -> Void) {
     XCTContext.runActivity(named: "Login") { _ in
       let registerExpectation = XCTestExpectation(description: "Register")
 
@@ -1266,9 +1266,9 @@ class ProviderTests: XCTestCase {
         return completion(false)
       }
       XCTAssertTrue(!address.isEmpty, "The address should not be empty")
-      let goerliChain = 5
+      let sepoliaChainId = 11155111
 
-      ProviderTests.PortalWrap.transferFunds(user: userResult, amount: 0.01, chainId: goerliChain, address: address) { fundResult in
+      ProviderTests.PortalWrap.transferFunds(user: userResult, amount: 0.01, chainId: sepoliaChainId, address: address) { fundResult in
         guard fundResult.error == nil else {
           XCTFail("Could not fund wallet with test eth")
           return completion(false)

--- a/SPM Example/Tests/e2e/ProviderTests.swift
+++ b/SPM Example/Tests/e2e/ProviderTests.swift
@@ -393,7 +393,7 @@ class ProviderTests: XCTestCase {
 
         print("Gateway response for eth_netVersion \(String(describing: version))")
         XCTAssert(!version.isEmpty, "Net version (chain id) should not be empty")
-        XCTAssert(version == "11155111", "Net version (chain id) should be empty 11155111 for Sepolia")
+        XCTAssert(version == "11155111", "Net version (chain id) should be 11155111 for Sepolia")
 
         expectation.fulfill()
       }

--- a/SPM Example/Tests/e2e/ProviderTests.swift
+++ b/SPM Example/Tests/e2e/ProviderTests.swift
@@ -43,7 +43,7 @@ class ProviderTests: XCTestCase {
         return expectation.fulfill()
       }
 
-      self.registerPortal(userResult: userResult, chainId: 11155111) { success in
+      self.registerPortal(userResult: userResult, chainId: 11_155_111) { success in
         guard success else {
           XCTFail("Failed on registering portal")
           return expectation.fulfill()
@@ -947,7 +947,7 @@ class ProviderTests: XCTestCase {
   func testEthGetTransactionBlockHashIndex() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 11155111) { success in
+    self.testLogin(chainId: 11_155_111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -971,7 +971,7 @@ class ProviderTests: XCTestCase {
   func testEthGetBlockTransactionCountHash() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 11155111) { success in
+    self.testLogin(chainId: 11_155_111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -995,7 +995,7 @@ class ProviderTests: XCTestCase {
   func testEthGetLogs() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 11155111) { success in
+    self.testLogin(chainId: 11_155_111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1079,7 +1079,7 @@ class ProviderTests: XCTestCase {
   func testNewFilter() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 11155111) { success in
+    self.testLogin(chainId: 11_155_111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1103,7 +1103,7 @@ class ProviderTests: XCTestCase {
   func testUninstallFilter() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 11155111) { success in
+    self.testLogin(chainId: 11_155_111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1127,7 +1127,7 @@ class ProviderTests: XCTestCase {
   func testEthGetBlockNumberFalse() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 11155111) { success in
+    self.testLogin(chainId: 11_155_111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1151,7 +1151,7 @@ class ProviderTests: XCTestCase {
   func testEthGetBlockNumberTrue() throws {
     let expectation = XCTestExpectation(description: "Expecting valid uncle by block number index response")
 
-    self.testLogin(chainId: 11155111) { success in
+    self.testLogin(chainId: 11_155_111) { success in
       guard success else {
         XCTFail("Failed on login")
         return expectation.fulfill()
@@ -1207,7 +1207,7 @@ class ProviderTests: XCTestCase {
     case portalObjectNil
   }
 
-  func testLogin(chainId: Int = 11155111, completion: @escaping (Bool) -> Void) {
+  func testLogin(chainId: Int = 11_155_111, completion: @escaping (Bool) -> Void) {
     XCTContext.runActivity(named: "Login") { _ in
       let registerExpectation = XCTestExpectation(description: "Register")
 
@@ -1266,7 +1266,7 @@ class ProviderTests: XCTestCase {
         return completion(false)
       }
       XCTAssertTrue(!address.isEmpty, "The address should not be empty")
-      let sepoliaChainId = 11155111
+      let sepoliaChainId = 11_155_111
 
       ProviderTests.PortalWrap.transferFunds(user: userResult, amount: 0.01, chainId: sepoliaChainId, address: address) { fundResult in
         guard fundResult.error == nil else {

--- a/SPM Example/Tests/e2e/WalletTests.swift
+++ b/SPM Example/Tests/e2e/WalletTests.swift
@@ -27,7 +27,7 @@ class WalletTests: XCTestCase {
     super.tearDown()
   }
 
-  func testLogin(chainId _: Int = 5, completion: @escaping (Result<Bool>) -> Void) {
+  func testLogin(chainId _: Int = 11155111, completion: @escaping (Result<Bool>) -> Void) {
     XCTContext.runActivity(named: "Login") { _ in
       let registerExpectation = XCTestExpectation(description: "Register")
 
@@ -75,7 +75,7 @@ class WalletTests: XCTestCase {
       let backupOption = LocalFileStorage(fileName: "PORTAL_BACKUP")
       let backup = BackupOptions(local: backupOption)
       print("registering portal")
-      WalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 5, optimized: true) {
+      WalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11155111, optimized: true) {
         result in
         guard result.error == nil else {
           registerExpectation.fulfill()

--- a/SPM Example/Tests/e2e/WalletTests.swift
+++ b/SPM Example/Tests/e2e/WalletTests.swift
@@ -27,7 +27,7 @@ class WalletTests: XCTestCase {
     super.tearDown()
   }
 
-  func testLogin(chainId _: Int = 11155111, completion: @escaping (Result<Bool>) -> Void) {
+  func testLogin(chainId _: Int = 11_155_111, completion: @escaping (Result<Bool>) -> Void) {
     XCTContext.runActivity(named: "Login") { _ in
       let registerExpectation = XCTestExpectation(description: "Register")
 
@@ -75,7 +75,7 @@ class WalletTests: XCTestCase {
       let backupOption = LocalFileStorage(fileName: "PORTAL_BACKUP")
       let backup = BackupOptions(local: backupOption)
       print("registering portal")
-      WalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11155111, optimized: true) {
+      WalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11_155_111, optimized: true) {
         result in
         guard result.error == nil else {
           registerExpectation.fulfill()

--- a/Sources/PortalSwift/Core/PortalApi.swift
+++ b/Sources/PortalSwift/Core/PortalApi.swift
@@ -420,7 +420,7 @@ public struct DappImage: Codable {
   public var filename: String
 }
 
-/// A contract network. For example, chainId 5 is the Goerli network.
+/// A contract network. For example, chainId 11155111 is the Sepolia network.
 public struct ContractNetwork: Codable {
   public var id: String
   public var chainId: String

--- a/Sources/PortalSwift/Mocks/Utils/MockHttpRequester.swift
+++ b/Sources/PortalSwift/Mocks/Utils/MockHttpRequester.swift
@@ -71,7 +71,7 @@ public class MockHttpRequester: HttpRequester {
       completion(Result(data: mockResponse as! T))
 
     case "net_version":
-      let mockResponse = ETHGatewayResponse(jsonrpc: "2.0", result: "5")
+      let mockResponse = ETHGatewayResponse(jsonrpc: "2.0", result: "11155111")
       completion(Result(data: mockResponse as! T))
 
     case "eth_newBlockFilter":

--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -283,26 +283,26 @@ public class Portal {
   public func emit(_ event: Events.RawValue, data: Any) {
     _ = self.provider.emit(event: event, data: data)
   }
-  
+
   public func ethEstimateGas(
     transaction: ETHTransactionParam,
-    completion: @escaping(Result<RequestCompletionResult>) -> Void
+    completion: @escaping (Result<RequestCompletionResult>) -> Void
   ) {
     self.provider.request(payload: ETHRequestPayload(
       method: ETHRequestMethods.EstimateGas.rawValue,
       params: [transaction]
     ), completion: completion)
   }
-  
+
   public func ethGasPrice(
-    completion: @escaping(Result<RequestCompletionResult>) -> Void
+    completion: @escaping (Result<RequestCompletionResult>) -> Void
   ) {
     self.provider.request(payload: ETHRequestPayload(
       method: ETHRequestMethods.GasPrice.rawValue,
       params: []
     ), completion: completion)
   }
-  
+
   public func ethGetBalance(
     completion: @escaping (Result<RequestCompletionResult>) -> Void
   ) {

--- a/Sources/PortalSwift/Provider/PortalProvider.swift
+++ b/Sources/PortalSwift/Provider/PortalProvider.swift
@@ -770,7 +770,7 @@ public enum Chains: Int {
   case Ropsten = 3
   case Rinkeby = 4
   case Goerli = 5
-  case Sepolia = 11155111
+  case Sepolia = 11_155_111
   case Kovan = 42
 }
 

--- a/Sources/PortalSwift/Provider/PortalProvider.swift
+++ b/Sources/PortalSwift/Provider/PortalProvider.swift
@@ -748,7 +748,7 @@ public class PortalProvider {
   /// Determines the appropriate Gateway URL to use for the current chainId
   /// - Parameters:
   ///   - gatewayConfig: A dictionary of chainIds (keys) and gateway URLs (values).
-  ///   - chainId: The chainId we should use, such as 5 (Goerli).
+  ///   - chainId: The chainId we should use, such as 11155111 (Sepolia).
   /// - Throws: PortalArgumentError.noGatewayConfigForChain with the chainId.
   /// - Returns: The URL to be used for Gateway requests.
   static func getGatewayUrl(gatewayConfig: [Int: String], chainId: Int) throws -> String {
@@ -770,6 +770,7 @@ public enum Chains: Int {
   case Ropsten = 3
   case Rinkeby = 4
   case Goerli = 5
+  case Sepolia = 11155111
   case Kovan = 42
 }
 

--- a/Sources/PortalSwift/Utils/Chains.swift
+++ b/Sources/PortalSwift/Utils/Chains.swift
@@ -11,13 +11,13 @@ class ChainUtils {
   private static let chainIdToName: [Int: String] = [
     1: "mainnet",
     5: "goerli",
-    11155111: "sepolia",
+    11_155_111: "sepolia",
   ]
 
   private static let chainNameToId: [String: Int] = [
     "mainnet": 1,
     "goerli": 5,
-    "sepolia": 11155111,
+    "sepolia": 11_155_111,
   ]
 
   public static func getChainIdForName(_ chainName: String) -> Int? {

--- a/Sources/PortalSwift/Utils/Chains.swift
+++ b/Sources/PortalSwift/Utils/Chains.swift
@@ -11,11 +11,13 @@ class ChainUtils {
   private static let chainIdToName: [Int: String] = [
     1: "mainnet",
     5: "goerli",
+    11155111: "sepolia",
   ]
 
   private static let chainNameToId: [String: Int] = [
     "mainnet": 1,
     "goerli": 5,
+    "sepolia": 11155111,
   ]
 
   public static func getChainIdForName(_ chainName: String) -> Int? {

--- a/Tests/PortalSwiftTests/Core/PortalApiTests.swift
+++ b/Tests/PortalSwiftTests/Core/PortalApiTests.swift
@@ -15,8 +15,8 @@ final class PortalApiTests: XCTestCase {
   override func setUpWithError() throws {
     let provider = try MockPortalProvider(
       apiKey: mockApiKey,
-      chainId: 5,
-      gatewayConfig: [5: mockHost],
+      chainId: 11155111,
+      gatewayConfig: [11155111: mockHost],
       keychain: MockPortalKeychain(),
       autoApprove: true
     )

--- a/Tests/PortalSwiftTests/Core/PortalApiTests.swift
+++ b/Tests/PortalSwiftTests/Core/PortalApiTests.swift
@@ -15,8 +15,8 @@ final class PortalApiTests: XCTestCase {
   override func setUpWithError() throws {
     let provider = try MockPortalProvider(
       apiKey: mockApiKey,
-      chainId: 11155111,
-      gatewayConfig: [11155111: mockHost],
+      chainId: 11_155_111,
+      gatewayConfig: [11_155_111: mockHost],
       keychain: MockPortalKeychain(),
       autoApprove: true
     )

--- a/Tests/PortalSwiftTests/Core/PortalCoreTests.swift
+++ b/Tests/PortalSwiftTests/Core/PortalCoreTests.swift
@@ -20,8 +20,8 @@ final class PortalCoreTests: XCTestCase {
 
     let provider = try MockPortalProvider(
       apiKey: mockApiKey,
-      chainId: 5,
-      gatewayConfig: [5: mockHost],
+      chainId: 11155111,
+      gatewayConfig: [11155111: mockHost],
       keychain: keychain,
       autoApprove: true
     )
@@ -41,7 +41,7 @@ final class PortalCoreTests: XCTestCase {
       mobile: mobile
     )
 
-    self.portal = try Portal(apiKey: mockApiKey, backup: BackupOptions(icloud: MockICloudStorage()), chainId: 5, keychain: keychain, gatewayConfig: [5: mockHost], mpc: mpc, api: api, binary: mobile)
+    self.portal = try Portal(apiKey: mockApiKey, backup: BackupOptions(icloud: MockICloudStorage()), chainId: 11155111, keychain: keychain, gatewayConfig: [11155111: mockHost], mpc: mpc, api: api, binary: mobile)
   }
 
   override func tearDownWithError() throws {

--- a/Tests/PortalSwiftTests/Core/PortalCoreTests.swift
+++ b/Tests/PortalSwiftTests/Core/PortalCoreTests.swift
@@ -20,8 +20,8 @@ final class PortalCoreTests: XCTestCase {
 
     let provider = try MockPortalProvider(
       apiKey: mockApiKey,
-      chainId: 11155111,
-      gatewayConfig: [11155111: mockHost],
+      chainId: 11_155_111,
+      gatewayConfig: [11_155_111: mockHost],
       keychain: keychain,
       autoApprove: true
     )
@@ -41,7 +41,7 @@ final class PortalCoreTests: XCTestCase {
       mobile: mobile
     )
 
-    self.portal = try Portal(apiKey: mockApiKey, backup: BackupOptions(icloud: MockICloudStorage()), chainId: 11155111, keychain: keychain, gatewayConfig: [11155111: mockHost], mpc: mpc, api: api, binary: mobile)
+    self.portal = try Portal(apiKey: mockApiKey, backup: BackupOptions(icloud: MockICloudStorage()), chainId: 11_155_111, keychain: keychain, gatewayConfig: [11_155_111: mockHost], mpc: mpc, api: api, binary: mobile)
   }
 
   override func tearDownWithError() throws {

--- a/Tests/PortalSwiftTests/Provider/MpcSignerTests.swift
+++ b/Tests/PortalSwiftTests/Provider/MpcSignerTests.swift
@@ -20,8 +20,8 @@ final class MpcSignerTests: XCTestCase {
     self.signer = MpcSigner(apiKey: mockApiKey, keychain: self.keychain, binary: MockMobileWrapper())
     self.provider = try PortalProvider(
       apiKey: mockApiKey,
-      chainId: 5,
-      gatewayConfig: [5: mockHost],
+      chainId: 11155111,
+      gatewayConfig: [11155111: mockHost],
       keychain: MockPortalKeychain(),
       autoApprove: true,
       gateway: MockHttpRequester(baseUrl: mockHost)

--- a/Tests/PortalSwiftTests/Provider/MpcSignerTests.swift
+++ b/Tests/PortalSwiftTests/Provider/MpcSignerTests.swift
@@ -20,8 +20,8 @@ final class MpcSignerTests: XCTestCase {
     self.signer = MpcSigner(apiKey: mockApiKey, keychain: self.keychain, binary: MockMobileWrapper())
     self.provider = try PortalProvider(
       apiKey: mockApiKey,
-      chainId: 11155111,
-      gatewayConfig: [11155111: mockHost],
+      chainId: 11_155_111,
+      gatewayConfig: [11_155_111: mockHost],
       keychain: MockPortalKeychain(),
       autoApprove: true,
       gateway: MockHttpRequester(baseUrl: mockHost)

--- a/Tests/PortalSwiftTests/Provider/PortalMpcTests.swift
+++ b/Tests/PortalSwiftTests/Provider/PortalMpcTests.swift
@@ -19,8 +19,8 @@ final class PortalMpcTests: XCTestCase {
 
     self.provider = try MockPortalProvider(
       apiKey: mockApiKey,
-      chainId: 5,
-      gatewayConfig: [5: mockHost],
+      chainId: 11155111,
+      gatewayConfig: [11155111: mockHost],
       keychain: keychain,
       autoApprove: true
     )

--- a/Tests/PortalSwiftTests/Provider/PortalMpcTests.swift
+++ b/Tests/PortalSwiftTests/Provider/PortalMpcTests.swift
@@ -19,8 +19,8 @@ final class PortalMpcTests: XCTestCase {
 
     self.provider = try MockPortalProvider(
       apiKey: mockApiKey,
-      chainId: 11155111,
-      gatewayConfig: [11155111: mockHost],
+      chainId: 11_155_111,
+      gatewayConfig: [11_155_111: mockHost],
       keychain: keychain,
       autoApprove: true
     )

--- a/Tests/PortalSwiftTests/Provider/PortalProviderTests.swift
+++ b/Tests/PortalSwiftTests/Provider/PortalProviderTests.swift
@@ -16,8 +16,8 @@ final class PortalProviderTests: XCTestCase {
     // Put setup code here. This method is called before the invocation of each test method in the class.
     self.provider = try PortalProvider(
       apiKey: mockApiKey,
-      chainId: 5,
-      gatewayConfig: [5: mockHost],
+      chainId: 11155111,
+      gatewayConfig: [11155111: mockHost],
       keychain: MockPortalKeychain(),
       autoApprove: true,
       gateway: MockHttpRequester(baseUrl: mockHost)
@@ -264,7 +264,7 @@ final class PortalProviderTests: XCTestCase {
       }
 
       XCTAssert(!version.isEmpty, "Net version (chain id) should not be empty")
-      XCTAssert(version == "5", "Net version (chain id) should be empty 5 for goerli")
+      XCTAssert(version == "11155111", "Net version (chain id) should be empty 11155111 for Sepolia")
 
       expectation.fulfill()
     }
@@ -392,8 +392,8 @@ final class PortalProviderTests: XCTestCase {
   }
 
   func testSetChainId() throws {
-    let _ = try provider!.setChainId(value: 5)
-    XCTAssertEqual(self.provider!.chainId, 5)
+    let _ = try provider!.setChainId(value: 11155111)
+    XCTAssertEqual(self.provider!.chainId, 11155111)
   }
 
   func performRequest(method: String, params: [Any], completion: @escaping (Result<RequestCompletionResult>) -> Void) {

--- a/Tests/PortalSwiftTests/Provider/PortalProviderTests.swift
+++ b/Tests/PortalSwiftTests/Provider/PortalProviderTests.swift
@@ -264,7 +264,6 @@ final class PortalProviderTests: XCTestCase {
       }
 
       XCTAssert(!version.isEmpty, "Net version (chain id) should not be empty")
-      XCTAssert(version == "11155111", "Net version (chain id) should be empty 11155111 for Sepolia")
       XCTAssert(version == "11155111", "Net version (chain id) should be 11155111 for Sepolia")
 
       expectation.fulfill()

--- a/Tests/PortalSwiftTests/Provider/PortalProviderTests.swift
+++ b/Tests/PortalSwiftTests/Provider/PortalProviderTests.swift
@@ -265,6 +265,7 @@ final class PortalProviderTests: XCTestCase {
 
       XCTAssert(!version.isEmpty, "Net version (chain id) should not be empty")
       XCTAssert(version == "11155111", "Net version (chain id) should be empty 11155111 for Sepolia")
+      XCTAssert(version == "11155111", "Net version (chain id) should be 11155111 for Sepolia")
 
       expectation.fulfill()
     }

--- a/Tests/PortalSwiftTests/Provider/PortalProviderTests.swift
+++ b/Tests/PortalSwiftTests/Provider/PortalProviderTests.swift
@@ -16,8 +16,8 @@ final class PortalProviderTests: XCTestCase {
     // Put setup code here. This method is called before the invocation of each test method in the class.
     self.provider = try PortalProvider(
       apiKey: mockApiKey,
-      chainId: 11155111,
-      gatewayConfig: [11155111: mockHost],
+      chainId: 11_155_111,
+      gatewayConfig: [11_155_111: mockHost],
       keychain: MockPortalKeychain(),
       autoApprove: true,
       gateway: MockHttpRequester(baseUrl: mockHost)
@@ -392,8 +392,8 @@ final class PortalProviderTests: XCTestCase {
   }
 
   func testSetChainId() throws {
-    let _ = try provider!.setChainId(value: 11155111)
-    XCTAssertEqual(self.provider!.chainId, 11155111)
+    let _ = try provider!.setChainId(value: 11_155_111)
+    XCTAssertEqual(self.provider!.chainId, 11_155_111)
   }
 
   func performRequest(method: String, params: [Any], completion: @escaping (Result<RequestCompletionResult>) -> Void) {

--- a/Tests/PortalSwiftTests/Storage/ICloudStorageTests.swift
+++ b/Tests/PortalSwiftTests/Storage/ICloudStorageTests.swift
@@ -13,7 +13,7 @@ final class ICloudStorageTests: XCTestCase {
   var storage: ICloudStorage?
 
   override func setUpWithError() throws {
-    let provider = try MockPortalProvider(apiKey: "", chainId: 11155111, gatewayConfig: [11155111: "https://example.com"], keychain: MockPortalKeychain(), autoApprove: true)
+    let provider = try MockPortalProvider(apiKey: "", chainId: 11_155_111, gatewayConfig: [11_155_111: "https://example.com"], keychain: MockPortalKeychain(), autoApprove: true)
 
     self.storage = ICloudStorage()
     self.storage?.api = MockPortalApi(apiKey: "", apiHost: "", provider: provider)

--- a/Tests/PortalSwiftTests/Storage/ICloudStorageTests.swift
+++ b/Tests/PortalSwiftTests/Storage/ICloudStorageTests.swift
@@ -13,7 +13,7 @@ final class ICloudStorageTests: XCTestCase {
   var storage: ICloudStorage?
 
   override func setUpWithError() throws {
-    let provider = try MockPortalProvider(apiKey: "", chainId: 5, gatewayConfig: [5: "https://example.com"], keychain: MockPortalKeychain(), autoApprove: true)
+    let provider = try MockPortalProvider(apiKey: "", chainId: 11155111, gatewayConfig: [11155111: "https://example.com"], keychain: MockPortalKeychain(), autoApprove: true)
 
     self.storage = ICloudStorage()
     self.storage?.api = MockPortalApi(apiKey: "", apiHost: "", provider: provider)


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR replaces all goerli + `5` chain ID references in favor of sepolia + `11155111`.

## Details

### Code
- Checked against coding style guide: Yes
  <!-- - Deviations from the style guide: [List any deviations] -->
  <!-- - Potential style guide updates: [Any suggestions?] -->
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: Yes, updated
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: Yes, updated
  <!-- - If no, reason: [Reason here] -->
- Manual tests in staging: Pending
  <!-- - ![Screenshot or video link here if applicable] -->
- E2E tests in Datadog: Pending
  <!-- ![Screenshot of e2e tests passing] -->

### Misc.
- Metrics, logs, or traces added: No
- Changelog updated: No
  <!-- - If no, reason: [Reason here] -->
<!-- - Other notes: [Any other relevant notes] -->
