### PR TITLE
refactor: Send client info to eject API endpoint

### DIFF
--- a/Sources/PortalSwift/Core/Api/PortalApi.swift
+++ b/Sources/PortalSwift/Core/Api/PortalApi.swift
@@ -117,7 +117,12 @@ public class PortalApi: PortalApiProtocol {
   public func eject() async throws -> String {
     if let url = URL(string: "\(baseUrl)/api/v3/clients/me/eject") {
       do {
-        let data = try await post(url, withBearerToken: self.apiKey)
+        let body: [String: String] = [
+          "clientPlatform": "NATIVE_IOS",
+          "clientPlatformVersion": SDK_VERSION
+        ]
+
+        let data = try await post(url, withBearerToken: self.apiKey, andPayload: body)
         guard let ejectResponse = String(data: data, encoding: .utf8) else {
           throw PortalApiError.unableToReadStringResponse
         }

--- a/Tests/PortalSwiftTests/Core/PortalApiTests.swift
+++ b/Tests/PortalSwiftTests/Core/PortalApiTests.swift
@@ -110,6 +110,23 @@ extension PortalApiTests {
     XCTAssertEqual(portalRequestsSpy.postCallsCount, 1)
   }
 
+  @available(iOS 16.0, *)
+  func test_eject_willCall_requestPost_passingCorrectParams() async throws {
+    // given
+    let portalRequestsSpy = PortalRequestsSpy()
+    initPortalApiWith(requests: portalRequestsSpy)
+
+    // and given
+    _ = try await api?.eject()
+
+    // then
+    XCTAssertEqual(portalRequestsSpy.postFromParam?.path() ?? "", "/api/v3/clients/me/eject")
+    XCTAssertEqual(portalRequestsSpy.postAndPayloadParam as? [String: String] ?? [:], [
+      "clientPlatform": "NATIVE_IOS",
+      "clientPlatformVersion": SDK_VERSION
+    ])
+  }
+
   func test_eject_willThrowCorrectError_whenRequestPostThrowError() async throws {
     // given
     let portalRequestsFailMock = PortalRequestsFailMock()


### PR DESCRIPTION
## Details
send `clientPlatform` and `clientPlatformVersion` in the request body to the `/me/eject`

### Code
- Documentation updated: No
No need

### Impact
- Breaking Changes: No

- Performance impact: No

### Testing
- Unit tests added: Yes

### Misc.
- Metrics, logs, or traces added:  No
