### PR TITLE
ENG-3108 - ApiKey has to be private if it is not already

### DIFF
--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -724,8 +724,8 @@ class ViewController: UIViewController, UITextFieldDelegate {
       try portal.setGDriveView(self)
       try portal.setPasskeyAuthenticationAnchor(self.view.window!)
       try portal.setPasskeyConfiguration(relyingParty: config.relyingParty, webAuthnHost: config.webAuthnHost)
-      // The apikey is private within the Portal SDK class, so it must not be accessible from outside.
-      //self.logger.info("ViewController.registerPortal() - Portal API Key: \(portal.apiKey)")
+      // The apikey from Portal class is private within the Portal SDK class, so it must not be accessible from outside. We already have the clientApiKey from user
+      self.logger.info("ViewController.registerPortal() - Portal API Key: \(user.clientApiKey)")
 
       portal.on(event: Events.PortalSigningRequested.rawValue, callback: { data in
         portal.emit(Events.PortalSigningApproved.rawValue, data: data)

--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -724,8 +724,8 @@ class ViewController: UIViewController, UITextFieldDelegate {
       try portal.setGDriveView(self)
       try portal.setPasskeyAuthenticationAnchor(self.view.window!)
       try portal.setPasskeyConfiguration(relyingParty: config.relyingParty, webAuthnHost: config.webAuthnHost)
-
-      self.logger.info("ViewController.registerPortal() - Portal API Key: \(portal.apiKey)")
+      // The apikey is private within the Portal SDK class, so it must not be accessible from outside.
+      //self.logger.info("ViewController.registerPortal() - Portal API Key: \(portal.apiKey)")
 
       portal.on(event: Events.PortalSigningRequested.rawValue, callback: { data in
         portal.emit(Events.PortalSigningApproved.rawValue, data: data)

--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -33,7 +33,7 @@ public class Portal {
   }
 
   public let api: PortalApi
-  public let apiKey: String
+  internal let apiKey: String
   public let autoApprove: Bool
   public var gatewayConfig: [Int: String] = [:]
   public let provider: PortalProvider

--- a/Sources/PortalSwift/Provider/PortalProvider.swift
+++ b/Sources/PortalSwift/Provider/PortalProvider.swift
@@ -18,7 +18,7 @@ public class PortalProvider {
     }
   }
 
-  public let apiKey: String
+  private let apiKey: String
   public var autoApprove: Bool
   public var chainId: Chains.RawValue?
   public var delegate: PortalProviderDelegate?

--- a/Sources/PortalSwift/Storage/Passkey/PasskeyStorage.swift
+++ b/Sources/PortalSwift/Storage/Passkey/PasskeyStorage.swift
@@ -19,7 +19,7 @@ public class PasskeyStorage: Storage, PortalStorage {
 
   public var api: PortalApi?
 
-  public var apiKey: String?
+  internal var apiKey: String?
   public var client: Client?
   public let encryption: PortalEncryption
   public var portalApi: PortalApi?


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
- **Portal.Swift**: Updated `apikey` to internal because it is used in the `PortalWebViewClass`.
- **PortalProvider.swift**: Made the `apikey` private.
- **PasskeyStorage.swift**: Updated `apikey` to internal because it is used in the `PortalMPC.swift` class.
- **ViewController.swift**: Commented out code that uses `apikey` since it was previously public.
- Other than these changes, there are 6 classes that are already using `apikey` as private.

## Visuals
<!-- Attach screenshots or videos of any visual changes. If none, delete this section. -->
![Screenshot here]

## Details

### Code
- Documentation updated: Yes|No|Pending
  <!-- - If pending, describe what needs to be updated and create a triage ticket for it -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: Yes|No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: Yes|No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: Yes|No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: Yes|No
  <!-- - If no, reason: [Reason here] -->

### Misc.
- Metrics, logs, or traces added: Yes|No
  <!-- - If yes, describe: [Describe what was added if necessary] -->
