### PR TITLE
Added test case for PortalConnect.swift

### DIFF
--- a/Sources/PortalSwift/Mocks/Constants.swift
+++ b/Sources/PortalSwift/Mocks/Constants.swift
@@ -377,4 +377,29 @@ public enum MockConstants {
       return mockMpcShareString
     }
   }
+  
+  public static var mockConnectData: ConnectData {
+    return ConnectData(id: "test-mock-connect-data-id", topic: "test-mock-connect-data-topic", params: SessionProposal(id: 1, params: Params(id: -1, pairingTopic: "", expiry: 1, requiredNamespaces: Namespaces(), relays: [], proposer: Proposer(publicKey: "", metadata: Metadata(description: "", url: "", icons: [], name: "")), verifyContext: nil)))
+  }
+    
+  public static var mockConnectedData: ConnectedData {
+    return ConnectedData(id: "test-mock-connected-data-id", topic: "test-mock-connected-data-topic", params: Pairing(active: true, expiry: nil, peerMetadata: PeerMetadata(name: "test-mock-connected-data-peer-metadata-name", description: "test-mock-connected-data-peer-metadata-description", url: "test-mock-connected-data-peer-metadata-url", icons: []), relay: nil, topic: "test-mock-connected-data-peer-metadata-topic"))
+  }
+  
+  public static var mockDicConnectedData: DisconnectData {
+    return DisconnectData(id: "test-mock-dis-connected-data-id", topic: "test-mock-dis-connected-data-topic")
+  }
+    
+  public static var mockSessionRequestData: SessionRequestData {
+    return SessionRequestData(id: "test-mock-session-request-data-id", params: ProviderRequestParams(chainId: 11_155_111, request: ProviderRequestData(method: "eth_sign", params: ["0x1234"])), topic: "test-mock-session-request-data-topic")
+  }
+  
+  public static var mockSessionRequestAddressData: SessionRequestAddressData {
+    return SessionRequestAddressData(id: "test-mock-session-request-data-id", params: ProviderRequestAddressParams(chainId: 11_155_111, request: ProviderRequestAddressData(method: "eth_sign", params: [ETHAddressParam(address: mockEip155Address)])), topic: "test-mock-session-request-data-topic")
+  }
+  
+  public static var mockSessionRequestTransactionData: SessionRequestTransactionData {
+    return SessionRequestTransactionData(id: "test-mock-session-request-data-id", params: ProviderRequestTransactionParams(chainId: 11_155_111, request: ProviderRequestTransactionData(method: "eth_sign", params: [ETHTransactionParam(from: mockEip155Address, to: "0xd46e8dd67c5d32be8058bb8eb970870f07244567")])), topic: "test-mock-session-request-data-topic")
+  }
+
 }

--- a/Sources/PortalSwift/Mocks/Utils/MockWebSocketClient.swift
+++ b/Sources/PortalSwift/Mocks/Utils/MockWebSocketClient.swift
@@ -1,0 +1,43 @@
+//
+//  MockWebSocketClient.swift
+//  
+//
+//  Created by Portal Labs on 12/06/2024.
+//
+import Foundation
+
+class MockWebSocketClient: WebSocketClient {
+  private var mockConnectState: ConnectState = .disconnected
+  var onConnect: (() -> Void)?
+  var onSend: ((Data) -> Void)?
+  var uri: String?
+  override var isConnected: Bool {
+    return mockConnectState == .connected || mockConnectState == .connecting
+  }
+  
+  override func connect(uri: String) {
+    self.uri = uri
+    self.mockConnectState = .connecting
+    DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
+      self.mockConnectState = .connected
+      self.onConnect?()
+    }
+  }
+  
+  override func disconnect(_ userInitiated: Bool = false) {
+    self.mockConnectState = .disconnected
+  }
+  
+  override func sendFinalMessageAndDisconnect() {
+    self.mockConnectState = .disconnecting
+    DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
+      self.mockConnectState = .disconnected
+    }
+  }
+  
+  override func send(_ data: Data) {
+    self.onSend?(data)
+  }
+  
+}
+

