### PR TITLE
Fix once event handler cleanup issue

### DIFF
--- a/Sources/PortalSwift/Provider/PortalProvider.swift
+++ b/Sources/PortalSwift/Provider/PortalProvider.swift
@@ -431,7 +431,7 @@ public class PortalProvider {
 
         if approvedPayload.id == payload.id, !self.processedRequestIds.contains(payload.id!) {
           self.processedRequestIds.append(payload.id!)
-
+          _ = self.removeListener(event: Events.PortalSigningApproved.rawValue)
           // If the approved event is fired
           return completion(Result(data: true))
         }
@@ -442,6 +442,7 @@ public class PortalProvider {
 
         if rejectedPayload.id == payload.id, !self.processedRequestIds.contains(payload.id!) {
           self.processedRequestIds.append(payload.id!)
+          _ = self.removeListener(event: Events.PortalSigningApproved.rawValue)
           // If the rejected event is fired
           return completion(Result(data: false))
         }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
- updated code in PortalProvider.swift for removing listener in case of signing approved or signing rejected

## Visuals
<!-- Attach screenshots or videos of any visual changes. If none, delete this section. -->
![Screenshot here]

## Details

### Code
- Documentation updated: Yes|No|Pending
  <!-- - If pending, describe what needs to be updated and create a triage ticket for it -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: Yes|No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: Yes|No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: Yes|No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: Yes|No
  <!-- - If no, reason: [Reason here] -->

### Misc.
- Metrics, logs, or traces added: Yes|No
  <!-- - If yes, describe: [Describe what was added if necessary] -->
