### PR TITLE
[Show Case] descriptive error localized description.

### DIFF
--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -1480,6 +1480,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
       } catch {
         self.stopLoading()
         self.logger.error("ViewController.handleGdriveRecover() - Error running recover: \(error)")
+          self.logger.error("ViewController.handleGdriveRecover() - Error running recover: \(error.localizedDescription)")
         self.showStatusView(message: "\(self.failureStatus) Error running recover \(error)")
       }
     }

--- a/Sources/PortalSwift/Core/Mpc/PortalMpc.swift
+++ b/Sources/PortalSwift/Core/Mpc/PortalMpc.swift
@@ -994,7 +994,7 @@ public enum MpcStatuses: String {
 }
 
 /// A list of errors MPC can throw.
-public enum MpcError: Error {
+public enum MpcError: LocalizedError {
   case addressNotFound(_ message: String)
   case backupMethodNotRegistered(_ message: String)
   case backupNoLongerSupported(_ message: String)
@@ -1027,6 +1027,10 @@ public enum MpcError: Error {
   case unsupportedStorageMethod
   case unwrappingAddress
   case walletModificationAlreadyInProgress
+
+    public var errorDescription: String? {
+        return "The operation couldn’t be completed. (PortalSwift.MpcError.\(self))"
+    }
 }
 
 /// A list of errors RSA can throw.


### PR DESCRIPTION
More descriptive Localized error messages,

This will make the error.localizedDescription more descriptive.

For example, for the error `PortalSwift.MpcError.walletModificationAlreadyInProgress`:

## Before the change:
`print(error)` -> will print `PortalSwift.MpcError.walletModificationAlreadyInProgress`
`print(error.localizedDescription)` -> will print `The operation couldn't be completed. (PortalSwift.MpcError error 31.)`

## After the change:
`print(error)` -> will print `PortalSwift.MpcError.walletModificationAlreadyInProgress`
`print(error.localizedDescription)` -> will print `The operation couldn’t be completed. (PortalSwift.MpcError.walletModificationAlreadyInProgress)`

we can even adjust the message to be more descriptive this is just a showcase and draft PR.