### PR TITLE
HOTFIX - Ensure continuations return when throwing

### DIFF
--- a/Sources/PortalSwift/Core/Mpc/PortalMpc.swift
+++ b/Sources/PortalSwift/Core/Mpc/PortalMpc.swift
@@ -157,6 +157,7 @@ public class PortalMpc {
               )
             } catch {
               continuation.resume(throwing: error)
+              return
             }
           }
 
@@ -258,6 +259,7 @@ public class PortalMpc {
           continuation.resume(returning: addresses)
         } catch {
           continuation.resume(throwing: error)
+          return
         }
       }
     }
@@ -319,6 +321,7 @@ public class PortalMpc {
             continuation.resume(returning: generateResponse)
           } catch {
             continuation.resume(throwing: error)
+            return
           }
         }
       }
@@ -426,6 +429,7 @@ public class PortalMpc {
             continuation.resume(returning: recoverResponse)
           } catch {
             continuation.resume(throwing: error)
+            return
           }
         }
       }
@@ -552,6 +556,7 @@ public class PortalMpc {
           continuation.resume(returning: backupShare)
         } catch {
           continuation.resume(throwing: error)
+          return
         }
       }
     }
@@ -589,6 +594,7 @@ public class PortalMpc {
         } catch {
           self.logger.error("Error generating \(forCurve.rawValue) share: \(error.localizedDescription)")
           continuation.resume(throwing: error)
+          return
         }
       }
     }
@@ -644,6 +650,7 @@ public class PortalMpc {
           continuation.resume(returning: signingShare)
         } catch {
           continuation.resume(throwing: error)
+          return
         }
       }
     }

--- a/Sources/PortalSwift/Utils/PortalEncryption.swift
+++ b/Sources/PortalSwift/Utils/PortalEncryption.swift
@@ -33,6 +33,7 @@ public class PortalEncryption {
           continuation.resume(returning: decryptedShare)
         } catch {
           continuation.resume(throwing: error)
+          return
         }
       }
     }
@@ -64,6 +65,7 @@ public class PortalEncryption {
           continuation.resume(returning: decryptedShare)
         } catch {
           continuation.resume(throwing: error)
+          return
         }
       }
     }
@@ -95,6 +97,7 @@ public class PortalEncryption {
           continuation.resume(returning: encryptData)
         } catch {
           continuation.resume(throwing: error)
+          return
         }
       }
     }
@@ -126,6 +129,7 @@ public class PortalEncryption {
           continuation.resume(returning: encryptData.cipherText)
         } catch {
           continuation.resume(throwing: error)
+          return
         }
       }
     }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->

Resolves an issue with `continuation.resume(throwing:)` not returning after. Resulting in the logging of shares on the machine.