### PR TITLE
Kelsonic/eng 2903 update uint8 to int in portalprovider request

### DIFF
--- a/Sources/PortalSwift/Components/PortalWebView.swift
+++ b/Sources/PortalSwift/Components/PortalWebView.swift
@@ -126,11 +126,11 @@ public class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMess
       if let data = data as? [String: String] {
         print("Chain changed is parseable. \(data)")
 
-        let chainId = Int(UInt8(data["chainId"] ?? "0", radix: 16) ?? 0)
-        if chainId > 0 {
+        let chainIdString = data["chainId"] ?? "0" // Get the string value, defaulting to "0" if nil
+        if let chainIdInt = Int(chainIdString, radix: 16) {
           print("Sending postMessage to WebView...")
           let javascript = """
-            window.postMessage(JSON.stringify({ type: 'portal_chainChanged', data: { chainId: \(chainId) } }));
+            window.postMessage(JSON.stringify({ type: 'portal_chainChanged', data: { chainId: \(chainIdInt) } }));
           """
           self.evaluateJavascript(javascript)
         }

--- a/Sources/PortalSwift/Provider/PortalProvider.swift
+++ b/Sources/PortalSwift/Provider/PortalProvider.swift
@@ -229,22 +229,26 @@ public class PortalProvider {
     if payload.method == ETHRequestMethods.WalletSwitchEthereumChain.rawValue {
       let param = payload.params[0] as! [String: String]
 
-      if let chainId = UInt8(param["chainId"]!.replacingOccurrences(of: "0x", with: ""), radix: 16) {
-        do {
-          _ = try self.setChainId(value: Int(chainId), connect: connect)
-
-          let completionResult = RequestCompletionResult(
-            method: payload.method,
-            params: payload.params,
-            result: "null",
-            id: ""
-          )
-
-          _ = self.emit(event: Events.PortalSignatureReceived.rawValue, data: completionResult)
-
-          return completion(Result(data: completionResult))
-        } catch {
-          return completion(Result(error: error))
+      if let chainIdString = param["chainId"]?.replacingOccurrences(of: "0x", with: "") {
+        if let chainId = Int(chainIdString, radix: 16) {
+          do {
+            _ = try self.setChainId(value: Int(chainId), connect: connect)
+            
+            let completionResult = RequestCompletionResult(
+              method: payload.method,
+              params: payload.params,
+              result: "null",
+              id: ""
+            )
+            
+            _ = self.emit(event: Events.PortalSignatureReceived.rawValue, data: completionResult)
+            
+            return completion(Result(data: completionResult))
+          } catch {
+            return completion(Result(error: error))
+          }
+        } else {
+          return completion(Result(error: ProviderRpcError.unsupportedMethod))
         }
       } else {
         return completion(Result(error: ProviderRpcError.unsupportedMethod))

--- a/Sources/PortalSwift/Provider/PortalProvider.swift
+++ b/Sources/PortalSwift/Provider/PortalProvider.swift
@@ -233,16 +233,16 @@ public class PortalProvider {
         if let chainId = Int(chainIdString, radix: 16) {
           do {
             _ = try self.setChainId(value: Int(chainId), connect: connect)
-            
+
             let completionResult = RequestCompletionResult(
               method: payload.method,
               params: payload.params,
               result: "null",
               id: ""
             )
-            
+
             _ = self.emit(event: Events.PortalSignatureReceived.rawValue, data: completionResult)
-            
+
             return completion(Result(data: completionResult))
           } catch {
             return completion(Result(error: error))


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR updates our derivation of chainId from UInt8 to Int since UInt8 can only support up to `255` and many chain IDs have values far beyond that.

## Details

### Code
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated and create a triage ticket for it -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->

### Misc.
- Metrics, logs, or traces added: No
  <!-- - If yes, describe: [Describe what was added if necessary] -->
