### PR TITLE
[Fix] `Portal.isWalletBackedUp` returns `true` when it should return `false`

### DIFF
--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -556,7 +556,7 @@ public class Portal {
         return false
       } else {
         let wallets = client.wallets
-        let shares = client.wallets.map { wallet in
+        let shares = client.wallets.compactMap { wallet in
           wallet.backupSharePairs.first { signingShare in
             signingShare.status == .completed
           }


### PR DESCRIPTION
[Fix] `Portal.isWalletBackedUp` returns true even when the `client.wallets.backupSharePairs = []`, used compaxtMap instead of Map to ignore the `nil` values

### Code
- Documentation updated:  No

### Impact
- Breaking Changes: No
- Performance impact: No

### Testing
- Unit tests added: No
Added to another branch with a commit with id: 
49ba8668fdfa0eb119d6dbed13e3829aedb62bec [49ba866]

- E2E tests added: No

### Misc.
- Metrics, logs, or traces added: No
