### PR TITLE
HOTFIX - ENG-1980 - Add support for PortalWebViewDelegate

### DIFF
--- a/Cocoapods Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Cocoapods Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		7BF9C8BA9229B5C13F1FF2214DCEB7EC /* PortalSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0742BF669F1AD39C9E8E283871646FFF /* PortalSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7C67CBD15D9B5D0B7769B2F469478332 /* FBSnapshotTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = EDE864ECC1E67F6A8D50CA0EB95FE26B /* FBSnapshotTestCase.m */; };
 		7DE2731ABF0A9B3DB57426EEB17BC1A8 /* NativeEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367DF94475CB58FA300719CC7C21934F /* NativeEngine.swift */; };
+		7E7005D62B223FDB00534246 /* PortalWebViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7005D52B223FDB00534246 /* PortalWebViewDelegate.swift */; };
 		7ECA1AE07A77457A0CA3EC39ED873274 /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 833AAF9E2791D276B133EB166B930F7E /* LocalAuthentication.framework */; };
 		7F6E015D616C80C1FDC9C2EBAACD8BF4 /* OIDEndSessionRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 599E3D46C58E1FA0CBEDB7BB8C6329E2 /* OIDEndSessionRequest.m */; };
 		7F719C2169F73F0AC6450A1CF23B4D29 /* Portal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BB6330A40B5EC391482872BDE28550 /* Portal.swift */; };
@@ -617,6 +618,7 @@
 		7D6C3466A304003B8826812379963DD9 /* PortalProviderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PortalProviderTests.swift; sourceTree = "<group>"; };
 		7D8662EFB4FAC42189A609FFAC578053 /* OIDFieldMapping.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OIDFieldMapping.h; path = Source/AppAuthCore/OIDFieldMapping.h; sourceTree = "<group>"; };
 		7E3750AD99F728616332AE37CAA945C9 /* GIDProfileData_Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GIDProfileData_Private.h; path = GoogleSignIn/Sources/GIDProfileData_Private.h; sourceTree = "<group>"; };
+		7E7005D52B223FDB00534246 /* PortalWebViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalWebViewDelegate.swift; sourceTree = "<group>"; };
 		7F72CEDA4AB1253CFEDA8319A60F1934 /* MockMpcMobileErrors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MockMpcMobileErrors.swift; sourceTree = "<group>"; };
 		808CDF5B25EE92B6142641D53F4E3EF2 /* LocalFileStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalFileStorage.swift; sourceTree = "<group>"; };
 		80E67469BC6004EA71E9BD8B3F8E77BB /* GIDGoogleUser.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GIDGoogleUser.h; path = GoogleSignIn/Sources/Public/GoogleSignIn/GIDGoogleUser.h; sourceTree = "<group>"; };
@@ -1247,6 +1249,7 @@
 			isa = PBXGroup;
 			children = (
 				192A62AED4237CCEED4562F343F997DF /* PortalWebView.swift */,
+				7E7005D52B223FDB00534246 /* PortalWebViewDelegate.swift */,
 			);
 			name = Components;
 			path = Sources/PortalSwift/Components;
@@ -2584,6 +2587,7 @@
 				FFA557CFE3A969A91820E04D04348290 /* PortalApi.swift in Sources */,
 				B86F2D6423159E1BEB8E50F0B1A957CD /* PortalConnect.swift in Sources */,
 				7F842524CE868B19BBDCEC4950B613EE /* PortalError.swift in Sources */,
+				7E7005D62B223FDB00534246 /* PortalWebViewDelegate.swift in Sources */,
 				502F870E81F00091D153932FC59A3F54 /* PortalErrorCodes.swift in Sources */,
 				1099B1B19CD287A43D2AD8FF11F13298 /* PortalErrorCodeTypes.swift in Sources */,
 				04F09861FF07ABE8481944459ADC6A1C /* PortalKeychain.swift in Sources */,

--- a/Cocoapods Example/PortalSwift/WebViewController.swift
+++ b/Cocoapods Example/PortalSwift/WebViewController.swift
@@ -8,8 +8,9 @@
 
 import PortalSwift
 import SwiftUI
+import WebKit
 
-class WebViewController: UIViewController {
+class WebViewController: UIViewController, PortalWebViewDelegate {
   public var portal: Portal?
   public var url: String?
 
@@ -47,6 +48,7 @@ class WebViewController: UIViewController {
         onPageStart: onPageStart,
         onPageComplete: onPageComplete
       )
+      webViewController.delegate = self
 
       // Install the WebViewController as a child view controller.
       addChild(webViewController)
@@ -95,6 +97,11 @@ class WebViewController: UIViewController {
       print("❌ Error in nested PortalWebviewError:", nestedError)
       return
     }
+  }
+  
+  public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+    print("✅ Delegate method fired!", webView, navigationAction, decisionHandler)
+    decisionHandler(.allow)
   }
 }
 

