### PR TITLE
[Fix] add Thread-Safe Wrapper to the ClientResponse in the PortalApi.

### DIFF
--- a/Sources/PortalSwift/Core/Api/PortalApi.swift
+++ b/Sources/PortalSwift/Core/Api/PortalApi.swift
@@ -8,7 +8,7 @@
 import AnyCodable
 import Foundation
 
-/// The ClientStorage is just a thread-safe actor to consume the ClientResponse class, we need to refactor that later.
+/// The ThreadSafeClientWrapper is just a thread-safe actor to consume the ClientResponse class, we need to refactor that later.
 private actor ThreadSafeClientWrapper {
   private var _client: ClientResponse?
 


### PR DESCRIPTION
## Important
This change needs careful review and testing.

## Summary
[Fix] add Thread-Safe Wrapper to the ClientResponse in the PortalApi.

### Code
- Documentation updated: No (no update needed)

### Impact
- Breaking Changes: No
- Performance impact: Yes
The PortalApi now using the ClientResponse in a Sync way.

### Testing
- Unit tests added: No
- E2E tests added: No

### Misc.
- Metrics, logs, or traces added: No
