### PR TITLE
Don't make feature flags optimized configurable, set it to true always

### DIFF
--- a/Cocoapods Example/PortalSwift/Portal.swift
+++ b/Cocoapods Example/PortalSwift/Portal.swift
@@ -104,7 +104,7 @@ class PortalWrapper {
     case cantLoadInfoPlist
   }
 
-  func registerPortal(apiKey: String, backup: BackupOptions, chainId: Int = 11_155_111, optimized: Bool = false, isMultiBackupEnabled: Bool? = nil, completion: @escaping (Result<Bool>) -> Void) {
+  func registerPortal(apiKey: String, backup: BackupOptions, chainId: Int = 11_155_111, isMultiBackupEnabled: Bool? = nil, completion: @escaping (Result<Bool>) -> Void) {
     do {
       guard let infoDictionary: [String: Any] = Bundle.main.infoDictionary else {
         return completion(Result(error: PortalWrapperError.cantLoadInfoPlist))
@@ -127,7 +127,7 @@ class PortalWrapper {
         autoApprove: false,
         apiHost: self.API_URL!,
         mpcHost: self.MPC_URL!,
-        featureFlags: FeatureFlags(optimized: optimized, isMultiBackupEnabled: isMultiBackupEnabled)
+        featureFlags: FeatureFlags(isMultiBackupEnabled: isMultiBackupEnabled)
       )
       _ = self.portal?.provider.on(event: Events.PortalSigningRequested.rawValue, callback: { [weak self] data in self?.didRequestApproval(data: data) })
       _ = self.portal?.provider.on(event: Events.PortalSignatureReceived.rawValue) { (data: Any) in

--- a/Cocoapods Example/PortalSwift/ViewController.swift
+++ b/Cocoapods Example/PortalSwift/ViewController.swift
@@ -699,7 +699,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
       self.passkey = PasskeyStorage(viewController: self, relyingParty: "portalhq.io", webAuthnHost: self.RP_URL)
       let backup = BackupOptions(gdrive: GDriveStorage(clientID: GDRIVE_CLIENT_ID, viewController: self), icloud: ICloudStorage(), passwordStorage: PasswordStorage(), passkeyStorage: self.passkey)
 
-      self.PortalWrapper.registerPortal(apiKey: apiKey, backup: backup, optimized: true, isMultiBackupEnabled: true) { _ in
+      self.PortalWrapper.registerPortal(apiKey: apiKey, backup: backup, isMultiBackupEnabled: true) { _ in
         DispatchQueue.main.async {
           self.generateButton?.isEnabled = true
 

--- a/Cocoapods Example/Tests/e2e/PasswordWalletTests.swift
+++ b/Cocoapods Example/Tests/e2e/PasswordWalletTests.swift
@@ -70,7 +70,7 @@ class PasswordWalletTests: XCTestCase {
       let backupOption = LocalFileStorage(fileName: "PORTAL_BACKUP")
       let backup = BackupOptions(local: backupOption)
       print("registering portal")
-      PasswordWalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11_155_111, optimized: true) {
+      PasswordWalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11_155_111) {
         result in
         guard result.error == nil else {
           registerExpectation.fulfill()

--- a/Cocoapods Example/Tests/e2e/ProviderTests.swift
+++ b/Cocoapods Example/Tests/e2e/ProviderTests.swift
@@ -1249,7 +1249,7 @@ class ProviderTests: XCTestCase {
     let backup = BackupOptions(local: backupOption)
     print("Registering portal...")
 
-    ProviderTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: chainId, optimized: true) { result in
+    ProviderTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: chainId) { result in
       guard result.error == nil else {
         XCTFail("Unable to register Portal")
         completion(false)

--- a/Cocoapods Example/Tests/e2e/WalletTests.swift
+++ b/Cocoapods Example/Tests/e2e/WalletTests.swift
@@ -75,7 +75,7 @@ class WalletTests: XCTestCase {
 //      let backupOption = LocalFileStorage(fileName: "PORTAL_BACKUP")
 //      let backup = BackupOptions(local: backupOption)
 //      print("registering portal")
-//      WalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11_155_111, optimized: true) {
+//      WalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11_155_111) {
 //        result in
 //        guard result.error == nil else {
 //          registerExpectation.fulfill()

--- a/PortalSwift.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PortalSwift.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "anycodable",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Flight-School/AnyCodable",
+      "location" : "https://github.com/Flight-School/AnyCodable.git",
       "state" : {
         "revision" : "862808b2070cd908cb04f9aafe7de83d35f81b05",
         "version" : "0.6.7"

--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -720,7 +720,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
           "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1": "https://solana-devnet.g.alchemy.com/v2/\(config.alchemyApiKey)"
         ],
         autoApprove: false,
-        featureFlags: FeatureFlags(optimized: true, isMultiBackupEnabled: true),
+        featureFlags: FeatureFlags(isMultiBackupEnabled: true),
         apiHost: config.apiUrl,
         mpcHost: config.mpcUrl
       )

--- a/SPM Example/Tests/e2e/PasswordWalletTests.swift
+++ b/SPM Example/Tests/e2e/PasswordWalletTests.swift
@@ -83,7 +83,7 @@ final class PasswordWalletTests: XCTestCase {
       let backupOption = LocalFileStorage(fileName: "PORTAL_BACKUP")
       let backup = BackupOptions(local: backupOption)
       print("registering portal")
-      PasswordWalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11_155_111, optimized: true) {
+      PasswordWalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11_155_111) {
         result in
         guard result.error == nil else {
           registerExpectation.fulfill()

--- a/SPM Example/Tests/e2e/ProviderTests.swift
+++ b/SPM Example/Tests/e2e/ProviderTests.swift
@@ -1263,7 +1263,7 @@ class ProviderTests: XCTestCase {
 //    let backup = BackupOptions(local: backupOption)
 //    print("Registering portal...")
 //
-//    ProviderTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: chainId, optimized: true) { result in
+//    ProviderTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: chainId) { result in
 //      guard result.error == nil else {
 //        XCTFail("Unable to register Portal")
 //        completion(false)

--- a/SPM Example/Tests/e2e/WalletTests.swift
+++ b/SPM Example/Tests/e2e/WalletTests.swift
@@ -70,7 +70,7 @@ final class WalletTests: XCTestCase {
       let backupOption = LocalFileStorage(fileName: "PORTAL_BACKUP")
       let backup = BackupOptions(local: backupOption)
       print("registering portal")
-      WalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11_155_111, optimized: true) {
+      WalletTests.PortalWrap.registerPortal(apiKey: userResult.clientApiKey, backup: backup, chainId: 11_155_111) {
         result in
         guard result.error == nil else {
           registerExpectation.fulfill()

--- a/Sources/PortalSwift/Core/Mpc/Mobile/MpcMobileProtocol.swift
+++ b/Sources/PortalSwift/Core/Mpc/Mobile/MpcMobileProtocol.swift
@@ -14,7 +14,7 @@ public struct MpcMetadata: Codable {
   var curve: PortalCurve?
   var isMultiBackupEnabled: Bool? = nil
   var mpcServerVersion: String
-  var optimized: Bool
+  var optimized: Bool = true
 }
 
 extension MpcMetadata {

--- a/Sources/PortalSwift/Core/Mpc/PortalMpc.swift
+++ b/Sources/PortalSwift/Core/Mpc/PortalMpc.swift
@@ -75,8 +75,7 @@ public class PortalMpc {
     self.mpcMetadata = MpcMetadata(
       clientPlatform: "NATIVE_IOS",
       isMultiBackupEnabled: featureFlags?.isMultiBackupEnabled,
-      mpcServerVersion: self.version,
-      optimized: featureFlags?.optimized ?? false
+      mpcServerVersion: self.version
     )
   }
 

--- a/Sources/PortalSwift/PortalTypes.swift
+++ b/Sources/PortalSwift/PortalTypes.swift
@@ -35,11 +35,9 @@ public struct PortalBackupWalletResponse {
  *********************************************/
 
 public struct FeatureFlags {
-  public var optimized: Bool
   public var isMultiBackupEnabled: Bool?
 
-  public init(optimized: Bool, isMultiBackupEnabled: Bool? = nil) {
-    self.optimized = optimized
+  public init(isMultiBackupEnabled: Bool? = nil) {
     self.isMultiBackupEnabled = isMultiBackupEnabled
   }
 }

--- a/Sources/PortalSwift/Provider/MpcSigner/PortalMpcSigner.swift
+++ b/Sources/PortalSwift/Provider/MpcSigner/PortalMpcSigner.swift
@@ -35,8 +35,7 @@ public class PortalMpcSigner {
     self.mpcMetadata = MpcMetadata(
       clientPlatform: "NATIVE_IOS",
       isMultiBackupEnabled: featureFlags?.isMultiBackupEnabled,
-      mpcServerVersion: self.version,
-      optimized: featureFlags?.optimized ?? false
+      mpcServerVersion: self.version
     )
   }
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR removes `optimized` as a feature flag and instead always sets it to `true` when passing it to MPC binary methods.

## Details

### Code
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated and create a triage ticket for it -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: Yes, must remove `optimized` feature flag
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: Yes, customers will always be using pre-generated primes
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->

### Misc.
- Metrics, logs, or traces added: No
  <!-- - If yes, describe: [Describe what was added if necessary] -->
