### PR TITLE
Adds `Send UNI` button to example app

### DIFF
--- a/PortalSwift.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PortalSwift.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,6 +10,24 @@
       }
     },
     {
+      "identity" : "bigint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attaswift/BigInt.git",
+      "state" : {
+        "revision" : "0ed110f7555c34ff468e72e1686e59721f2b0da6",
+        "version" : "5.3.0"
+      }
+    },
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "db51c407d3be4a051484a141bf0bff36c43d3b1e",
+        "version" : "1.8.0"
+      }
+    },
+    {
       "identity" : "googlesignin-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleSignIn-iOS.git",
@@ -37,12 +55,120 @@
       }
     },
     {
+      "identity" : "promisekit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mxcl/PromiseKit.git",
+      "state" : {
+        "revision" : "8a98e31a47854d3180882c8068cc4d9381bf382d",
+        "version" : "6.22.1"
+      }
+    },
+    {
+      "identity" : "secp256k1.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Boilertalk/secp256k1.swift.git",
+      "state" : {
+        "revision" : "cd187c632fb812fd93711a9f7e644adb7e5f97f0",
+        "version" : "0.1.7"
+      }
+    },
+    {
       "identity" : "starscream",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/daltoniam/Starscream.git",
       "state" : {
         "revision" : "ac6c0fc9da221873e01bd1a0d4818498a71eef33",
         "version" : "4.0.6"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a902f1823a7ff3c9ab2fba0f992396b948eda307",
+        "version" : "1.0.5"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "1827dc94bdab2eb5f2fc804e9b0cb43574282566",
+        "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "702cd7c56d5d44eeba73fdf83918339b26dc855c",
+        "version" : "2.62.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "798c962495593a23fdea0c0c63fd55571d8dff51",
+        "version" : "1.20.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "3bd9004b9d685ed6b629760fc84903e48efec806",
+        "version" : "1.29.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "320bd978cceb8e88c125dcbb774943a92f6286e9",
+        "version" : "2.25.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "ebf8b9c365a6ce043bf6e6326a04b15589bd285e",
+        "version" : "1.20.0"
+      }
+    },
+    {
+      "identity" : "web3.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Boilertalk/Web3.swift",
+      "state" : {
+        "revision" : "808d6c70daa10186d0084f44b3dfa2b8d4c88789",
+        "version" : "0.8.4"
+      }
+    },
+    {
+      "identity" : "websocket-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/websocket-kit",
+      "state" : {
+        "revision" : "53fe0639a98903858d0196b699720decb42aee7b",
+        "version" : "2.14.0"
       }
     }
   ],

--- a/SPM Example/PortalSwift/Base.lproj/Main.storyboard
+++ b/SPM Example/PortalSwift/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,7 +11,7 @@
         <!--View Controller-->
         <scene sceneID="ufC-wZ-h7g">
             <objects>
-                <viewController storyboardIdentifier="Main" id="vXZ-lx-hvc" customClass="ViewController" customModule="PortalSwift_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Main" id="vXZ-lx-hvc" customClass="ViewController" customModule="SPM_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="jyV-Pf-zRb"/>
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
@@ -190,7 +190,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="portalConnectButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Oix-QY-d5L">
-                                <rect key="frame" x="17" y="603" width="342" height="35"/>
+                                <rect key="frame" x="17" y="603" width="152" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Portal Connect">
@@ -241,6 +241,16 @@
                                     <action selector="handleLegacyRecover:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="0HD-Qe-Ets"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jpZ-X5-eUU">
+                                <rect key="frame" x="210" y="602" width="149" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Send UNI"/>
+                                <connections>
+                                    <action selector="sendERC20Token" destination="vXZ-lx-hvc" eventType="touchUpInside" id="i4w-uu-wPs"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
@@ -273,7 +283,7 @@
         <!--Web View Controller-->
         <scene sceneID="AeA-zC-7Sc">
             <objects>