--- a/SPM Example/PortalSwift/WebViewController.swift
+++ b/SPM Example/PortalSwift/WebViewController.swift
@@ -8,8 +8,9 @@
 
 import PortalSwift
 import SwiftUI
+import WebKit
 
-class WebViewController: UIViewController {
+class WebViewController: UIViewController, PortalWebViewDelegate {
   public var portal: Portal?
   public var url: String?
 
@@ -35,7 +36,15 @@ class WebViewController: UIViewController {
         return
       }
 
-      let webViewController = PortalWebView(portal: portal, url: url, onError: onError, onPageStart: onPageStart, onPageComplete: onPageComplete)
+      let webViewController = PortalWebView(
+        portal: portal,
+        url: url,
+        onError: onError,
+        onPageStart: onPageStart,
+        onPageComplete: onPageComplete
+      )
+      
+      webViewController.delegate = self
 
       // Install the WebViewController as a child view controller.
       addChild(webViewController)
@@ -78,6 +87,11 @@ class WebViewController: UIViewController {
       print("❌ Error in nested PortalWebviewError:", nestedError)
       return
     }
+  }
+  
+  public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+    print("✅ Delegate method fired!", webView, navigationAction, decisionHandler)
+    decisionHandler(.allow)
   }
 }
 

--- a/Sources/PortalSwift/Components/PortalWebView.swift
+++ b/Sources/PortalSwift/Components/PortalWebView.swift
@@ -35,6 +35,7 @@ enum WebViewControllerErrors: Error {
 
 /// A controller that allows you to create Portal's web view.
 public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMessageHandler {
+  public var delegate: PortalWebViewDelegate?
   public var webView: WKWebView!
   public var webViewContentIsLoaded = false
 
@@ -148,12 +149,20 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
       completion?(error?.localizedDescription)
     }
   }
+  
+  public func webView(
+    _ webView: WKWebView,
+    decidePolicyFor navigationAction: WKNavigationAction,
+    decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+  ) {
+    self.delegate?.webView(webView, decidePolicyFor: navigationAction, decisionHandler: decisionHandler)
+  }
 
   /// Called when the web view starts loading a new page.
   /// - Parameters:
   ///   - webView: The WKWebView instance that started loading.
   ///   - navigation: The navigation information associated with the event.
-  public func webView(_: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
+  public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
     self.onPageStart?()
   }
 
@@ -161,7 +170,7 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
   /// - Parameters:
   ///   - webView: The WKWebView instance that finished loading.
   ///   - navigation: The navigation information associated with the event.
-  public func webView(_: WKWebView, didFinish _: WKNavigation!) {
+  public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
     guard let address = portal.address else {
       print("[PortalWebView] No address found for user. Cannot inject provider into web page.")
       return
@@ -180,6 +189,7 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
 
     self.onPageComplete?()
   }
+  
 
   /// The controller used to handle messages to and from the web view.
   /// - Parameters:

--- a/Sources/PortalSwift/Components/PortalWebViewDelegate.swift
+++ b/Sources/PortalSwift/Components/PortalWebViewDelegate.swift
@@ -1,0 +1,22 @@
+//
+//  PortalWebViewDelegate.swift
+//  PortalSwift
+//
+//  Created by Blake Williams on 12/7/23.
+//
+
+import Foundation
+import WebKit
+
+public protocol PortalWebViewDelegate: NSObjectProtocol {
+  /** @abstract Decides whether to allow or cancel a navigation.
+   @param webView The web view invoking the delegate method.
+   @param navigationAction Descriptive information about the action
+   triggering the navigation request.
+   @param decisionHandler The decision handler to call to allow or cancel the
+   navigation. The argument is one of the constants of the enumerated type WKNavigationActionPolicy.
+   @discussion If you do not implement this method, the web view will load the request or, if appropriate, forward it to another application.
+   */
+  @available(iOS 8.0, *)
+  func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void)
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->

This exposes a `PortalWebViewDelegate` protocol, allowing customers to hook into the `decidePolicyFor` delegate method. This will unblock Bitso in setting up WalletConnect deep linking.

## Visuals
<!-- Attach screenshots or videos of any visual changes. If none, delete this section. -->

<img width="622" alt="Screenshot 2023-12-07 at 10 47 26 AM" src="https://github.com/portal-hq/PortalSwift/assets/372400/dff859f1-366f-46c5-ae15-74510506978d">


## Details

### Code
- Checked against coding style guide: Yes
  <!-- - Deviations from the style guide: [List any deviations] -->
  <!-- - Potential style guide updates: [Any suggestions?] -->
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->
- Manual tests in staging: Pending
  <!-- - ![Screenshot or video link here if applicable] -->
- E2E tests in Datadog: No
  <!-- ![Screenshot of e2e tests passing] -->

### Misc.
- Metrics, logs, or traces added: No
- Changelog updated: No
  <!-- - If no, reason: [Reason here] -->
<!-- - Other notes: [Any other relevant notes] -->
