### PR TITLE
Kelsonic/eng 2441 add status incomplete complete for backup share pairs api

### DIFF
--- a/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Core/PortalApi.swift
+++ b/Cocoapods Example/Pods/PortalSwift/Sources/PortalSwift/Core/PortalApi.swift
@@ -673,5 +673,21 @@ public struct BackupSharePair: Codable {
   public var backupMethod: String
   public var createdAt: String
   public var id: String
-  public var status: String
+  public var status: Status
+
+  public enum Status: String, Codable {
+    case completed
+    case incomplete
+  }
+}
+
+public struct SigningSharePair: Codable {
+  public var createdAt: String
+  public var id: String
+  public var status: Status
+
+  public enum Status: String, Codable {
+    case completed
+    case incomplete
+  }
 }

--- a/Cocoapods Example/PortalSwift/ViewController.swift
+++ b/Cocoapods Example/PortalSwift/ViewController.swift
@@ -497,7 +497,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
     self.getTransactions()
     self.getBalances()
     self.simulateTransaction()
-    self.getBackupShareMetadata()
+    self.getShareMetadata()
   }
 
   func populateAddressInformation() {
@@ -549,7 +549,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
     }
   }
 
-  func getBackupShareMetadata() {
+  func getShareMetadata() {
     do {
       try self.portal?.api.getBackupShareMetadata { results in
         guard results.error == nil else {
@@ -561,6 +561,19 @@ class ViewController: UIViewController, UITextFieldDelegate {
       }
     } catch {
       print("❌ Unable to retrieve backup share pairs", error)
+    }
+    
+    do {
+      try self.portal?.api.getSigningShareMetadata { results in
+        guard results.error == nil else {
+          print("❌ Unable to get signing share pairs", results.error ?? "")
+          return
+        }
+
+        print("✅ Retrieved signing share pairs", results.data ?? "")
+      }
+    } catch {
+      print("❌ Unable to retrieve signing share pairs", error)
     }
   }
 

--- a/Cocoapods Example/PortalSwift/ViewController.swift
+++ b/Cocoapods Example/PortalSwift/ViewController.swift
@@ -562,7 +562,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
     } catch {
       print("❌ Unable to retrieve backup share pairs", error)
     }
-    
+
     do {
       try self.portal?.api.getSigningShareMetadata { results in
         guard results.error == nil else {

--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -563,7 +563,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
     } catch {
       print("❌ Unable to retrieve backup share pairs", error)
     }
-    
+
     do {
       try self.portal?.api.getSigningShareMetadata { results in
         guard results.error == nil else {

--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -498,7 +498,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
     self.getTransactions()
     self.getBalances()
     self.simulateTransaction()
-    self.getBackupShareMetadata()
+    self.getShareMetadata()
   }
 
   func populateAddressInformation() {
@@ -550,7 +550,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
     }
   }
 
-  func getBackupShareMetadata() {
+  func getShareMetadata() {
     do {
       try self.portal?.api.getBackupShareMetadata { results in
         guard results.error == nil else {
@@ -562,6 +562,19 @@ class ViewController: UIViewController, UITextFieldDelegate {
       }
     } catch {
       print("❌ Unable to retrieve backup share pairs", error)
+    }
+    
+    do {
+      try self.portal?.api.getSigningShareMetadata { results in
+        guard results.error == nil else {
+          print("❌ Unable to get signing share pairs", results.error ?? "")
+          return
+        }
+
+        print("✅ Retrieved signing share pairs", results.data ?? "")
+      }
+    } catch {
+      print("❌ Unable to retrieve signing share pairs", error)
     }
   }
 

--- a/Sources/PortalSwift/Core/PortalApi.swift
+++ b/Sources/PortalSwift/Core/PortalApi.swift
@@ -706,9 +706,21 @@ public struct BackupSharePair: Codable {
   public var backupMethod: String
   public var createdAt: String
   public var id: String
+  public var status: Status
+
+  public enum Status: String, Codable {
+    case completed
+    case incomplete
+  }
 }
 
 public struct SigningSharePair: Codable {
   public var createdAt: String
   public var id: String
+  public var status: Status
+
+  public enum Status: String, Codable {
+    case completed
+    case incomplete
+  }
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR updates the types for `/signing-share-pairs` and `/backup-share-pairs`

## Visuals
<!-- Attach screenshots or videos of any visual changes. If none, delete this section. -->
<img width="1433" alt="image" src="https://github.com/portal-hq/PortalSwift/assets/12773166/7b08bb7e-32d2-4525-a84f-0be08e38bffd">

## Details

### Code
- Checked against coding style guide: Yes
  <!-- - Deviations from the style guide: [List any deviations] -->
  <!-- - Potential style guide updates: [Any suggestions?] -->
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->
- Manual tests in staging: Pending
  <!-- - ![Screenshot or video link here if applicable] -->
- E2E tests in Datadog: Pending
  <!-- ![Screenshot of e2e tests passing] -->

### Misc.
- Metrics, logs, or traces added: No
- Changelog updated: No
  <!-- - If no, reason: [Reason here] -->
<!-- - Other notes: [Any other relevant notes] -->
