### PR TITLE
rename the `PortalWebView.WebViewControllerErrors` to `PortalWebView.…

### DIFF
--- a/Sources/PortalSwift/Components/PortalWebView.swift
+++ b/Sources/PortalSwift/Components/PortalWebView.swift
@@ -28,7 +28,7 @@ public struct PortalMessageBody {
 }
 
 /// The errors the web view controller can throw.
-enum WebViewControllerErrors: LocalizedError {
+enum PortalWebViewErrors: LocalizedError {
   case unparseableMessage
   case MissingFieldsForEIP1559Transation
   case unknownMessageType(type: String)
@@ -365,7 +365,7 @@ open class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMessag
           try self.handlePortalSign(method: portalMessageBody.data.method, params: portalMessageBody.data.params)
         }
       default:
-        self.onError(Result(error: WebViewControllerErrors.unknownMessageType(type: portalMessageBody.type)))
+        self.onError(Result(error: PortalWebViewErrors.unknownMessageType(type: portalMessageBody.type)))
       }
     } catch {
       self.onError(Result(error: error))
@@ -412,7 +412,7 @@ open class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMessag
     let transactionParam: ETHTransactionParam
     if firstParams["maxPriorityFeePerGas"] != nil, firstParams["maxFeePerGas"] != nil {
       guard firstParams["maxPriorityFeePerGas"]!.isEmpty || firstParams["maxFeePerGas"]!.isEmpty else {
-        throw WebViewControllerErrors.MissingFieldsForEIP1559Transation
+        throw PortalWebViewErrors.MissingFieldsForEIP1559Transation
       }
       transactionParam = ETHTransactionParam(
         from: firstParams["from"]!,
@@ -570,12 +570,12 @@ open class PortalWebView: UIViewController, WKNavigationDelegate, WKScriptMessag
     }
 
     guard let requestData = result.data else {
-      self.onError(Result(error: WebViewControllerErrors.dataNilError))
+      self.onError(Result(error: PortalWebViewErrors.dataNilError))
       return
     }
 
     guard let signature = requestData.result as? String else {
-      self.onError(Result(error: WebViewControllerErrors.invalidResponseType))
+      self.onError(Result(error: PortalWebViewErrors.invalidResponseType))
       return
     }
 


### PR DESCRIPTION

## Details
rename the `PortalWebView.WebViewControllerErrors` to `PortalWebView.PortalWebViewErrors` for a better naming convention to be aligned with the class `PortalWebView`

### Code
- Documentation updated: No
No need

### Impact
- Breaking Changes: Yes (Maybe)
rename the `PortalWebView.WebViewControllerErrors` to `PortalWebView.PortalWebViewErrors`

- Performance impact: Yes

### Testing
- Unit tests added: No

- E2E tests added: No

### Misc.
- Metrics, logs, or traces added: No