--- a/Tests/PortalSwiftTests/PortalConnectTest.swift
+++ b/Tests/PortalSwiftTests/PortalConnectTest.swift
@@ -1,0 +1,116 @@
+//
+//  PortalConnectTest.swift
+//  
+//
+//  Created by Portal Labs on 12/06/2024.
+//
+
+import XCTest
+@testable import PortalSwift
+
+class PortalConnectTest: XCTestCase {
+  var portalConnect: PortalConnect!
+  var mockClient: MockWebSocketClient!
+  
+  let mockURL = "https://\(MockConstants.mockHost)/test-rpc"
+  
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    
+    let keychain = MockPortalKeychain()
+    let chainId = 11_155_111
+    
+    portalConnect = try PortalConnect(
+      MockConstants.mockApiKey,
+      chainId,
+      keychain,
+      ["eip155:11155111": mockURL]
+    )
+    
+    mockClient = MockWebSocketClient(apiKey: MockConstants.mockApiKey, connect: portalConnect)
+    portalConnect.client = mockClient
+  }
+  
+  override func tearDownWithError() throws {
+    portalConnect = nil
+    mockClient = nil
+    try super.tearDownWithError()
+  }
+  
+  func testConnect_success() {
+    portalConnect.connect(mockURL)
+    XCTAssertTrue(self.mockClient.isConnected)
+    XCTAssertEqual(self.mockClient.uri, self.mockURL)
+  }
+  
+  func testDisconnect() {
+    portalConnect.connect(mockURL)
+    portalConnect.disconnect(true)
+    XCTAssertFalse(mockClient.isConnected)
+  }
+  
+  func testHandleClose() {
+    portalConnect.handleClose()
+    XCTAssertNil(portalConnect.client!.topic)
+    XCTAssertFalse(portalConnect.client!.isConnected)
+  }
+  
+  func testHandleDappSessionRequested_approved() throws {
+    let data = MockConstants.mockConnectData
+    
+    let expectation = self.expectation(description: "DappSessionApproved event should be handled")
+    mockClient.onSend = { message in
+      let event = try! JSONDecoder().decode(DappSessionResponseMessage.self, from: message)
+      XCTAssertEqual(event.event, "portal_dappSessionApproved")
+      expectation.fulfill()
+    }
+    
+    portalConnect.handleDappSessionRequested(data: data)
+    portalConnect.emit(event: Events.PortalDappSessionApproved.rawValue, data: data)
+    
+    waitForExpectations(timeout: 2.0, handler: nil)
+  }
+  
+  func testHandleDappSessionRequested_rejected() throws {
+    let data = MockConstants.mockConnectData
+    
+    let expectation = self.expectation(description: "DappSessionRejected event should be handled")
+    mockClient.onSend = { message in
+      let event = try! JSONDecoder().decode(DappSessionResponseMessage.self, from: message)
+      XCTAssertEqual(event.event, "portal_dappSessionRejected")
+      expectation.fulfill()
+    }
+    
+    portalConnect.handleDappSessionRequested(data: data)
+    portalConnect.emit(event: Events.PortalDappSessionRejected.rawValue, data: data)
+    
+    waitForExpectations(timeout: 2.0, handler: nil)
+  }
+  
+  func testHandleSessionRequest_success() async throws {
+    let data = MockConstants.mockSessionRequestData
+    
+    let expectation = self.expectation(description: "SessionRequest should be handled successfully")
+    portalConnect.handleSessionRequest(data: data)
+    expectation.fulfill()
+    await fulfillment(of: [expectation], timeout: 5.0)
+  }
+  
+  func testHandleSessionRequestAddress_success() async throws {
+    let data = MockConstants.mockSessionRequestAddressData
+    
+    let expectation = self.expectation(description: "SessionRequestAddress should be handled successfully")
+    portalConnect.handleSessionRequestAddress(data: data)
+    expectation.fulfill()
+    await fulfillment(of: [expectation], timeout: 5.0)
+  }
+  
+  func testHandleSessionRequestTransaction_success() async throws {
+    let data = MockConstants.mockSessionRequestTransactionData
+    
+    let expectation = self.expectation(description: "SessionRequestTransaction should be handled successfully")
+    portalConnect.handleSessionRequestTransaction(data: data)
+    expectation.fulfill()
+    await fulfillment(of: [expectation], timeout: 5.0)
+  }  
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
- MockConstants.swift - updated some values that are needed to write test case.
- created new class PortalConnectTest and MockWebSocketClient
- added test cases for following methods: connect
         disconnect
         handleClose
         handleDappSessionRequested
         handleSessionRequest
         handleSessionRequestAddress
         handleSessionRequestTransaction
         handleProviderRequest - can not add test case for this because this is private method

## Visuals
<!-- Attach screenshots or videos of any visual changes. If none, delete this section. -->
![Screenshot here]

## Details

### Code
- Documentation updated: Yes|No|Pending
  <!-- - If pending, describe what needs to be updated and create a triage ticket for it -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: Yes|No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: Yes|No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: Yes|No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: Yes|No
  <!-- - If no, reason: [Reason here] -->

### Misc.
- Metrics, logs, or traces added: Yes|No
  <!-- - If yes, describe: [Describe what was added if necessary] -->
