### PR TITLE
Add support for v6

### DIFF
--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Connect/PortalConnect.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Connect/PortalConnect.swift
@@ -52,7 +52,7 @@ public class PortalConnect: EventBus {
     _ autoApprove: Bool = false,
     _ apiHost: String = "api.portalhq.io",
     _ mpcHost: String = "mpc.portalhq.io",
-    _ version: String = "v5"
+    _ version: String = "v6"
   ) throws {
     self.apiKey = apiKey
     self.webSocketServer = webSocketServer

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Core/mpc/MpcMobileProtocol.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Core/mpc/MpcMobileProtocol.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public struct MpcMetadata: Codable {
+  var backupMethod: BackupMethods.RawValue?
   var clientPlatform: String
   var mpcServerVersion: String
   var optimized: Bool

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Core/mpc/PortalMpc.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Core/mpc/PortalMpc.swift
@@ -42,7 +42,7 @@ public class PortalMpc {
   private let rsaFooter = "\n-----END RSA KEY-----"
   private var isWalletModificationInProgress: Bool = false
   private var isMock: Bool = false
-  private let mpcMetadata: MpcMetadata
+  private var mpcMetadata: MpcMetadata
 
   /// Create an instance of Portal's MPC service.
   public init(
@@ -52,7 +52,7 @@ public class PortalMpc {
     storage: BackupOptions,
     isSimulator: Bool = false,
     host: String = "mpc.portalhq.io",
-    version: String = "v5",
+    version: String = "v6",
     mobile: Mobile,
     apiHost: String = "api.portalhq.io",
     featureFlags: FeatureFlags? = nil
@@ -78,7 +78,7 @@ public class PortalMpc {
   }
 
   public func getBinaryVersion() -> String {
-    return self.mobile.MobileGetVersion()
+    self.mobile.MobileGetVersion()
   }
 
   /// Creates a backup share, encrypts it, and stores the private key in cloud storage.
@@ -91,8 +91,8 @@ public class PortalMpc {
     completion: @escaping (Result<String>) -> Void,
     progress: ((MpcStatus) -> Void)? = nil
   ) {
-    if self.version != "v5" {
-      return completion(Result(error: MpcError.backupNoLongerSupported(message: "[PortalMpc] Backup is no longer supported for this version of MPC. Please use `version = v5`.")))
+    if self.version != "v6" {
+      return completion(Result(error: MpcError.backupNoLongerSupported(message: "[PortalMpc] Backup is no longer supported for this version of MPC. Please use `version = v6`.")))
     }
 
     guard !self.isWalletModificationInProgress else {
@@ -132,6 +132,15 @@ public class PortalMpc {
             }
 
             progress?(MpcStatus(status: MpcStatuses.done, done: true))
+
+            // Capture analytics.
+            do {
+              try self.api.identify { _ in }
+              self.api.track(event: MetricsEvents.walletBackedUp.rawValue, properties: [:])
+            } catch {
+              // Do nothing.
+            }
+
             self.isWalletModificationInProgress = false
             return completion(backupResult)
           } progress: { status in
@@ -154,6 +163,16 @@ public class PortalMpc {
           } progress: { status in
             progress?(status)
           }
+        }
+      } else if method == BackupMethods.Passkey.rawValue {
+        print("Validating Passkey Storage is available...")
+        // @TODO add a validation method for passkeys
+        print("Passkey Storage is available, starting backup...")
+
+        self.executeBackup(storage: storage, signingShare: signingShare, backupMethod: method) { backupResult in
+          self.handleExecuteBackupCompletion(result: backupResult, progress: progress, completion: completion)
+        } progress: { status in
+          progress?(status)
         }
       } else if method == BackupMethods.Password.rawValue {
         print("Starting Password Storage...")
@@ -194,6 +213,15 @@ public class PortalMpc {
     }
 
     progress?(MpcStatus(status: MpcStatuses.done, done: true))
+
+    // Capture analytics.
+    do {
+      try self.api.identify { _ in }
+      self.api.track(event: MetricsEvents.walletBackedUp.rawValue, properties: [:])
+    } catch {
+      // Do nothing.
+    }
+
     self.isWalletModificationInProgress = false
     return completion(result)
   }
@@ -202,9 +230,9 @@ public class PortalMpc {
   /// - Returns: The address of the newly created MPC wallet.
   public func generate(completion: @escaping (Result<String>) -> Void, progress: ((MpcStatus) -> Void)? = nil) {
     DispatchQueue.global(qos: .background).async { [self] in
-      if self.version != "v5" {
+      if self.version != "v6" {
         let result = Result<String>(error: MpcError.generateNoLongerSupported(
-          message: "[PortalMpc] Generate is no longer supported for this version of MPC. Please use `version = v5`."
+          message: "[PortalMpc] Generate is no longer supported for this version of MPC. Please use `version = v6`."
         ))
         completion(result)
       }
@@ -287,6 +315,14 @@ public class PortalMpc {
 
                   progress?(MpcStatus(status: MpcStatuses.done, done: true))
 
+                  // Capture analytics.
+                  do {
+                    try self.api.identify { _ in }
+                    self.api.track(event: MetricsEvents.walletCreated.rawValue, properties: [:])
+                  } catch {
+                    // Do nothing.
+                  }
+
                   // Return the address.
                   self.isWalletModificationInProgress = false
                   return completion(Result(data: address))
@@ -317,8 +353,8 @@ public class PortalMpc {
     completion: @escaping (Result<String>) -> Void,
     progress: ((MpcStatus) -> Void)? = nil
   ) {
-    if self.version != "v5" {
-      return completion(Result(error: MpcError.recoverNoLongerSupported(message: "[PortalMpc] Recover is no longer supported for this version of MPC. Please use `version = v5`.")))
+    if self.version != "v6" {
+      return completion(Result(error: MpcError.recoverNoLongerSupported(message: "[PortalMpc] Recover is no longer supported for this version of MPC. Please use `version = v6`.")))
     }
 
     guard !self.isWalletModificationInProgress else {
@@ -363,6 +399,15 @@ public class PortalMpc {
               return completion(Result(error: recoveryResult.error!))
             }
             progress?(MpcStatus(status: MpcStatuses.done, done: true))
+
+            // Capture analytics.
+            do {
+              try self.api.identify { _ in }
+              self.api.track(event: MetricsEvents.walletRecovered.rawValue, properties: [:])
+            } catch {
+              // Do nothing.
+            }
+
             self.isWalletModificationInProgress = false
             return completion(Result(data: recoveryResult.data!))
           } progress: { status in
@@ -386,12 +431,37 @@ public class PortalMpc {
               return completion(Result(error: recoveryResult.error!))
             }
             progress?(MpcStatus(status: MpcStatuses.done, done: true))
+
+            // Capture analytics.
+            do {
+              try self.api.identify { _ in }
+              self.api.track(event: MetricsEvents.walletRecovered.rawValue, properties: [:])
+            } catch {
+              // Do nothing.
+            }
+
             self.isWalletModificationInProgress = false
             return completion(Result(data: recoveryResult.data!))
           } progress: { status in
             progress?(status)
           }
         }
+      } else if method == BackupMethods.Passkey.rawValue {
+        print("Validating Passkey Storage is available...")
+        // @TODO add a validation method for passkeys
+        print("Passkey Storage is available, starting recovery...")
+        self.executeRecovery(storage: storage!, method: method, cipherText: cipherText) { recoveryResult in
+          if recoveryResult.error != nil {
+            self.isWalletModificationInProgress = false
+            return completion(Result(error: recoveryResult.error!))
+          }
+          progress?(MpcStatus(status: MpcStatuses.done, done: true))
+          self.isWalletModificationInProgress = false
+          return completion(Result(data: recoveryResult.data!))
+        } progress: { status in
+          progress?(status)
+        }
+
       } else if method == BackupMethods.local.rawValue || method == BackupMethods.Password.rawValue {
         self.executeRecovery(storage: storage!, method: method, backupConfigs: backupConfigs, cipherText: cipherText) { recoveryResult in
           if recoveryResult.error != nil {
@@ -399,6 +469,15 @@ public class PortalMpc {
             return completion(Result(error: recoveryResult.error!))
           }
           progress?(MpcStatus(status: MpcStatuses.done, done: true))
+
+          // Capture analytics.
+          do {
+            try self.api.identify { _ in }
+            self.api.track(event: MetricsEvents.walletRecovered.rawValue, properties: [:])
+          } catch {
+            // Do nothing.
+          }
+
           self.isWalletModificationInProgress = false
           return completion(Result(data: recoveryResult.data!))
         } progress: { status in
@@ -423,8 +502,8 @@ public class PortalMpc {
     completion: @escaping (Result<String>) -> Void,
     progress: ((MpcStatus) -> Void)? = nil
   ) {
-    if self.version != "v5" {
-      return completion(Result(error: MpcError.recoverNoLongerSupported(message: "[PortalMpc] Recover is no longer supported for this version of MPC. Please use `version = v5`.")))
+    if self.version != "v6" {
+      return completion(Result(error: MpcError.recoverNoLongerSupported(message: "[PortalMpc] Recover is no longer supported for this version of MPC. Please use `version = v6`.")))
     }
 
     guard !self.isWalletModificationInProgress else {
@@ -603,6 +682,9 @@ public class PortalMpc {
     progress: ((MpcStatus) -> Void)? = nil
   ) {
     do {
+      // Add the backup method.
+      self.mpcMetadata.backupMethod = backupMethod
+
       // Stringify the MPC metadata.
       let mpcMetadataString = self.mpcMetadata.jsonString() ?? ""
 
@@ -636,7 +718,7 @@ public class PortalMpc {
       } else {
         // Encrypt the backup share.
         self.encryptShare(mpcShare: backupShare) { encryptedResult in
-          self.handleEncryptedShareCompletion(encryptedResult: encryptedResult, storage: storage, backupMethod: backupMethod, progress: progress, completion: completion)
+          self.handleEncryptedShareCompletion(encryptedResult: encryptedResult, storage: storage, backupMethod: backupMethod, backupSharePairId: backupShare.backupSharePairId!, progress: progress, completion: completion)
         } progress: { status in
           progress?(status)
         }
@@ -659,10 +741,8 @@ public class PortalMpc {
     }
 
     do {
-      // Call api to update backup method + update backup status to `STORED_CLIENT_BACKUP_SHARE_KEY`.
-      let formattedBackupMethod = self.formatBackupMethod(backupMethod: backupMethod)
-      print(formattedBackupMethod)
-      try self.api.storedClientBackupShareKey(backupMethod: formattedBackupMethod) { (apiResult: Result<String>) in
+      // Call api to update backup status to `STORED_CLIENT_BACKUP_SHARE_KEY`.
+      try self.api.storedClientBackupShareKey(success: true, backupMethod: backupMethod) { (apiResult: Result<String>) in
         // Throw an error if we can't update the backup status + save the backup method.
         if let error = apiResult.error {
           return completion(Result(error: error))
@@ -692,9 +772,8 @@ public class PortalMpc {
     progress?(MpcStatus(status: MpcStatuses.storingShare, done: false))
 
     do {
-      // Call api to update backup method + update backup status to `STORED_CLIENT_BACKUP_SHARE_KEY`.
-      let formattedBackupMethod = self.formatBackupMethod(backupMethod: backupMethod)
-      try self.api.storedClientBackupShareKey(backupMethod: formattedBackupMethod) { (apiResult: Result<String>) in
+      // Call api to update backup status to `STORED_CLIENT_BACKUP_SHARE_KEY`.
+      try self.api.storedClientBackupShareKey(success: true, backupMethod: backupMethod) { (apiResult: Result<String>) in
         // Throw an error if we can't update the backup status + save the backup method.
         if let error = apiResult.error {
           return completion(Result(error: error))
@@ -791,7 +870,7 @@ public class PortalMpc {
 
         progress?(MpcStatus(status: MpcStatuses.recoveringBackupShare, done: false))
 
-        self.recoverBackup(clientBackupShare: result.data!) { backupResult in
+        self.recoverBackup(clientBackupShare: result.data!, backupMethod: method) { backupResult in
           if backupResult.error != nil {
             print("Signing shares were successfully replaced, but backup shares were not refreshed. Try running backup again with your new signing shares.")
             if let error = backupResult.error {
@@ -827,9 +906,8 @@ public class PortalMpc {
               }
 
               do {
-                // Call api to update backup method + update backup status to `STORED_CLIENT_BACKUP_SHARE_KEY`.
-                let formattedBackupMethod = self.formatBackupMethod(backupMethod: method)
-                try self.api.storedClientBackupShareKey(backupMethod: formattedBackupMethod) { (result: Result<String>) in
+                // Call api to update backup status to `STORED_CLIENT_BACKUP_SHARE_KEY`.
+                try self.api.storedClientBackupShareKey(success: true, backupMethod: method) { (_: Result<String>) in
                   // Throw an error if we can't update the backup status + save the backup method.
                   if result.error != nil {
                     print("Signing shares were successfully replaced, but backup shares were not refreshed. Try running backup again with your new signing shares.")
@@ -916,14 +994,18 @@ public class PortalMpc {
 
   /// Uses the signing share to create a new backup share and returns that share in JSON format.
   /// - Parameter
-  ///   - signingShare: The signing share as a string.
+  ///   - clientBackupShare: The signing share as a string.
   /// - Returns: The backup share.
   private func recoverBackup(
     clientBackupShare: String,
+    backupMethod: BackupMethods.RawValue,
     completion: (Result<MpcShare>) -> Void,
     progress: ((MpcStatus) -> Void)? = nil
   ) {
     do {
+      // Add the backup method.
+      self.mpcMetadata.backupMethod = backupMethod
+
       // Stringify the MPC metadata.
       let mpcMetadataString = self.mpcMetadata.jsonString() ?? ""
 
@@ -1067,6 +1149,7 @@ public class PortalMpc {
 /// CGGMP shares will contain all fields except: pubkey.
 public struct MpcShare: Codable {
   public var allY: PartialPublicKey?
+  public var backupSharePairId: String?
   public var bks: Berkhoffs?
   public var clientId: String
   public var p: String

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Mocks/Core/MockPortalApi.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Mocks/Core/MockPortalApi.swift
@@ -28,13 +28,13 @@ public class MockPortalApi: PortalApi {
   }
 
   override public func getEnabledDapps(completion: @escaping (Result<[Dapp]>) -> Void) {
-    if let dapps = dapps {
+    if let dapps {
       completion(Result(data: dapps))
     }
   }
 
   override public func getSupportedNetworks(completion: @escaping (Result<[ContractNetwork]>) -> Void) {
-    if let networks = networks {
+    if let networks {
       completion(Result(data: networks))
     }
   }
@@ -52,25 +52,40 @@ public class MockPortalApi: PortalApi {
   // Mocking the storedClientBackupShare function
   override public func storedClientBackupShare(
     success: Bool,
+    backupMethod _: BackupMethods.RawValue,
     completion: @escaping (Result<String>) -> Void
   ) throws {
     // Mock response based on the success parameter
-    let mockResponse: Result<String>
     if success {
-      mockResponse = Result(data: "Backup share successfully stored")
+      completion(Result(data: "Backup share successfully stored"))
     } else {
-      mockResponse = Result(error: NSError(domain: "MockError", code: 0, userInfo: nil))
+      completion(Result<String>(error: NSError(domain: "MockError", code: 0, userInfo: nil)))
     }
-    completion(mockResponse)
   }
 
   // Mocking the storedClientBackupShare function
   override public func storedClientBackupShareKey(
-    backupMethod _: String,
+    success _: Bool,
+    backupMethod _: BackupMethods.RawValue,
     completion: @escaping (Result<String>) -> Void
   ) throws {
     // Mock response based on the success parameter
     let mockResponse = Result(data: "Backup share key successfully stored")
+    completion(mockResponse)
+  }
+
+  override public func identify(traits _: [String: Any] = [:], completion: @escaping (Result<MetricsResponse>) -> Void) throws {
+    let mockResponse = Result(data: MetricsResponse(status: true))
+
+    completion(mockResponse)
+  }
+
+  override public func track(event _: String, properties _: [String: Any], completion: ((Result<MetricsResponse>) -> Void)? = nil) {
+    let mockResponse = Result(data: MetricsResponse(status: true))
+    guard let completion else {
+      return
+    }
+
     completion(mockResponse)
   }
 }

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Portal.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Portal.swift
@@ -59,7 +59,7 @@ public class Portal {
     gatewayConfig: [Int: String],
     // Optional
     isSimulator: Bool = false,
-    version: String = "v5",
+    version: String = "v6",
     autoApprove: Bool = false,
     apiHost: String = "api.portalhq.io",
     mpcHost: String = "mpc.portalhq.io",
@@ -79,8 +79,8 @@ public class Portal {
     self.version = version
     self.featureFlags = featureFlags
 
-    if version != "v5" {
-      throw PortalArgumentError.versionNoLongerSupported(message: "MPC Version is not supported. Only version 'v5' is currently supported.")
+    if version != "v6" {
+      throw PortalArgumentError.versionNoLongerSupported(message: "MPC Version is not supported. Only version 'v6' is currently supported.")
     }
 
     // Initialize the PortalProvider
@@ -154,7 +154,7 @@ public class Portal {
     gatewayConfig: [Int: String],
     // Optional
     isSimulator: Bool = false,
-    version: String = "v5",
+    version: String = "v6",
     autoApprove: Bool = false,
     apiHost: String = "api.portalhq.io",
     mpcHost: String = "mpc.portalhq.io",
@@ -177,8 +177,8 @@ public class Portal {
     self.version = version
     self.featureFlags = featureFlags
 
-    if version != "v5" {
-      throw PortalArgumentError.versionNoLongerSupported(message: "MPC Version is not supported. Only version 'v5' is currently supported.")
+    if version != "v6" {
+      throw PortalArgumentError.versionNoLongerSupported(message: "MPC Version is not supported. Only version 'v6' is currently supported.")
     }
 
     // Initialize the PortalProvider

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Provider/MpcSigner.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Provider/MpcSigner.swift
@@ -36,7 +36,7 @@ class MpcSigner {
     apiKey: String,
     keychain: PortalKeychain,
     mpcUrl: String = "mpc.portalhq.io",
-    version: String = "v5",
+    version: String = "v6",
     featureFlags: FeatureFlags? = nil
   ) {
     self.apiKey = apiKey
@@ -56,7 +56,7 @@ class MpcSigner {
     apiKey: String,
     keychain: PortalKeychain,
     mpcUrl: String = "mpc.portalhq.io",
-    version: String = "v5",
+    version: String = "v6",
     featureFlags: FeatureFlags? = nil,
     binary: Mobile?
   ) {

--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Provider/PortalProvider.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Provider/PortalProvider.swift
@@ -57,7 +57,7 @@ public class PortalProvider {
     autoApprove: Bool,
     apiHost: String = "api.portalhq.io",
     mpcHost: String = "mpc.portalhq.io",
-    version: String = "v5",
+    version: String = "v6",
     featureFlags: FeatureFlags? = nil
   ) throws {
     // User-defined instance variables
@@ -100,7 +100,7 @@ public class PortalProvider {
     gateway: HttpRequester,
     apiHost: String = "api.portalhq.io",
     mpcHost: String = "mpc.portalhq.io",
-    version: String = "v5",
+    version: String = "v6",
     featureFlags: FeatureFlags? = nil
   ) throws {
     // User-defined instance variables

--- a/Cocoapods Example/PortalSwift/Base.lproj/Main.storyboard
+++ b/Cocoapods Example/PortalSwift/Base.lproj/Main.storyboard
@@ -180,7 +180,7 @@
                                 <rect key="frame" x="17" y="810" width="342" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="NFTs, Trxs, Balances, Sim trx">
+                                <buttonConfiguration key="configuration" style="filled" title="API Methods">
                                     <backgroundConfiguration key="background"/>
                                     <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                     <color key="baseBackgroundColor" red="0.027450980390000001" green="0.054901960780000002" blue="0.086274509799999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -560,7 +560,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemPinkColor">
-            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Cocoapods Example/PortalSwift/Portal.swift
+++ b/Cocoapods Example/PortalSwift/Portal.swift
@@ -245,8 +245,7 @@ class PortalWrapper {
   func recover(backupMethod: BackupMethods.RawValue, user: UserResult, backupConfigs: BackupConfigs? = nil, completion: @escaping (Result<Bool>) -> Void) {
     print("[PortalWrapper] Starting recover...")
     let request = HttpRequest<CipherTextResult, [String: String]>(
-      // url: CUSTODIAN_SERVER_URL! + "/mobile/\(user.exchangeUserId)/cipher-text/fetch?backupMethod=\(backupMethod)", // Use this to fetch v6+ client backup share.
-      url: CUSTODIAN_SERVER_URL! + "/mobile/\(user.exchangeUserId)/cipher-text/fetch", // Use this to fetch pre-v6 client backup share.
+      url: CUSTODIAN_SERVER_URL! + "/mobile/\(user.exchangeUserId)/cipher-text/fetch?backupMethod=\(backupMethod)", // Use this to fetch v6+ client backup share.
       method: "GET", body: [:],
       headers: [:],
       requestType: HttpRequestType.CustomRequest

--- a/Cocoapods Example/PortalSwift/ViewController.swift
+++ b/Cocoapods Example/PortalSwift/ViewController.swift
@@ -428,7 +428,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
       guard result.error == nil else {
         print("❌ handleLegacyRecover(): Error fetching cipherText:", result.error ?? "")
         do {
-          try self.PortalWrapper.portal?.api.storedClientBackupShare(success: false) { result in
+          try self.PortalWrapper.portal?.api.storedClientBackupShare(success: false, backupMethod: BackupMethods.iCloud.rawValue) { result in
             guard result.error == nil else {
               print("❌ handleLegacyRecover(): Error notifying Portal that backup share was not stored.")
               return
@@ -441,7 +441,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
       }
 
       do {
-        try self.PortalWrapper.portal?.api.storedClientBackupShare(success: true) { result in
+        try self.PortalWrapper.portal?.api.storedClientBackupShare(success: true, backupMethod: BackupMethods.iCloud.rawValue) { result in
           guard result.error == nil else {
             print("❌ handleLegacyRecover(): Error notifying Portal that backup share was stored.")
             return
@@ -497,6 +497,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
     self.getTransactions()
     self.getBalances()
     self.simulateTransaction()
+    self.getBackupShareMetadata()
   }
 
   func populateAddressInformation() {
@@ -545,6 +546,21 @@ class ViewController: UIViewController, UITextFieldDelegate {
       }
     } catch {
       print("❌ Unable to retrieve transactions", error)
+    }
+  }
+
+  func getBackupShareMetadata() {
+    do {
+      try self.portal?.api.getBackupShareMetadata { results in
+        guard results.error == nil else {
+          print("❌ Unable to get backup share pairs", results.error ?? "")
+          return
+        }
+
+        print("✅ Retrieved backup share pairs", results.data ?? "")
+      }
+    } catch {
+      print("❌ Unable to retrieve backup share pairs", error)
     }
   }
 

--- a/Cocoapods Example/Tests/e2e/PasswordWalletTests.swift
+++ b/Cocoapods Example/Tests/e2e/PasswordWalletTests.swift
@@ -157,7 +157,7 @@ class PasswordWalletTests: XCTestCase {
           print("❌ handleBackup():", result.error!)
 
           do {
-            try PasswordWalletTests.PortalWrap.portal?.api.storedClientBackupShare(success: false) { result in
+            try PasswordWalletTests.PortalWrap.portal?.api.storedClientBackupShare(success: false, backupMethod: BackupMethods.Password.rawValue) { result in
               guard result.error == nil else {
                 backupExpectation.fulfill()
                 return XCTFail("Backup failed \(String(describing: result.error))")
@@ -172,7 +172,7 @@ class PasswordWalletTests: XCTestCase {
         }
 
         do {
-          try PasswordWalletTests.PortalWrap.portal?.api.storedClientBackupShare(success: true) { _ in
+          try PasswordWalletTests.PortalWrap.portal?.api.storedClientBackupShare(success: true, backupMethod: BackupMethods.Password.rawValue) { _ in
             guard backupResult.error == nil else {
               print("❌ handleBackup(): Error notifying Portal that backup share was stored.")
               return

--- a/Cocoapods Example/Tests/e2e/ProviderTests.swift
+++ b/Cocoapods Example/Tests/e2e/ProviderTests.swift
@@ -1062,8 +1062,8 @@ class ProviderTests: XCTestCase {
         }
         sleep(7) // there is a delay between creating the filter and the chain knowing about the filter
         self.performRequest(method: ETHRequestMethods.GetFilterChanges.rawValue, params: [filter]) { result in
-          guard result.error == nil, let logs = (result.data?.result as? LogsResponse)?.result else {
-            XCTFail("Error testing provider request: \(String(describing: result.error))")
+          guard result.error == nil, let logs = (result.data?.result as? LogsResponse)?.result, !logs.isEmpty else {
+            XCTFail("Error testing provider request or no logs found: \(String(describing: result.error))")
             return expectation.fulfill()
           }
 

--- a/Cocoapods Example/Tests/e2e/WalletTests.swift
+++ b/Cocoapods Example/Tests/e2e/WalletTests.swift
@@ -165,7 +165,7 @@ class WalletTests: XCTestCase {
           print("❌ handleBackup():", result.error ?? "")
 
           do {
-            try WalletTests.PortalWrap.portal?.api.storedClientBackupShare(success: false) { result in
+            try WalletTests.PortalWrap.portal?.api.storedClientBackupShare(success: false, backupMethod: BackupMethods.Password.rawValue) { result in
               guard result.error == nil else {
                 backupExpectation.fulfill()
                 return XCTFail("Backup failed \(String(describing: result.error))")
@@ -180,7 +180,7 @@ class WalletTests: XCTestCase {
         }
 
         do {
-          try WalletTests.PortalWrap.portal?.api.storedClientBackupShare(success: true) { _ in
+          try WalletTests.PortalWrap.portal?.api.storedClientBackupShare(success: true, backupMethod: BackupMethods.Password.rawValue) { _ in
             guard backupResult.error == nil else {
               print("❌ handleBackup(): Error notifying Portal that backup share was stored.")
               return

--- a/SPM Example/PortalSwift/Base.lproj/Main.storyboard
+++ b/SPM Example/PortalSwift/Base.lproj/Main.storyboard
@@ -245,7 +245,7 @@
                                 <rect key="frame" x="17" y="811" width="342" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="NFTs, Trxs, Balances, Sim trx">
+                                <buttonConfiguration key="configuration" style="filled" title="API Methods">
                                     <backgroundConfiguration key="background"/>
                                     <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                     <color key="baseBackgroundColor" red="0.027450980390000001" green="0.054901960780000002" blue="0.086274509799999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -555,7 +555,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemPinkColor">
-            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/SPM Example/PortalSwift/Portal.swift
+++ b/SPM Example/PortalSwift/Portal.swift
@@ -39,8 +39,11 @@ class PortalWrapper {
 
     let LOCAL_API_URL = "localhost:3001"
     let LOCAL_MPC_URL = "localhost:3002"
-
-    guard let ENV: String = Bundle.main.infoDictionary?["ENV"] as? String else {
+    guard let infoDictionary: [String: Any] = Bundle.main.infoDictionary else {
+      print("Couldnt load info plist")
+      return
+    }
+    guard let ENV: String = infoDictionary["ENV"] as? String else {
       print("Error: Do you have `ENV=$(ENV)` in your info.plist?")
       return
     }
@@ -58,8 +61,6 @@ class PortalWrapper {
       self.API_URL = LOCAL_API_URL
       self.MPC_URL = LOCAL_MPC_URL
     }
-
-    print("CUSTODIAN_SERVER_URL", self.CUSTODIAN_SERVER_URL)
   }
 
   func signIn(username: String, completion: @escaping (Result<UserResult>) -> Void) {
@@ -102,13 +103,17 @@ class PortalWrapper {
     case cantLoadInfoPlist
   }
 
-  func registerPortal(apiKey: String, backup: BackupOptions, chainId: Int = 5, optimized: Bool = false, completion: @escaping (Result<Bool>) -> Void) {
+  func registerPortal(apiKey: String, backup: BackupOptions, chainId: Int = 11_155_111, optimized: Bool = false, completion: @escaping (Result<Bool>) -> Void) {
     do {
-      guard let ALCHEMY_API_KEY: String = Bundle.main.infoDictionary?["ALCHEMY_API_KEY"] as? String else {
+      guard let infoDictionary: [String: Any] = Bundle.main.infoDictionary else {
+        return completion(Result(error: PortalWrapperError.cantLoadInfoPlist))
+      }
+      guard let ALCHEMY_API_KEY: String = infoDictionary["ALCHEMY_API_KEY"] as? String else {
         print("Error: Do you have `ALCHEMY_API_KEY=$(ALCHEMY_API_KEY)` in your info.plist?")
         return
       }
       let keychain = PortalKeychain()
+
       // Configure the chain.
       self.portal = try Portal(
         apiKey: apiKey,
@@ -116,7 +121,7 @@ class PortalWrapper {
         chainId: chainId,
         keychain: keychain,
         gatewayConfig: [
-          11_155_111: "https://eth-sepolia.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 5: "https://eth-goerli.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 1: "https://eth-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 80001: "https://polygon-mumbai.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 137: "https://polygon-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)",
+          11_155_111: "https://eth-sepolia.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 1: "https://eth-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 80001: "https://polygon-mumbai.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 137: "https://polygon-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)",
         ],
         autoApprove: false,
         apiHost: self.API_URL!,
@@ -160,19 +165,20 @@ class PortalWrapper {
   func backup(backupMethod: BackupMethods.RawValue, user: UserResult, backupConfigs: BackupConfigs? = nil, completion: @escaping (Result<String>) -> Void) {
     self.portal?.backupWallet(method: backupMethod, backupConfigs: backupConfigs) { (result: Result<String>) in
       guard result.error == nil else {
-        return completion(Result(error: result.error!))
+        print("❌ backup(): Error backing up wallet", result.error)
+        return completion(result)
       }
       let request = HttpRequest<String, [String: String]>(
         url: self.CUSTODIAN_SERVER_URL! + "/mobile/\(user.exchangeUserId)/cipher-text",
         method: "POST",
-        body: ["cipherText": result.data!],
+        body: ["cipherText": result.data!, "backupMethod": backupMethod],
         headers: [:],
         requestType: HttpRequestType.CustomRequest
       )
 
       request.send { (_: Result<String>) in
         do {
-          try self.portal!.api.storedClientBackupShare(success: true) { result in
+          try self.portal!.api.storedClientBackupShare(success: true, backupMethod: backupMethod) { result in
             guard result.error == nil else {
               print("❌ handleBackup(): Error notifying Portal that backup share was stored.")
               return completion(result)
@@ -239,7 +245,7 @@ class PortalWrapper {
   func recover(backupMethod: BackupMethods.RawValue, user: UserResult, backupConfigs: BackupConfigs? = nil, completion: @escaping (Result<Bool>) -> Void) {
     print("[PortalWrapper] Starting recover...")
     let request = HttpRequest<CipherTextResult, [String: String]>(
-      url: CUSTODIAN_SERVER_URL! + "/mobile/\(user.exchangeUserId)/cipher-text/fetch",
+      url: CUSTODIAN_SERVER_URL! + "/mobile/\(user.exchangeUserId)/cipher-text/fetch?backupMethod=\(backupMethod)",
       method: "GET", body: [:],
       headers: [:],
       requestType: HttpRequestType.CustomRequest
@@ -270,7 +276,7 @@ class PortalWrapper {
   func legacyRecover(backupMethod: BackupMethods.RawValue, user: UserResult, completion: @escaping (Result<Bool>) -> Void) {
     print("[PortalWrapper] Starting legacy recover...")
     let request = HttpRequest<CipherTextResult, [String: String]>(
-      url: CUSTODIAN_SERVER_URL! + "/mobile/\(user.exchangeUserId)/cipher-text/fetch",
+      url: CUSTODIAN_SERVER_URL! + "/mobile/\(user.exchangeUserId)/cipher-text/fetch?backupMethod=\(backupMethod)",
       method: "GET", body: [:],
       headers: [:],
       requestType: HttpRequestType.CustomRequest
@@ -293,7 +299,7 @@ class PortalWrapper {
         let request = HttpRequest<String, [String: String]>(
           url: self.CUSTODIAN_SERVER_URL! + "/mobile/\(user.exchangeUserId)/cipher-text",
           method: "POST",
-          body: ["cipherText": result.data!],
+          body: ["cipherText": result.data!, "backupMethod": backupMethod],
           headers: [:],
           requestType: HttpRequestType.CustomRequest
         )

--- a/SPM Example/PortalSwift/Portal.swift
+++ b/SPM Example/PortalSwift/Portal.swift
@@ -121,7 +121,7 @@ class PortalWrapper {
         chainId: chainId,
         keychain: keychain,
         gatewayConfig: [
-          11_155_111: "https://eth-sepolia.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 1: "https://eth-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 80001: "https://polygon-mumbai.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 137: "https://polygon-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)",
+          11_155_111: "https://eth-sepolia.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 5: "https://eth-goerli.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 1: "https://eth-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 80001: "https://polygon-mumbai.g.alchemy.com/v2/\(ALCHEMY_API_KEY)", 137: "https://polygon-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)",
         ],
         autoApprove: false,
         apiHost: self.API_URL!,

--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -429,7 +429,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
       guard result.error == nil else {
         print("❌ handleLegacyRecover(): Error fetching cipherText:", result.error ?? "")
         do {
-          try self.PortalWrapper.portal?.api.storedClientBackupShare(success: false) { result in
+          try self.PortalWrapper.portal?.api.storedClientBackupShare(success: false, backupMethod: BackupMethods.iCloud.rawValue) { result in
             guard result.error == nil else {
               print("❌ handleLegacyRecover(): Error notifying Portal that backup share was not stored.")
               return
@@ -442,7 +442,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
       }
 
       do {
-        try self.PortalWrapper.portal?.api.storedClientBackupShare(success: true) { result in
+        try self.PortalWrapper.portal?.api.storedClientBackupShare(success: true, backupMethod: BackupMethods.iCloud.rawValue) { result in
           guard result.error == nil else {
             print("❌ handleLegacyRecover(): Error notifying Portal that backup share was stored.")
             return
@@ -498,6 +498,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
     self.getTransactions()
     self.getBalances()
     self.simulateTransaction()
+    self.getBackupShareMetadata()
   }
 
   func populateAddressInformation() {
@@ -546,6 +547,21 @@ class ViewController: UIViewController, UITextFieldDelegate {
       }
     } catch {
       print("❌ Unable to retrieve transactions", error)
+    }
+  }
+
+  func getBackupShareMetadata() {
+    do {
+      try self.portal?.api.getBackupShareMetadata { results in
+        guard results.error == nil else {
+          print("❌ Unable to get backup share pairs", results.error ?? "")
+          return
+        }
+
+        print("✅ Retrieved backup share pairs", results.data ?? "")
+      }
+    } catch {
+      print("❌ Unable to retrieve backup share pairs", error)
     }
   }
 

--- a/Sources/PortalSwift/Connect/PortalConnect.swift
+++ b/Sources/PortalSwift/Connect/PortalConnect.swift
@@ -52,7 +52,7 @@ public class PortalConnect: EventBus {
     _ autoApprove: Bool = false,
     _ apiHost: String = "api.portalhq.io",
     _ mpcHost: String = "mpc.portalhq.io",
-    _ version: String = "v5"
+    _ version: String = "v6"
   ) throws {
     self.apiKey = apiKey
     self.webSocketServer = webSocketServer

--- a/Sources/PortalSwift/Core/PortalApi.swift
+++ b/Sources/PortalSwift/Core/PortalApi.swift
@@ -298,16 +298,19 @@ public class PortalApi {
 
   /// Updates the client's wallet backup state to have successfully stored the client backup share key in the client's storage (e.g. gdrive, icloud, etc).
   /// - Parameters:
-  ///   - backupMethod: One of: "ICLOUD", "GDRIVE", or "CUSTOM".
+  ///   - success: Boolean indicating whether the storage operation failed.
+  ///   - backupMethod: The `BackupMethod` used to create the  backup share.
   ///   - completion: The callback that contains the response status.
   /// - Returns: Void.
   public func storedClientBackupShareKey(
-    backupMethod: String,
+    success: Bool,
+    backupMethod: BackupMethods.RawValue,
     completion: @escaping (Result<String>) -> Void
   ) throws {
+    let body = ["success": success, "backupMethod": "\(backupMethod)"] as [String: Any]
     try self.requests.put(
-      path: "/api/v1/clients/me/wallet/stored-client-backup-share-key",
-      body: ["backupMethod": backupMethod],
+      path: "/api/v2/clients/me/wallet/stored-client-backup-share-key",
+      body: body,
       headers: [
         "Authorization": "Bearer \(self.apiKey)",
       ],
@@ -315,7 +318,7 @@ public class PortalApi {
     ) { (result: Result<String>) in
       completion(result)
 
-      self.track(event: MetricsEvents.storedClientBackupShareKey.rawValue, properties: ["path": "/api/v1/clients/me/wallet/stored-client-backup-share-key"])
+      self.track(event: MetricsEvents.storedClientBackupShareKey.rawValue, properties: ["path": "/api/v2/clients/me/wallet/stored-client-backup-share-key"])
     }
   }
 
@@ -337,15 +340,18 @@ public class PortalApi {
   /// Updates the client's wallet backup state to have successfully stored the client backup share with the custodian.
   /// - Parameters:
   ///   - success: Boolean indicating whether the storage operation failed.
+  ///   - backupSharePairId: The `backupSharePairId` on the share.
   ///   - completion: The callback that contains the response status.
   /// - Returns: Void.
   public func storedClientBackupShare(
     success: Bool,
+    backupMethod: BackupMethods.RawValue,
     completion: @escaping (Result<String>) -> Void
   ) throws {
+    let body = ["success": success, "backupMethod": "\(backupMethod)"] as [String: Any]
     try self.requests.put(
-      path: "/api/v1/clients/me/wallet/stored-client-backup-share",
-      body: ["success": success],
+      path: "/api/v2/clients/me/wallet/stored-client-backup-share",
+      body: body,
       headers: [
         "Authorization": "Bearer \(self.apiKey)",
       ],
@@ -353,7 +359,41 @@ public class PortalApi {
     ) { (result: Result<String>) in
       completion(result)
 
-      self.track(event: MetricsEvents.storedClientBackupShare.rawValue, properties: ["path": "/api/v1/clients/me/wallet/stored-client-backup-share"])
+      self.track(event: MetricsEvents.storedClientBackupShare.rawValue, properties: ["path": "/api/v2/clients/me/wallet/stored-client-backup-share"])
+    }
+  }
+
+  /// Retrieve a list of backup share pairs' details for the client.
+  /// - Parameter completion: The callback that contains the list of BackupSharePairs' details.
+  /// - Returns: Void.
+  public func getBackupShareMetadata(completion: @escaping (Result<[BackupSharePair]>) -> Void) throws {
+    try self.requests.get(
+      path: "/api/v1/clients/me/backup-share-pairs",
+      headers: [
+        "Authorization": "Bearer \(self.apiKey)",
+      ],
+      requestType: HttpRequestType.CustomRequest
+    ) { (result: Result<[BackupSharePair]>) in
+      completion(result)
+
+      self.track(event: MetricsEvents.getBackupShareMetadata.rawValue, properties: ["path": "/api/v1/clients/me/backup-share-pairs"])
+    }
+  }
+
+  /// Retrieve a list of signing share pairs' details for the client.
+  /// - Parameter completion: The callback that contains the list of SigningSharePairs' details.
+  /// - Returns: Void.
+  public func getSigningShareMetadata(completion: @escaping (Result<[SigningSharePair]>) -> Void) throws {
+    try self.requests.get(
+      path: "/api/v1/clients/me/signing-share-pairs",
+      headers: [
+        "Authorization": "Bearer \(self.apiKey)",
+      ],
+      requestType: HttpRequestType.CustomRequest
+    ) { (result: Result<[SigningSharePair]>) in
+      completion(result)
+
+      self.track(event: MetricsEvents.getSigningShareMetadata.rawValue, properties: ["path": "/api/v1/clients/me/signing-share-pairs"])
     }
   }
 
@@ -641,21 +681,34 @@ public enum MetricsEvents: String {
   case walletRecovered = "Wallet Recovered"
 
   // API Method events
+  case getBackupShareMetadata = "Get Backup Share Metadata"
+  case getBalances = "Get Balances"
   case getClient = "Get Client"
   case getEnabledDapps = "Get Enabled Dapps"
+  case getNFTs = "Get NFTs"
   case getNetworks = "Get Networks"
   case getQuote = "Get Quote"
+  case getSigningShareMetadata = "Get Signing Share Metadata"
   case getSources = "Get Sources"
-  case getNFTs = "Get NFTs"
   case getTransactions = "Get Transactions"
-  case getBalances = "Get Balances"
   case simulateTransaction = "Simulate Transaction"
-  case storedClientSigningShare = "Stored Client Signing Share"
-  case storedClientBackupShareKey = "Stored Client Backup Share Key"
   case storedClientBackupShare = "Stored Client Backup Share"
+  case storedClientBackupShareKey = "Stored Client Backup Share Key"
+  case storedClientSigningShare = "Stored Client Signing Share"
 }
 
 public enum GetTransactionsOrder: String {
   case asc
   case desc
+}
+
+public struct BackupSharePair: Codable {
+  public var backupMethod: String
+  public var createdAt: String
+  public var id: String
+}
+
+public struct SigningSharePair: Codable {
+  public var createdAt: String
+  public var id: String
 }

--- a/Sources/PortalSwift/Core/mpc/MpcMobileProtocol.swift
+++ b/Sources/PortalSwift/Core/mpc/MpcMobileProtocol.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public struct MpcMetadata: Codable {
+  var backupMethod: BackupMethods.RawValue?
   var clientPlatform: String
   var mpcServerVersion: String
   var optimized: Bool

--- a/Sources/PortalSwift/Core/mpc/PortalMpc.swift
+++ b/Sources/PortalSwift/Core/mpc/PortalMpc.swift
@@ -42,7 +42,7 @@ public class PortalMpc {
   private let rsaFooter = "\n-----END RSA KEY-----"
   private var isWalletModificationInProgress: Bool = false
   private var isMock: Bool = false
-  private let mpcMetadata: MpcMetadata
+  private var mpcMetadata: MpcMetadata
 
   /// Create an instance of Portal's MPC service.
   public init(
@@ -52,7 +52,7 @@ public class PortalMpc {
     storage: BackupOptions,
     isSimulator: Bool = false,
     host: String = "mpc.portalhq.io",
-    version: String = "v5",
+    version: String = "v6",
     mobile: Mobile,
     apiHost: String = "api.portalhq.io",
     featureFlags: FeatureFlags? = nil
@@ -91,8 +91,8 @@ public class PortalMpc {
     completion: @escaping (Result<String>) -> Void,
     progress: ((MpcStatus) -> Void)? = nil
   ) {
-    if self.version != "v5" {
-      return completion(Result(error: MpcError.backupNoLongerSupported(message: "[PortalMpc] Backup is no longer supported for this version of MPC. Please use `version = v5`.")))
+    if self.version != "v6" {
+      return completion(Result(error: MpcError.backupNoLongerSupported(message: "[PortalMpc] Backup is no longer supported for this version of MPC. Please use `version = v6`.")))
     }
 
     guard !self.isWalletModificationInProgress else {
@@ -230,9 +230,9 @@ public class PortalMpc {
   /// - Returns: The address of the newly created MPC wallet.
   public func generate(completion: @escaping (Result<String>) -> Void, progress: ((MpcStatus) -> Void)? = nil) {
     DispatchQueue.global(qos: .background).async { [self] in
-      if self.version != "v5" {
+      if self.version != "v6" {
         let result = Result<String>(error: MpcError.generateNoLongerSupported(
-          message: "[PortalMpc] Generate is no longer supported for this version of MPC. Please use `version = v5`."
+          message: "[PortalMpc] Generate is no longer supported for this version of MPC. Please use `version = v6`."
         ))
         completion(result)
       }
@@ -413,8 +413,8 @@ public class PortalMpc {
     completion: @escaping (Result<String>) -> Void,
     progress: ((MpcStatus) -> Void)? = nil
   ) {
-    if self.version != "v5" {
-      return completion(Result(error: MpcError.recoverNoLongerSupported(message: "[PortalMpc] Recover is no longer supported for this version of MPC. Please use `version = v5`.")))
+    if self.version != "v6" {
+      return completion(Result(error: MpcError.recoverNoLongerSupported(message: "[PortalMpc] Recover is no longer supported for this version of MPC. Please use `version = v6`.")))
     }
 
     guard !self.isWalletModificationInProgress else {
@@ -562,8 +562,8 @@ public class PortalMpc {
     completion: @escaping (Result<String>) -> Void,
     progress: ((MpcStatus) -> Void)? = nil
   ) {
-    if self.version != "v5" {
-      return completion(Result(error: MpcError.recoverNoLongerSupported(message: "[PortalMpc] Recover is no longer supported for this version of MPC. Please use `version = v5`.")))
+    if self.version != "v6" {
+      return completion(Result(error: MpcError.recoverNoLongerSupported(message: "[PortalMpc] Recover is no longer supported for this version of MPC. Please use `version = v6`.")))
     }
 
     guard !self.isWalletModificationInProgress else {
@@ -742,6 +742,9 @@ public class PortalMpc {
     progress: ((MpcStatus) -> Void)? = nil
   ) {
     do {
+      // Add the backup method.
+      self.mpcMetadata.backupMethod = backupMethod
+
       // Stringify the MPC metadata.
       let mpcMetadataString = self.mpcMetadata.jsonString() ?? ""
 
@@ -775,7 +778,7 @@ public class PortalMpc {
       } else {
         // Encrypt the backup share.
         self.encryptShare(mpcShare: backupShare) { encryptedResult in
-          self.handleEncryptedShareCompletion(encryptedResult: encryptedResult, storage: storage, backupMethod: backupMethod, progress: progress, completion: completion)
+          self.handleEncryptedShareCompletion(encryptedResult: encryptedResult, storage: storage, backupMethod: backupMethod, backupSharePairId: backupShare.backupSharePairId!, progress: progress, completion: completion)
         } progress: { status in
           progress?(status)
         }
@@ -798,9 +801,8 @@ public class PortalMpc {
     }
 
     do {
-      // Call api to update backup method + update backup status to `STORED_CLIENT_BACKUP_SHARE_KEY`.
-      let formattedBackupMethod = self.formatBackupMethod(backupMethod: backupMethod)
-      try self.api.storedClientBackupShareKey(backupMethod: formattedBackupMethod) { (apiResult: Result<String>) in
+      // Call api to update backup status to `STORED_CLIENT_BACKUP_SHARE_KEY`.
+      try self.api.storedClientBackupShareKey(success: true, backupMethod: backupMethod) { (apiResult: Result<String>) in
         // Throw an error if we can't update the backup status + save the backup method.
         if let error = apiResult.error {
           return completion(Result(error: error))
@@ -830,9 +832,8 @@ public class PortalMpc {
     progress?(MpcStatus(status: MpcStatuses.storingShare, done: false))
 
     do {
-      // Call api to update backup method + update backup status to `STORED_CLIENT_BACKUP_SHARE_KEY`.
-      let formattedBackupMethod = self.formatBackupMethod(backupMethod: backupMethod)
-      try self.api.storedClientBackupShareKey(backupMethod: formattedBackupMethod) { (apiResult: Result<String>) in
+      // Call api to update backup status to `STORED_CLIENT_BACKUP_SHARE_KEY`.
+      try self.api.storedClientBackupShareKey(success: true, backupMethod: backupMethod) { (apiResult: Result<String>) in
         // Throw an error if we can't update the backup status + save the backup method.
         if let error = apiResult.error {
           return completion(Result(error: error))
@@ -853,6 +854,7 @@ public class PortalMpc {
     encryptedResult: Result<EncryptData>,
     storage: Storage,
     backupMethod: BackupMethods.RawValue,
+    backupSharePairId _: String,
     progress: ((MpcStatus) -> Void)?,
     completion: @escaping (Result<String>) -> Void
   ) {
@@ -929,7 +931,7 @@ public class PortalMpc {
 
         progress?(MpcStatus(status: MpcStatuses.recoveringBackupShare, done: false))
 
-        self.recoverBackup(clientBackupShare: result.data!) { backupResult in
+        self.recoverBackup(clientBackupShare: result.data!, backupMethod: method) { backupResult in
           if backupResult.error != nil {
             print("Signing shares were successfully replaced, but backup shares were not refreshed. Try running backup again with your new signing shares.")
             if let error = backupResult.error {
@@ -965,9 +967,8 @@ public class PortalMpc {
               }
 
               do {
-                // Call api to update backup method + update backup status to `STORED_CLIENT_BACKUP_SHARE_KEY`.
-                let formattedBackupMethod = self.formatBackupMethod(backupMethod: method)
-                try self.api.storedClientBackupShareKey(backupMethod: formattedBackupMethod) { (result: Result<String>) in
+                // Call api to update backup status to `STORED_CLIENT_BACKUP_SHARE_KEY`.
+                try self.api.storedClientBackupShareKey(success: true, backupMethod: method) { (_: Result<String>) in
                   // Throw an error if we can't update the backup status + save the backup method.
                   if result.error != nil {
                     print("Signing shares were successfully replaced, but backup shares were not refreshed. Try running backup again with your new signing shares.")
@@ -1036,7 +1037,6 @@ public class PortalMpc {
       storage.read { (result: Result<String>) in
         // If the private key was not found, return an error.
         guard let privateKey = result.data else {
-          print(result.error)
           return completion(Result(error: MpcError.failedToGetBackupFromStorage))
         }
 
@@ -1055,14 +1055,18 @@ public class PortalMpc {
 
   /// Uses the signing share to create a new backup share and returns that share in JSON format.
   /// - Parameter
-  ///   - signingShare: The signing share as a string.
+  ///   - clientBackupShare: The signing share as a string.
   /// - Returns: The backup share.
   private func recoverBackup(
     clientBackupShare: String,
+    backupMethod: BackupMethods.RawValue,
     completion: (Result<MpcShare>) -> Void,
     progress: ((MpcStatus) -> Void)? = nil
   ) {
     do {
+      // Add the backup method.
+      self.mpcMetadata.backupMethod = backupMethod
+
       // Stringify the MPC metadata.
       let mpcMetadataString = self.mpcMetadata.jsonString() ?? ""
 
@@ -1206,6 +1210,7 @@ public class PortalMpc {
 /// CGGMP shares will contain all fields except: pubkey.
 public struct MpcShare: Codable {
   public var allY: PartialPublicKey?
+  public var backupSharePairId: String?
   public var bks: Berkhoffs?
   public var clientId: String
   public var p: String

--- a/Sources/PortalSwift/Mocks/Core/MockPortal.swift
+++ b/Sources/PortalSwift/Mocks/Core/MockPortal.swift
@@ -17,7 +17,7 @@ public class MockPortal: Portal {
     gatewayConfig: [Int: String],
     // Optional
     isSimulator: Bool = false,
-    version: String = "v5",
+    version: String = "v6",
     autoApprove: Bool = false,
     apiHost: String = "api.portalhq.io",
     mpcHost: String = "mpc.portalhq.io",

--- a/Sources/PortalSwift/Mocks/Core/MockPortalApi.swift
+++ b/Sources/PortalSwift/Mocks/Core/MockPortalApi.swift
@@ -52,6 +52,7 @@ public class MockPortalApi: PortalApi {
   // Mocking the storedClientBackupShare function
   override public func storedClientBackupShare(
     success: Bool,
+    backupMethod _: BackupMethods.RawValue,
     completion: @escaping (Result<String>) -> Void
   ) throws {
     // Mock response based on the success parameter
@@ -64,7 +65,8 @@ public class MockPortalApi: PortalApi {
 
   // Mocking the storedClientBackupShare function
   override public func storedClientBackupShareKey(
-    backupMethod _: String,
+    success _: Bool,
+    backupMethod _: BackupMethods.RawValue,
     completion: @escaping (Result<String>) -> Void
   ) throws {
     // Mock response based on the success parameter

--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -60,7 +60,7 @@ public class Portal {
     gatewayConfig: [Int: String],
     // Optional
     isSimulator: Bool = false,
-    version: String = "v5",
+    version: String = "v6",
     autoApprove: Bool = false,
     apiHost: String = "api.portalhq.io",
     mpcHost: String = "mpc.portalhq.io",
@@ -82,8 +82,8 @@ public class Portal {
     self.version = version
     self.featureFlags = featureFlags
 
-    if version != "v5" {
-      throw PortalArgumentError.versionNoLongerSupported(message: "MPC Version is not supported. Only version 'v5' is currently supported.")
+    if version != "v6" {
+      throw PortalArgumentError.versionNoLongerSupported(message: "MPC Version is not supported. Only version 'v6' is currently supported.")
     }
 
     // Initialize the PortalProvider
@@ -164,7 +164,7 @@ public class Portal {
     gatewayConfig: [Int: String],
     // Optional
     isSimulator: Bool = false,
-    version: String = "v5",
+    version: String = "v6",
     autoApprove: Bool = false,
     apiHost: String = "api.portalhq.io",
     mpcHost: String = "mpc.portalhq.io",
@@ -189,8 +189,8 @@ public class Portal {
     self.version = version
     self.featureFlags = featureFlags
 
-    if version != "v5" {
-      throw PortalArgumentError.versionNoLongerSupported(message: "MPC Version is not supported. Only version 'v5' is currently supported.")
+    if version != "v6" {
+      throw PortalArgumentError.versionNoLongerSupported(message: "MPC Version is not supported. Only version 'v6' is currently supported.")
     }
 
     // Initialize the PortalProvider
@@ -536,11 +536,12 @@ enum PortalProviderError: Error {
 
 /// The list of backup methods for PortalSwift.
 public enum BackupMethods: String {
-  case GoogleDrive = "gdrive"
-  case iCloud = "icloud"
-  case local
-  case Password = "password"
-  case Passkey = "passkey"
+  case GoogleDrive = "GDRIVE"
+  case iCloud = "ICLOUD"
+  case local = "CUSTOM"
+  case Password = "PASSWORD"
+  case Passkey = "PASSKEY"
+  case Unknown = "UNKNOWN"
 }
 
 public struct BackupConfigs {

--- a/Sources/PortalSwift/Provider/MpcSigner.swift
+++ b/Sources/PortalSwift/Provider/MpcSigner.swift
@@ -36,7 +36,7 @@ class MpcSigner {
     apiKey: String,
     keychain: PortalKeychain,
     mpcUrl: String = "mpc.portalhq.io",
-    version: String = "v5",
+    version: String = "v6",
     featureFlags: FeatureFlags? = nil
   ) {
     self.apiKey = apiKey
@@ -56,7 +56,7 @@ class MpcSigner {
     apiKey: String,
     keychain: PortalKeychain,
     mpcUrl: String = "mpc.portalhq.io",
-    version: String = "v5",
+    version: String = "v6",
     featureFlags: FeatureFlags? = nil,
     binary: Mobile?
   ) {

--- a/Sources/PortalSwift/Provider/PortalProvider.swift
+++ b/Sources/PortalSwift/Provider/PortalProvider.swift
@@ -57,7 +57,7 @@ public class PortalProvider {
     autoApprove: Bool,
     apiHost: String = "api.portalhq.io",
     mpcHost: String = "mpc.portalhq.io",
-    version: String = "v5",
+    version: String = "v6",
     featureFlags: FeatureFlags? = nil
   ) throws {
     // User-defined instance variables
@@ -100,7 +100,7 @@ public class PortalProvider {
     gateway: HttpRequester,
     apiHost: String = "api.portalhq.io",
     mpcHost: String = "mpc.portalhq.io",
-    version: String = "v5",
+    version: String = "v6",
     featureFlags: FeatureFlags? = nil
   ) throws {
     // User-defined instance variables


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR enables multi-backup functionality by completing the following tickets:

- Allow multiple backing up and recovering with multiple backups.
- Update MpcShare type to include optional backupSharePairId.
- Update recoverBackup
- Update portal.backup
- Add api endpoint handler portal.api.getBackupShareMetadata (array of backup share pair records, includes { backupSharePairId }) for new endpoint.
- Update storedClientBackupShareKey API request to pass in backupSharePairId in the request body
- Update recoverSigning

https://linear.app/portal-hq/issue/ENG-2215/allow-multiple-backing-up-and-recovering-with-multiple-backups
https://linear.app/portal-hq/issue/ENG-2214/update-mpcshare-type-to-include-optional-backupsharepairid
https://linear.app/portal-hq/issue/ENG-2212/update-recoverbackup
https://linear.app/portal-hq/issue/ENG-2211/update-portalbackup
https://linear.app/portal-hq/issue/ENG-2210/add-api-endpoint-handler-portalapigetbackupsharemetadata-array-of
https://linear.app/portal-hq/issue/ENG-2209/update-storedclientbackupsharekey-api-request-to-pass-in
https://linear.app/portal-hq/issue/ENG-2213/update-recoversigning

## Details

### Code
- Checked against coding style guide: Yes
  <!-- - Deviations from the style guide: [List any deviations] -->
  <!-- - Potential style guide updates: [Any suggestions?] -->
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: Yes, will create a doc to migrate
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->
- Manual tests in staging: Pending
  <!-- - ![Screenshot or video link here if applicable] -->
- E2E tests in Datadog: Pending
  <!-- ![Screenshot of e2e tests passing] -->

### Misc.
- Metrics, logs, or traces added: No
- Changelog updated: No
  <!-- - If no, reason: [Reason here] -->
<!-- - Other notes: [Any other relevant notes] -->
