### PR TITLE
PortalAPI - deprecate `track` with completion function

### DIFF
--- a/Sources/PortalSwift/Core/Api/PortalApi.swift
+++ b/Sources/PortalSwift/Core/Api/PortalApi.swift
@@ -662,6 +662,7 @@ public class PortalApi {
     }
   }
 
+  @available(*, deprecated, message: "Please use the async/await implementation of track().")
   func track(event: String, properties: [String: String], completion: ((Result<MetricsResponse>) -> Void)? = nil) {
     Task.init {
       do {


### PR DESCRIPTION
## Summary
PortalAPI - deprecate `track` with completion function