### PR TITLE
Kelsonic/multi backup hotfix

### DIFF
--- a/Cocoapods Example/PortalSwift/ViewController.swift
+++ b/Cocoapods Example/PortalSwift/ViewController.swift
@@ -97,7 +97,8 @@ class ViewController: UIViewController, UITextFieldDelegate {
     self.url?.delegate = self
 
     let PROD_CUSTODIAN_SERVER_URL = "https://portalex-mpc.portalhq.io"
-    let STAGING_CUSTODIAN_SERVER_URL = "https://staging-portalex-mpc-service.onrender.com"
+    // let STAGING_CUSTODIAN_SERVER_URL = "https://staging-portalex-mpc-service.onrender.com"
+    let STAGING_CUSTODIAN_SERVER_URL = "https://staging-portalex-legacy.onrender.com"
     let PROD_API_URL = "api.portalhq.io"
     let PROD_MPC_URL = "mpc.portalhq.io"
     let STAGING_API_URL = "api.portalhq.dev"
@@ -735,7 +736,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
       self.passkey = PasskeyStorage(viewController: self, relyingParty: "portalhq.io", webAuthnHost: self.RP_URL)
       let backup = BackupOptions(gdrive: GDriveStorage(clientID: GDRIVE_CLIENT_ID, viewController: self), icloud: ICloudStorage(), passwordStorage: PasswordStorage(), passkeyStorage: self.passkey)
 
-      self.PortalWrapper.registerPortal(apiKey: apiKey, backup: backup, optimized: true) { _ in
+      self.PortalWrapper.registerPortal(apiKey: apiKey, backup: backup, optimized: true, isMultiBackupEnabled: true) { _ in
         DispatchQueue.main.async {
           self.generateButton?.isEnabled = true
 

--- a/Cocoapods Example/PortalSwift/ViewController.swift
+++ b/Cocoapods Example/PortalSwift/ViewController.swift
@@ -97,8 +97,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
     self.url?.delegate = self
 
     let PROD_CUSTODIAN_SERVER_URL = "https://portalex-mpc.portalhq.io"
-    // let STAGING_CUSTODIAN_SERVER_URL = "https://staging-portalex-mpc-service.onrender.com"
-    let STAGING_CUSTODIAN_SERVER_URL = "https://staging-portalex-legacy.onrender.com"
+    let STAGING_CUSTODIAN_SERVER_URL = "https://staging-portalex-mpc-service.onrender.com"
     let PROD_API_URL = "api.portalhq.io"
     let PROD_MPC_URL = "mpc.portalhq.io"
     let STAGING_API_URL = "api.portalhq.dev"

--- a/Sources/PortalSwift/Core/PortalApi.swift
+++ b/Sources/PortalSwift/Core/PortalApi.swift
@@ -408,7 +408,6 @@ public class PortalApi {
   /// - Parameter completion: The callback that contains the list of SigningSharePairs' details.
   /// - Returns: Void.
   public func getSigningShareMetadata(completion: @escaping (Result<[SigningSharePair]>) -> Void) throws {
-    print("test")
     try self.requests.get(
       path: "/api/v1/clients/me/signing-share-pairs",
       headers: [

--- a/Sources/PortalSwift/Core/PortalApi.swift
+++ b/Sources/PortalSwift/Core/PortalApi.swift
@@ -12,6 +12,7 @@ public class PortalApi {
   private var apiKey: String
   private var provider: PortalProvider
   private var requests: HttpRequester
+  private let featureFlags: FeatureFlags?
 
   private var address: String? {
     return self.provider.address
@@ -30,13 +31,16 @@ public class PortalApi {
     apiKey: String,
     apiHost: String = "api.portalhq.io",
     provider: PortalProvider,
-    mockRequests: Bool = false
+    mockRequests: Bool = false,
+    featureFlags: FeatureFlags? = nil
   ) {
     self.apiKey = apiKey
     self.provider = provider
 
     let baseUrl = apiHost.starts(with: "localhost") ? "http://\(apiHost)" : "https://\(apiHost)"
     self.requests = mockRequests ? MockHttpRequester(baseUrl: baseUrl) : HttpRequester(baseUrl: baseUrl)
+    
+    self.featureFlags = featureFlags
   }
 
   /// Retrieve the client by API key.
@@ -307,7 +311,17 @@ public class PortalApi {
     backupMethod: BackupMethods.RawValue,
     completion: @escaping (Result<String>) -> Void
   ) throws {
-    let body = ["success": success, "backupMethod": "\(backupMethod)"] as [String: Any]
+    // Start with a dictionary containing the always-present keys
+    var body: [String: Any] = [
+      "backupMethod": "\(backupMethod)",
+      "success": success,
+    ]
+
+    // Conditionally add isMultiBackupEnabled if it's not nil
+    if let isMultiBackupEnabled = self.featureFlags?.isMultiBackupEnabled {
+      body["isMultiBackupEnabled"] = isMultiBackupEnabled
+    }
+
     try self.requests.put(
       path: "/api/v2/clients/me/wallet/stored-client-backup-share-key",
       body: body,
@@ -348,7 +362,17 @@ public class PortalApi {
     backupMethod: BackupMethods.RawValue,
     completion: @escaping (Result<String>) -> Void
   ) throws {
-    let body = ["success": success, "backupMethod": "\(backupMethod)"] as [String: Any]
+    // Start with a dictionary containing the always-present keys
+    var body: [String: Any] = [
+      "backupMethod": "\(backupMethod)",
+      "success": success,
+    ]
+
+    // Conditionally add isMultiBackupEnabled if it's not nil
+    if let isMultiBackupEnabled = self.featureFlags?.isMultiBackupEnabled {
+      body["isMultiBackupEnabled"] = isMultiBackupEnabled
+    }
+
     try self.requests.put(
       path: "/api/v2/clients/me/wallet/stored-client-backup-share",
       body: body,
@@ -384,6 +408,7 @@ public class PortalApi {
   /// - Parameter completion: The callback that contains the list of SigningSharePairs' details.
   /// - Returns: Void.
   public func getSigningShareMetadata(completion: @escaping (Result<[SigningSharePair]>) -> Void) throws {
+    print("test")
     try self.requests.get(
       path: "/api/v1/clients/me/signing-share-pairs",
       headers: [

--- a/Sources/PortalSwift/Core/PortalApi.swift
+++ b/Sources/PortalSwift/Core/PortalApi.swift
@@ -39,7 +39,7 @@ public class PortalApi {
 
     let baseUrl = apiHost.starts(with: "localhost") ? "http://\(apiHost)" : "https://\(apiHost)"
     self.requests = mockRequests ? MockHttpRequester(baseUrl: baseUrl) : HttpRequester(baseUrl: baseUrl)
-    
+
     self.featureFlags = featureFlags
   }
 

--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -100,7 +100,7 @@ public class Portal {
     )
 
     // Initialize the Portal API
-    self.api = PortalApi(apiKey: apiKey, apiHost: apiHost, provider: self.provider)
+    self.api = PortalApi(apiKey: apiKey, apiHost: apiHost, provider: self.provider, featureFlags: self.featureFlags)
 
     // Ensure storage adapters have access to the Portal API
     if backup.gdrive != nil {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR passes the `featureFlag.isMultiBackupEnabled` if present to `storedClientBackupShare` and `storedClientBackupShareKey` requests.

## Details

### Code
- Checked against coding style guide: Yes|No
  <!-- - Deviations from the style guide: [List any deviations] -->
  <!-- - Potential style guide updates: [Any suggestions?] -->
- Documentation updated: Yes|No|Pending
  <!-- - If pending, describe what needs to be updated -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: Yes|No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: Yes|No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: Yes|No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: Yes|No
  <!-- - If no, reason: [Reason here] -->
- Manual tests in staging: Pending
  <!-- - ![Screenshot or video link here if applicable] -->
- E2E tests in Datadog: Pending
  <!-- ![Screenshot of e2e tests passing] -->

### Misc.
- Metrics, logs, or traces added: Yes|No
- Changelog updated: Yes|No
  <!-- - If no, reason: [Reason here] -->
<!-- - Other notes: [Any other relevant notes] -->
