### PR TITLE
ENG-2809-Add check for params before calling count

### DIFF
--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -732,18 +732,6 @@ class ViewController: UIViewController, UITextFieldDelegate {
       portal.on(event: Events.PortalSigningRequested.rawValue, callback: { data in
         portal.emit(Events.PortalSigningApproved.rawValue, data: data)
       })
-      //code to verify decline condition
-//      portal.on(event: Events.PortalSigningRequested.rawValue) { data in
-//        let approved : Bool = false
-//        let passingData = approved ? data : nil
-//          let responseEventName = approved ? Events.PortalSigningApproved : Events.Connect
-//        self.portal!.emit(responseEventName.rawValue,
-//                          data: passingData as Any)
-//        print("check print console")
-//        if !approved{
-//          self.updateUIComponents()
-//        }
-//      }
 
       portal.on(event: Events.PortalSignatureReceived.rawValue) { (data: Any) in
         let result = data as! RequestCompletionResult

--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -732,6 +732,18 @@ class ViewController: UIViewController, UITextFieldDelegate {
       portal.on(event: Events.PortalSigningRequested.rawValue, callback: { data in
         portal.emit(Events.PortalSigningApproved.rawValue, data: data)
       })
+      //code to verify decline condition
+//      portal.on(event: Events.PortalSigningRequested.rawValue) { data in
+//        let approved : Bool = false
+//        let passingData = approved ? data : nil
+//          let responseEventName = approved ? Events.PortalSigningApproved : Events.Connect
+//        self.portal!.emit(responseEventName.rawValue,
+//                          data: passingData as Any)
+//        print("check print console")
+//        if !approved{
+//          self.updateUIComponents()
+//        }
+//      }
 
       portal.on(event: Events.PortalSignatureReceived.rawValue) { (data: Any) in
         let result = data as! RequestCompletionResult

--- a/Sources/PortalSwift/Provider/PortalProvider.swift
+++ b/Sources/PortalSwift/Provider/PortalProvider.swift
@@ -99,26 +99,24 @@ public class PortalProvider {
   ///   - data: The data to pass to registered event handlers.
   /// - Returns: The Portal Provider instance.
   public func emit(event: Events.RawValue, data: Any) -> PortalProvider {
-    let registeredEventHandlers = self.events[event]
-
-    if registeredEventHandlers == nil {
+    guard let registeredEventHandlers = self.events[event] else {
       self.logger.info(String(format: "PortalProvider.emit() - ⚠️ Could not find any bindings for event '%@'. Ignoring...", event))
       return self
-    } else {
-      // Invoke all registered handlers for the event
-      do {
-        for registeredEventHandler in registeredEventHandlers! {
-          try registeredEventHandler.handler(data)
-        }
-      } catch {
-        self.logger.info("PortalProvider.emit() - 🚨 Error invoking registered handlers: \(error.localizedDescription)")
-      }
-
-      // Remove once instances
-      self.events[event] = registeredEventHandlers?.filter(self.removeOnce)
-
-      return self
     }
+    
+    // Invoke all registered handlers for the event
+    do {
+      for registeredEventHandler in registeredEventHandlers {
+        try registeredEventHandler.handler(data)
+      }
+    } catch {
+      self.logger.info("PortalProvider.emit() - 🚨 Error invoking registered handlers: \(error.localizedDescription)")
+    }
+    
+    // Remove once instances
+    self.events[event] = registeredEventHandlers.filter(self.removeOnce)
+    
+    return self
   }
 
   /// Registers a callback for an event.

--- a/Sources/PortalSwift/Utils/EventBus.swift
+++ b/Sources/PortalSwift/Utils/EventBus.swift
@@ -21,26 +21,23 @@ public class EventBus {
   ///   - data: The data to pass to registered event handlers.
   /// - Returns: The Portal Provider instance.
   public func emit(event: Events.RawValue, data: Any) {
-    let registeredEventHandlers = self.events[event]
-
-    if registeredEventHandlers == nil {
+    guard let registeredEventHandlers = self.events[event] else {
       print(String(format: "[\(self.label)] Could not find any bindings for event '%@'. Ignoring...", event))
       return
-    } else {
-      // Invoke all registered handlers for the event
-      do {
-        for registeredEventHandler in registeredEventHandlers! {
-          try registeredEventHandler.handler(data)
-        }
-      } catch {
-        print("[\(self.label)] Error invoking registered handlers", error)
-      }
-
-      // Remove once instances
-      self.events[event] = registeredEventHandlers?.filter(self.removeOnce)
-
-      return
     }
+    // Invoke all registered handlers for the event
+    do {
+      for registeredEventHandler in registeredEventHandlers {
+        try registeredEventHandler.handler(data)
+      }
+    } catch {
+      print("[\(self.label)] Error invoking registered handlers", error)
+    }
+    
+    // Remove once instances
+    self.events[event] = registeredEventHandlers.filter(self.removeOnce)
+    
+    return
   }
 
   /// Registers a callback for an event.


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
- calling emit function multiple times for same event was causing the crash
- added a check using guard in PortalProvider.swift and EventBus.swift to check if the registered evnt is not nil
- added test code in viewcontroller to verify decline condition

## Visuals
<!-- Attach screenshots or videos of any visual changes. If none, delete this section. -->
![Screenshot here]

## Details

### Code
- Documentation updated: Yes|No|Pending
  <!-- - If pending, describe what needs to be updated and create a triage ticket for it -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: Yes|No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: Yes|No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: Yes|No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: Yes|No
  <!-- - If no, reason: [Reason here] -->

### Misc.
- Metrics, logs, or traces added: Yes|No
  <!-- - If yes, describe: [Describe what was added if necessary] -->