-                <viewController id="R0A-w7-x9S" customClass="WebViewController" customModule="PortalSwift_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="R0A-w7-x9S" customClass="WebViewController" customModule="SPM_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="fSO-SS-BfH"/>
                         <viewControllerLayoutGuide type="bottom" id="fg1-21-qPe"/>
@@ -291,7 +301,7 @@
         <!--Connect View Controller-->
         <scene sceneID="94S-6a-j1d">
             <objects>
-                <viewController storyboardIdentifier="Connect" useStoryboardIdentifierAsRestorationIdentifier="YES" id="7fk-LF-non" customClass="ConnectViewController" customModule="PortalSwift_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Connect" useStoryboardIdentifierAsRestorationIdentifier="YES" id="7fk-LF-non" customClass="ConnectViewController" customModule="SPM_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="zXS-6W-gVU"/>
                         <viewControllerLayoutGuide type="bottom" id="qa6-Jg-pyi"/>
@@ -452,7 +462,7 @@
     </scenes>
     <resources>
         <systemColor name="labelColor">
-            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -8,6 +8,8 @@
 
 import PortalSwift
 import UIKit
+import Web3
+import Web3ContractABI
 
 struct SignUpBody: Codable {
   var username: String
@@ -563,6 +565,74 @@ class ViewController: UIViewController, UITextFieldDelegate {
       }
 
       print("✅ handleSign(): Successfully signed:", result.data ?? "")
+    }
+  }
+
+  func sendERC20Token(tokenAddress: String, toAddress: String, amount: Int64) throws {
+    // Get the Gateway URL from the Portal Provider
+    guard let gatewayUrl = portal?.provider.gatewayUrl else {
+      return
+    }
+
+    // Ensure the Portal Address is set
+    guard let address = portal?.address else {
+      // Probably throw an error here
+      return
+    }
+
+    // Initialize Web3
+    let web3 = Web3(rpcURL: gatewayUrl)
+
+    do {
+      // Transform the receiver address
+      let receiverAddress = try EthereumAddress(hex: toAddress, eip55: false) // eip55 is dependent on the wallet receiving funds
+
+      // Transfor the sender address
+      let senderAddress = try EthereumAddress(hex: address, eip55: false) // eip55 will be false for Portal MPC Wallets
+
+      // Transform the token address
+      let tokenContractAddress = try EthereumAddress(hex: tokenAddress, eip55: true) // eip55 will be true for Token Contracts
+
+      // Initialize the token contract
+      let contract = web3.eth.Contract(
+        type: GenericERC20Contract.self,
+        address: tokenContractAddress
+      )
+
+      // Generate the transaction for Portal to execute
+      guard let tx = contract
+        .transfer(to: receiverAddress, value: BigUInt(amount))
+        .createTransaction(
+          nonce: 0, // Here you'd want to provide the actual nonce for this transaction
+          gasPrice: EthereumQuantity(quantity: 21.gwei),
+          maxFeePerGas: nil,
+          maxPriorityFeePerGas: nil,
+          gasLimit: 100_000,
+          from: senderAddress,
+          value: 0,
+          accessList: [:],
+          transactionType: .legacy
+        ) else { return }
+
+      // Ensure gasPrice was properly set
+      guard let gasPrice = tx.gasPrice?.hex() else {
+        // Probably throw an error here
+        return
+      }
+
+      // Send the transaction
+      self.portal?.ethSendTransaction(transaction: ETHTransactionParam(
+        from: address,
+        to: tokenAddress,
+        gasPrice: gasPrice,
+        value: "0x0",
+        data: tx.data.hex(),
+        nonce: tx.nonce?.hex()
+      )) { (_: Result<TransactionCompletionResult>) in
+        // Handle result of submitting transaction
+      }
+    } catch {
+      // Handle errors
     }
   }
 

--- a/SPM Example/SPM Example.xcodeproj/project.pbxproj
+++ b/SPM Example/SPM Example.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		607FACEC1AFB9204008FA782 /* WalletTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* WalletTests.swift */; };
 		7E1A4FDB2AF46A1B00A6F7A5 /* PortalSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7E1A4FDA2AF46A1B00A6F7A5 /* PortalSwift */; };
 		7E4B874E2A58BFFB003A8DB5 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4B874D2A58BFFB003A8DB5 /* WebViewController.swift */; };
