### PR TITLE
[Example] Add success / fail message to the UI with the result of deleting keychain

### DIFF
--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -200,8 +200,10 @@ class ViewController: UIViewController, UITextFieldDelegate {
       try await portal.deleteShares()
       try portal.deleteAddress()
       try portal.deleteSigningShare()
+      self.showStatusView(message: "\(successStatus) Deleted keychain data")
       self.logger.debug("ViewController.deleteKeychain() - ✅ Deleted keychain data")
     } catch {
+      self.showStatusView(message: "\(failureStatus) Error deleting keychain data: \(error)")
       self.logger.error("ViewController.deleteKeychain() - ❌ Error deleting keychain data: \(error)")
     }
   }
@@ -970,6 +972,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
   @IBAction func handleDeleteKeychain(_: Any) {
     Task {
       guard let portal else {
+        self.showStatusView(message: "\(failureStatus) Error Deleting Keychain - Portal not initialized.")
         throw PortalExampleAppError.portalNotInitialized()
       }
 


### PR DESCRIPTION
Add success / fail message to the UI with the result of deleting keychain when click on the "Delete Keychain" button.

## Summary
<!-- Briefly describe what this PR is about. -->
Add success / fail message to the UI with the result of deleting keychain when click on the "Delete Keychain" button.


## Visuals

![simulator_screenshot_43A4D381-781D-4F3E-A447-985DA42A5CD8](https://github.com/portal-hq/PortalSwift/assets/6969466/fe4966e8-07e0-45df-b501-3528e875ad56)

## Details

### Code
- Documentation updated: No
  <!-- - If pending, describe what needs to be updated and create a triage ticket for it -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: Yes|No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added:  No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added:  No
  <!-- - If no, reason: [Reason here] -->

### Misc.
- Metrics, logs, or traces added:  No
  <!-- - If yes, describe: [Describe what was added if necessary] -->
