### PR TITLE
handle the `PortalKeychain.getMetadata()` decoding error properly.

### DIFF
--- a/Sources/PortalSwift/Core/Keychain/PortalKeychain.swift
+++ b/Sources/PortalSwift/Core/Keychain/PortalKeychain.swift
@@ -55,6 +55,7 @@ public class PortalKeychain: PortalKeychainProtocol {
     case noWalletsFound
     case shareNotFoundForCurve(_ curve: PortalCurve)
     case unableToEncodeKeychainData
+    case unableToDecodeMetadata
     case unexpectedItemData(item: String)
     case unhandledError(status: OSStatus)
     case unsupportedNamespace(_ chainId: String)
@@ -197,9 +198,12 @@ public class PortalKeychain: PortalKeychainProtocol {
       self.logger.error("PortalKeychain.getMetadata() - Unable to encode keychain data")
       throw KeychainError.unableToEncodeKeychainData
     }
-    let metadata = try decoder.decode(PortalKeychainClientMetadata.self, from: data)
-
-    return metadata
+    do {
+      let metadata = try decoder.decode(PortalKeychainClientMetadata.self, from: data)
+      return metadata
+    } catch {
+      throw KeychainError.unableToDecodeMetadata
+    }
   }
 
   public func getShare(_ forChainId: String) async throws -> String {

--- a/Tests/PortalSwiftTests/Core/PortalKeychainTests.swift
+++ b/Tests/PortalSwiftTests/Core/PortalKeychainTests.swift
@@ -165,6 +165,23 @@ extension PortalKeychainTests {
     // then
     XCTAssertTrue(keyChainAccessSpy.getItemCallsCount >= 1)
   }
+
+  func test_getAddresses_willThrowCorrectError_WhenThereIsNoMetadata() async throws {
+    // given
+    let keyChainAccessSpy = PortalKeyChainAccessSpy()
+    initKeychainWith(keychainAccess: keyChainAccessSpy)
+
+    do {
+      // and given
+      _ = try await keychain.getAddresses()
+      XCTFail("Expected error not thrown when calling PortalKeychain.getAddresses when there is metadata.")
+    } catch {
+      // then
+      XCTAssertEqual(error as? PortalKeychain.KeychainError, PortalKeychain.KeychainError.unableToDecodeMetadata)
+    }
+    // then
+    XCTAssertTrue(keyChainAccessSpy.getItemCallsCount >= 1)
+  }
 }
 
 // MARK: - getMetadata tests


### PR DESCRIPTION
## Summary
handle the `PortalKeychain.getMetadata()` decoding error properly.

### Testing
- Unit tests added: Yes
- E2E tests added: No

### Misc.
- Metrics, logs, or traces added: No