+		7E4DC8F02B1E69080002834B /* Web3 in Frameworks */ = {isa = PBXBuildFile; productRef = 7E4DC8EF2B1E69080002834B /* Web3 */; };
+		7E4DC8F22B1E69080002834B /* Web3ContractABI in Frameworks */ = {isa = PBXBuildFile; productRef = 7E4DC8F12B1E69080002834B /* Web3ContractABI */; };
+		7E4DC8F42B1E69080002834B /* Web3PromiseKit in Frameworks */ = {isa = PBXBuildFile; productRef = 7E4DC8F32B1E69080002834B /* Web3PromiseKit */; };
 		7E7F4C002A002D7F00756B6A /* ConnectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7F4BFF2A002D7F00756B6A /* ConnectViewController.swift */; };
 		7EDEB9F72AF4ACC9005E8C7F /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 7EDEB9F62AF4ACC9005E8C7F /* Secrets.xcconfig */; };
 		7EDEB9F82AF4ACC9005E8C7F /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 7EDEB9F62AF4ACC9005E8C7F /* Secrets.xcconfig */; };
@@ -62,7 +65,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7E4DC8F22B1E69080002834B /* Web3ContractABI in Frameworks */,
 				7E1A4FDB2AF46A1B00A6F7A5 /* PortalSwift in Frameworks */,
+				7E4DC8F42B1E69080002834B /* Web3PromiseKit in Frameworks */,
+				7E4DC8F02B1E69080002834B /* Web3 in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -177,6 +183,9 @@
 			name = "SPM Example";
 			packageProductDependencies = (
 				7E1A4FDA2AF46A1B00A6F7A5 /* PortalSwift */,
+				7E4DC8EF2B1E69080002834B /* Web3 */,
+				7E4DC8F12B1E69080002834B /* Web3ContractABI */,
+				7E4DC8F32B1E69080002834B /* Web3PromiseKit */,
 			);
 			productName = PortalSwift;
 			productReference = 607FACD01AFB9204008FA782 /* SPM Example.app */;
@@ -238,6 +247,7 @@
 			mainGroup = 607FACC71AFB9204008FA782;
 			packageReferences = (
 				7E1A4FD92AF46A1B00A6F7A5 /* XCLocalSwiftPackageReference ".." */,
+				7E4DC8EE2B1E69080002834B /* XCRemoteSwiftPackageReference "Web3" */,
 			);
 			productRefGroup = 607FACD11AFB9204008FA782 /* Products */;
 			projectDirPath = "";
@@ -582,10 +592,36 @@
 		};
 /* End XCLocalSwiftPackageReference section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		7E4DC8EE2B1E69080002834B /* XCRemoteSwiftPackageReference "Web3" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Boilertalk/Web3.swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.8.4;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		7E1A4FDA2AF46A1B00A6F7A5 /* PortalSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = PortalSwift;
+		};
+		7E4DC8EF2B1E69080002834B /* Web3 */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7E4DC8EE2B1E69080002834B /* XCRemoteSwiftPackageReference "Web3" */;
+			productName = Web3;
+		};
+		7E4DC8F12B1E69080002834B /* Web3ContractABI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7E4DC8EE2B1E69080002834B /* XCRemoteSwiftPackageReference "Web3" */;
+			productName = Web3ContractABI;
+		};
+		7E4DC8F32B1E69080002834B /* Web3PromiseKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7E4DC8EE2B1E69080002834B /* XCRemoteSwiftPackageReference "Web3" */;
+			productName = Web3PromiseKit;
 		};
 		7EDEB9FB2AF59EC3005E8C7F /* PortalSwift */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->

Adds `Send UNI` button to example app. Since `Web3.swift` doesn't support Cocoapods, I've excluded this update from the `Cocoapods Example` app.