### PR TITLE
Add portal.api.fund  + portal.receiveTestnetAsset + portal.sendAsset

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Unit Tests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Unit Tests.xcscheme
@@ -8,8 +8,8 @@
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
       <Testables>

--- a/SPM Example/PortalSwift/Base.lproj/Main.storyboard
+++ b/SPM Example/PortalSwift/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23090" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23079"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +17,7 @@
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
                     </layoutGuides>
                     <scrollView key="view" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="mainViewController" id="kh9-bI-dsS">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="1125"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="1158"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WxW-BK-2tM">
@@ -383,13 +383,26 @@
                                 <rect key="frame" x="16" y="993" width="342" height="41"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="Fund Sepolia Wallet">
+                                <buttonConfiguration key="configuration" style="filled" title="Receive Asset (ETH)">
                                     <backgroundConfiguration key="background"/>
                                     <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                     <color key="baseBackgroundColor" red="0.027450980390000001" green="0.054901960780000002" blue="0.086274509799999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </buttonConfiguration>
                                 <connections>
                                     <action selector="handleFundSepolia:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="OQH-mh-gh1"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ePx-1g-j7r">
+                                <rect key="frame" x="14" y="1042" width="342" height="41"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Send Asset (ETH)">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" red="0.027450980390000001" green="0.054901960780000002" blue="0.086274509799999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="handleFundSepolia:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="qDZ-Cc-wEo"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="ejectAllButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V5k-BN-vvY">
@@ -405,19 +418,6 @@
                                     <action selector="handleEjectAll:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="jlh-3X-DKv"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hXu-Hw-ELJ">
-                                <rect key="frame" x="14" y="1042" width="342" height="41"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="Generate Solana and backup shares">
-                                    <backgroundConfiguration key="background"/>
-                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                    <color key="baseBackgroundColor" red="0.027450980390000001" green="0.054901960780000002" blue="0.086274509799999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </buttonConfiguration>
-                                <connections>
-                                    <action selector="handleGenerateSolanaAndBackupShares:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="wM4-i4-wOq"/>
-                                </connections>
-                            </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oF6-Ou-ZFR">
                                 <rect key="frame" x="272" y="138" width="87" height="28"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -431,6 +431,19 @@
                                     <action selector="didPressSettings:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Hac-vY-GcK"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hXu-Hw-ELJ">
+                                <rect key="frame" x="14" y="1091" width="342" height="41"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Generate Solana and backup shares">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" red="0.027450980390000001" green="0.054901960780000002" blue="0.086274509799999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="handleGenerateSolanaAndBackupShares:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="wM4-i4-wOq"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <variation key="default">
@@ -439,7 +452,7 @@
                             </mask>
                         </variation>
                     </scrollView>
-                    <size key="freeformSize" width="375" height="1125"/>
+                    <size key="freeformSize" width="375" height="1158"/>
                     <connections>
                         <outlet property="addressInformation" destination="0fE-Dt-jQE" id="FgG-eb-2eu"/>
                         <outlet property="dappBrowserButton" destination="qcu-G8-SAB" id="A5q-1k-dxD"/>
@@ -478,7 +491,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="93.599999999999994" y="69.715142428785612"/>
+            <point key="canvasLocation" x="93.599999999999994" y="84.557721139430285"/>
         </scene>
         <!--Web View Controller-->
         <scene sceneID="AeA-zC-7Sc">
@@ -712,7 +725,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemPinkColor">
-            <color red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/SPM Example/PortalSwift/Base.lproj/Main.storyboard
+++ b/SPM Example/PortalSwift/Base.lproj/Main.storyboard
@@ -389,7 +389,7 @@
                                     <color key="baseBackgroundColor" red="0.027450980390000001" green="0.054901960780000002" blue="0.086274509799999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </buttonConfiguration>
                                 <connections>
-                                    <action selector="handleFundSepolia:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="OQH-mh-gh1"/>
+                                    <action selector="handleReceiveAsset:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="7Ui-U5-54N"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ePx-1g-j7r">
@@ -402,7 +402,7 @@
                                     <color key="baseBackgroundColor" red="0.027450980390000001" green="0.054901960780000002" blue="0.086274509799999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </buttonConfiguration>
                                 <connections>
-                                    <action selector="handleFundSepolia:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="qDZ-Cc-wEo"/>
+                                    <action selector="handleSendAsset:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="U39-2j-hYj"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="ejectAllButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V5k-BN-vvY">
@@ -460,7 +460,6 @@
                         <outlet property="ejectAllButton" destination="V5k-BN-vvY" id="5TG-3y-6ed"/>
                         <outlet property="ejectButton" destination="xhu-mS-abX" id="Ihh-3a-afy"/>
                         <outlet property="ethBalanceInformation" destination="XWB-hw-iZv" id="c0l-fG-eWb"/>
-                        <outlet property="fundSepoliaButton" destination="weH-pZ-F1n" id="I3z-Up-cgE"/>
                         <outlet property="gdriveBackupButton" destination="DaJ-fr-bUt" id="5NR-6g-wxq"/>
                         <outlet property="gdriveRecoverButton" destination="U9U-6p-gAr" id="aUT-iv-Rxw"/>
                         <outlet property="generateButton" destination="PLS-JE-WGU" id="i8N-R8-wtj"/>
@@ -475,8 +474,10 @@
                         <outlet property="passwordRecoverButton" destination="e3a-WD-Rlx" id="1rg-cD-ovX"/>
                         <outlet property="personalSignButton" destination="ML8-lm-u4m" id="htk-XR-9zw"/>
                         <outlet property="portalConnectButton" destination="Oix-QY-d5L" id="ggO-uw-BBj"/>
+                        <outlet property="receiveAssetButton" destination="weH-pZ-F1n" id="FjP-f9-WsX"/>
                         <outlet property="scrollView" destination="kh9-bI-dsS" id="weE-Dd-shd"/>
                         <outlet property="sendAddress" destination="rf6-ZQ-VL3" id="jeB-Fl-Ghp"/>
+                        <outlet property="sendAssetButton" destination="ePx-1g-j7r" id="6Iz-DL-DbK"/>
                         <outlet property="sendButton" destination="a21-UV-DHr" id="e3D-3c-9Tc"/>
                         <outlet property="sendUniButton" destination="jpZ-X5-eUU" id="Caj-Z5-rEC"/>
                         <outlet property="signButton" destination="NGV-LW-69G" id="A0r-h6-x1L"/>
@@ -725,7 +726,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemPinkColor">
-            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -1311,14 +1311,11 @@ class ViewController: UIViewController, UITextFieldDelegate {
         self.startLoading()
 
         let chainId = "eip155:11155111"
-        let params = FundParams(
-          amount: "0.001",
-          token: "ETH"
-        )
+        let params = FundParams(amount: "0.001", token: "ETH")
         
-        let response = try await portal?.api.fund(chainId: chainId, params: params)
+        let response = try await portal?.receiveTestnetAsset(chainId: chainId, params: params)
         
-        if let txHash = response?.data.txHash {
+        if let txHash = response?.data?.txHash {
           self.logger.info("ViewController.handleFundSepolia() - ✅ Successfully sent transaction")
           self.showStatusView(message: "\(self.successStatus) Successfully sent transaction")
           self.logger.info("ViewController.handleFundSepolia() - ✅ Transaction Hash: \(txHash)")

--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -1319,8 +1319,8 @@ class ViewController: UIViewController, UITextFieldDelegate {
         let response = try await portal?.receiveTestnetAsset(chainId: chainId, params: params)
         
         if let txHash = response?.data?.txHash {
-          self.logger.info("ViewController.handleReceiveAsset() - ✅ Successfully sent transaction")
-          self.showStatusView(message: "\(self.successStatus) Successfully sent transaction")
+          self.logger.info("ViewController.handleReceiveAsset() - ✅ Successfully created transaction to fund account")
+          self.showStatusView(message: "\(self.successStatus) Successfully created transaction to fund account")
           self.logger.info("ViewController.handleReceiveAsset() - ✅ Transaction Hash: \(txHash)")
           try await self.populateEthBalance()
         }

--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -1309,11 +1309,22 @@ class ViewController: UIViewController, UITextFieldDelegate {
     Task {
       do {
         self.startLoading()
-        let transactionHash = try await sendSepoliaTransaction()
-        self.logger.info("ViewController.handleFundSepolia() - ✅ Successfully sent transaction")
-        self.showStatusView(message: "\(self.successStatus) Successfully sent transaction")
-        self.logger.info("ViewController.handleFundSepolia() - ✅ Transaction Hash: \(transactionHash)")
-        try await self.populateEthBalance()
+
+        let chainId = "eip155:11155111"
+        let params = FundParams(
+          amount: "0.001",
+          token: "ETH"
+        )
+        
+        let response = try await portal?.api.fund(chainId: chainId, params: params)
+        
+        if let txHash = response?.data.txHash {
+          self.logger.info("ViewController.handleFundSepolia() - ✅ Successfully sent transaction")
+          self.showStatusView(message: "\(self.successStatus) Successfully sent transaction")
+          self.logger.info("ViewController.handleFundSepolia() - ✅ Transaction Hash: \(txHash)")
+          try await self.populateEthBalance()
+        }
+
         self.stopLoading()
       } catch {
         self.stopLoading()

--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -1315,9 +1315,9 @@ class ViewController: UIViewController, UITextFieldDelegate {
 
         let chainId = "eip155:11155111"
         let params = FundParams(amount: "0.01", token: "NATIVE")
-        
+
         let response = try await portal?.receiveTestnetAsset(chainId: chainId, params: params)
-        
+
         if let txHash = response?.data?.txHash {
           self.logger.info("ViewController.handleReceiveAsset() - ✅ Successfully created transaction to fund account")
           self.showStatusView(message: "\(self.successStatus) Successfully created transaction to fund account")
@@ -1333,7 +1333,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
       }
     }
   }
-  
+
   @IBAction func handleSendAsset(_: UIButton) {
     Task {
       do {
@@ -1341,9 +1341,9 @@ class ViewController: UIViewController, UITextFieldDelegate {
 
         let chainId = "eip155:11155111"
         let params = SendAssetParams(to: "0xdFd8302f44727A6348F702fF7B594f127dE3A902", amount: "0.001", token: "NATIVE")
-        
+
         let response = try await portal?.sendAsset(chainId: chainId, params: params)
-        
+
         if let txHash = response?.txHash {
           self.logger.info("ViewController.handleSendAsset() - ✅ Successfully sent transaction")
           self.showStatusView(message: "\(self.successStatus) Successfully sent transaction")

--- a/Sources/PortalSwift/Core/Api/PortalApi.swift
+++ b/Sources/PortalSwift/Core/Api/PortalApi.swift
@@ -445,7 +445,7 @@ public class PortalApi: PortalApiProtocol {
     self.logger.error("PortalApi.updateShareStatus() - Unable to build request URL.")
     throw URLError(.badURL)
   }
-  
+
   public func fund(chainId: String, params: FundParams) async throws -> FundResponse {
     if let url = URL(string: "\(baseUrl)/api/v3/clients/me/fund") {
       let payload = FundRequestBody(amount: params.amount, chainId: chainId, token: params.token)

--- a/Sources/PortalSwift/Core/Api/PortalApi.swift
+++ b/Sources/PortalSwift/Core/Api/PortalApi.swift
@@ -12,6 +12,7 @@ public protocol PortalApiProtocol: AnyObject {
   var client: ClientResponse? { get async throws }
 
   func eject() async throws -> String
+  func fund(chainId: String, params: FundParams) async throws -> FundResponse
   func getBalances(_ chainId: String) async throws -> [FetchedBalance]
   func getClient() async throws -> ClientResponse
   func getClientCipherText(_ backupSharePairId: String) async throws -> String

--- a/Sources/PortalSwift/Core/Api/PortalApi.swift
+++ b/Sources/PortalSwift/Core/Api/PortalApi.swift
@@ -444,6 +444,18 @@ public class PortalApi: PortalApiProtocol {
     self.logger.error("PortalApi.updateShareStatus() - Unable to build request URL.")
     throw URLError(.badURL)
   }
+  
+  public func fund(chainId: String, params: FundParams) async throws -> FundResponse {
+    if let url = URL(string: "\(baseUrl)/api/v3/clients/me/fund") {
+      let payload = FundRequestBody(amount: params.amount, chainId: chainId, token: params.token)
+      let data = try await post(url, withBearerToken: self.apiKey, andPayload: payload)
+      let response = try decoder.decode(FundResponse.self, from: data)
+
+      return response
+    }
+
+    throw URLError(.badURL)
+  }
 
   public func buildEip155Transaction(chainId: String, params: BuildTransactionParam) async throws -> BuildEip115TransactionResponse {
     guard chainId.starts(with: "eip155:") else {

--- a/Sources/PortalSwift/Core/Api/PortalApiTypes.swift
+++ b/Sources/PortalSwift/Core/Api/PortalApiTypes.swift
@@ -532,6 +532,42 @@ public enum EvaluateTransactionOperationType: String, CaseIterable {
   case all
 }
 
+public struct FundParams: Codable {
+  public let amount: String
+  public let token: String
+}
+
+public struct FundRequestBody: Codable {
+  public let amount: String
+  public let chainId: String
+  public let token: String
+}
+
+public struct FundResponseData: Codable {
+  public let explorerUrl: String
+  public let txHash: String
+}
+
+public struct FundResponseMetadata: Codable {
+  public let amount: String
+  public let chainId: String
+  public let clientId: String
+  public let custodianId: String
+  public let environmentId: String
+  public let token: String
+}
+
+public struct FundResponseError: Codable {
+  public let id: String
+  public let message: String
+}
+
+public struct FundResponse: Codable {
+  public let data: FundResponseData?
+  public let metadata: FundResponseMetadata
+  public let error: FundResponseError?
+}
+
 public struct BuildEip115TransactionResponse: Codable {
   public let transaction: Eip115Transaction
   public let metadata: BuildTransactionMetaData

--- a/Sources/PortalSwift/Core/Api/PortalApiTypes.swift
+++ b/Sources/PortalSwift/Core/Api/PortalApiTypes.swift
@@ -533,6 +533,11 @@ public enum EvaluateTransactionOperationType: String, CaseIterable {
 }
 
 public struct FundParams: Codable {
+  public init (amount: String, token: String) {
+    self.amount = amount
+    self.token = token
+  }
+
   public let amount: String
   public let token: String
 }

--- a/Sources/PortalSwift/Core/Api/PortalApiTypes.swift
+++ b/Sources/PortalSwift/Core/Api/PortalApiTypes.swift
@@ -533,7 +533,7 @@ public enum EvaluateTransactionOperationType: String, CaseIterable {
 }
 
 public struct FundParams: Codable {
-  public init (amount: String, token: String) {
+  public init(amount: String, token: String) {
     self.amount = amount
     self.token = token
   }
@@ -542,10 +542,10 @@ public struct FundParams: Codable {
   public let token: String
 }
 
-public struct FundRequestBody: Codable {
-  public let amount: String
-  public let chainId: String
-  public let token: String
+struct FundRequestBody: Codable, Equatable {
+  let amount: String
+  let chainId: String
+  let token: String
 }
 
 public struct FundResponseData: Codable {

--- a/Sources/PortalSwift/Mocks/Constants.swift
+++ b/Sources/PortalSwift/Mocks/Constants.swift
@@ -109,6 +109,21 @@ public enum MockConstants {
     metadata: FetchedTransaction.FetchedTransactionMetadata(blockTimestamp: "test-block-timestamp"),
     chainId: 11_155_111
   )
+  public static let mockFundResponse = FundResponse(
+    data: FundResponseData(
+      explorerUrl: "https://sepolia.etherscan.io/tx/0x13aebe28e9661959f73e06c48123d67d47e8e24a3833f626d2fcaa6ef640d0de",
+      txHash: "0x13aebe28e9661959f73e06c48123d67d47e8e24a3833f626d2fcaa6ef640d0de"
+    ),
+    metadata: FundResponseMetadata(
+      amount: "0.01",
+      chainId: "eip155:11155111",
+      clientId: "clientId",
+      custodianId: "custodianId",
+      environmentId: "environmentId",
+      token: "ETH"
+    ),
+    error: FundResponseError(id: "id", message: "message")
+  )
   public static let mockGDriveClientId = "test-mock-gdrive-client-id"
   public static let mockGDriveFile = GDriveFile(
     kind: "test-gdrive-file-kind",

--- a/Sources/PortalSwift/Mocks/Utils/MockPortalRequests.swift
+++ b/Sources/PortalSwift/Mocks/Utils/MockPortalRequests.swift
@@ -108,6 +108,9 @@ public actor MockPortalRequests: PortalRequestsProtocol {
     case "/api/v3/clients/me/simulate-transaction":
       let mockSimulateTransactionData = try encoder.encode(MockConstants.mockSimulatedTransaction)
       return mockSimulateTransactionData
+    case "/api/v3/clients/me/fund":
+      let mockFundResponse = try encoder.encode(MockConstants.mockFundResponse)
+      return mockFundResponse
     case "/drive/v3/files":
       let mockFilesListResponse = GDriveFilesListResponse(
         kind: "test-gdrive-file-kind",

--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -1422,6 +1422,10 @@ public class Portal {
   public func getWalletCapabilities() async throws -> WalletCapabilitiesResponse {
     return try await api.getWalletCapabilities()
   }
+  
+  public func receiveTestnetAsset(chainId: String, params: FundParams) async throws -> FundResponse {
+    return try await api.fund(chainId: chainId, params: params)
+  }
 
   /**********************************
    * Deprecated functions

--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -1423,6 +1423,23 @@ public class Portal {
     return try await api.getWalletCapabilities()
   }
   
+  /// Requests testnet assets (tokens/coins) for development and testing purposes.
+  ///
+  /// This method allows developers to receive test assets on supported testnet chains
+  /// to facilitate development and testing of their applications.
+  ///
+  /// - Parameters:
+  ///   - chainId: The CAIP-2 chain identifier (e.g., "eip155:11155111" for Ethereum Sepolia)
+  ///   - params: Request parameters including:
+  ///     - token: The token symbol to receive (e.g., "ETH" for Ethereum Sepolia)
+  ///     - amount: The amount of tokens to request as a string (e.g. "0.01" is 0.01 Test ETH)
+  ///
+  /// - Returns: A `FundResponse` containing the transaction details and status
+  ///
+  /// - Throws: Various API-related errors if the funding request fails
+  ///
+  /// - Note: This method only works on testnet chains. Attempting to request
+  ///   assets on mainnet chains will result in an error.
   public func receiveTestnetAsset(chainId: String, params: FundParams) async throws -> FundResponse {
     return try await api.fund(chainId: chainId, params: params)
   }

--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -1471,12 +1471,16 @@ public class Portal {
       throw PortalClassError.invalidParameters("Missing required parameters: to, token, or amount")
     }
     
-    // Get chain namespace
+    // Get chain parts
     let chainParts = chainId.split(separator: ":")
     guard chainParts.count == 2 else {
       throw PortalClassError.invalidChainId(chainId)
     }
-    let namespace = String(chainParts[0])
+    
+    // Get chain namespace
+    guard let namespace = PortalNamespace(rawValue: String(chainParts[0])) else {
+      throw PortalClassError.invalidChainId(chainId)
+    }
     
     // Build the appropriate transaction based on chain type
     let transactionParam = BuildTransactionParam(
@@ -1486,7 +1490,7 @@ public class Portal {
     )
     
     switch namespace {
-    case "eip155":
+    case PortalNamespace.eip155:
       // Build and send EVM transaction
       let transactionResponse = try await buildEip155Transaction(chainId: chainId, params: transactionParam)
       
@@ -1500,7 +1504,7 @@ public class Portal {
       // Construct and return response
       return SendAssetResponse(txHash: txHash)
         
-    case "solana":
+    case PortalNamespace.solana:
       // Build and send Solana transaction
       let transactionResponse = try await buildSolanaTransaction(chainId: chainId, params: transactionParam)
       
@@ -2077,7 +2081,7 @@ public class Portal {
       "eip155:137": "https://\(apiHost)/rpc/v1/eip155/137", // Polygon Mainnet
       "eip155:8453": "https://\(apiHost)/rpc/v1/eip155/8453", // Base Mainnet
       "eip155:80002": "https://\(apiHost)/rpc/v1/eip155/80002", // Polygon Amoy
-      "eip155:84532": "https://\(apiHost)/rpc/v1/eip155/84532", // Base Testnet
+      "eip155:84532": "https://\(apiHost)/rpc/v1/eip155/84532", // Base Sepolia
       "eip155:11155111": "https://\(apiHost)/rpc/v1/eip155/11155111", // Ethereum Sepolia
       "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": "https://\(apiHost)/rpc/v1/solana/5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp", // Solana Mainnet
       "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1": "https://\(apiHost)/rpc/v1/solana/EtWTRABZaYq6iMfeYKouRu166VU2xqa1" // Solana Devnet

--- a/Sources/PortalSwift/PortalTypes.swift
+++ b/Sources/PortalSwift/PortalTypes.swift
@@ -189,7 +189,7 @@ public struct SendAssetParams: Codable {
     self.amount = amount
     self.token = token
   }
-  
+
   public let to: String
   public let amount: String
   public let token: String

--- a/Sources/PortalSwift/PortalTypes.swift
+++ b/Sources/PortalSwift/PortalTypes.swift
@@ -182,3 +182,19 @@ public struct SolanaMessage: Codable {
   public var recentBlockhash: String
   public var instructions: [SolanaInstruction]
 }
+
+public struct SendAssetParams: Codable {
+  public init(to: String, amount: String, token: String) {
+    self.to = to
+    self.amount = amount
+    self.token = token
+  }
+  
+  public let to: String
+  public let amount: String
+  public let token: String
+}
+
+public struct SendAssetResponse: Codable {
+  public let txHash: String
+}

--- a/Tests/PortalSwiftTests/Core/PortalApiTests.swift
+++ b/Tests/PortalSwiftTests/Core/PortalApiTests.swift
@@ -514,8 +514,6 @@ extension PortalApiTests {
     let expectation = XCTestExpectation(description: "PortalApi.fund()")
     let mockFundResponse = MockConstants.mockFundResponse
     let fundResponse = try await api?.fund(chainId: "eip155:11155111", params: FundParams(amount: "0.01", token: "ETH"))
-    print("fundResponse", fundResponse)
-    print("mockFundResponse", mockFundResponse)
     XCTAssert(fundResponse?.data?.txHash == mockFundResponse.data?.txHash)
     expectation.fulfill()
     await fulfillment(of: [expectation], timeout: 5.0)

--- a/Tests/PortalSwiftTests/Core/PortalApiTests.swift
+++ b/Tests/PortalSwiftTests/Core/PortalApiTests.swift
@@ -507,6 +507,21 @@ extension PortalApiTests {
   }
 }
 
+// MARK: - fund tests
+
+extension PortalApiTests {
+  func test_fund() async throws {
+    let expectation = XCTestExpectation(description: "PortalApi.fund()")
+    let mockFundResponse = MockConstants.mockFundResponse
+    let fundResponse = try await api?.fund(chainId: "eip155:11155111", params: FundParams(amount: "0.01", token: "ETH"))
+    print("fundResponse", fundResponse)
+    print("mockFundResponse", mockFundResponse)
+    XCTAssert(fundResponse?.data?.txHash == mockFundResponse.data?.txHash)
+    expectation.fulfill()
+    await fulfillment(of: [expectation], timeout: 5.0)
+  }
+}
+
 // MARK: - getTransactions tests
 
 extension PortalApiTests {

--- a/Tests/PortalSwiftTests/Core/PortalApiTests.swift
+++ b/Tests/PortalSwiftTests/Core/PortalApiTests.swift
@@ -518,6 +518,56 @@ extension PortalApiTests {
     expectation.fulfill()
     await fulfillment(of: [expectation], timeout: 5.0)
   }
+
+  func test_fund_willCall_requestPost_onlyOnce() async throws {
+    // given
+    let portalRequestsSpy = PortalRequestsSpy()
+    let fundResponse = MockConstants.mockFundResponse
+    portalRequestsSpy.returnData = try Data(JSONEncoder().encode(fundResponse))
+    initPortalApiWith(requests: portalRequestsSpy)
+
+    // and given
+    _ = try await api?.fund(chainId: "", params: FundParams(amount: "", token: ""))
+
+    // then
+    XCTAssertEqual(portalRequestsSpy.postCallsCount, 1)
+  }
+
+  @available(iOS 16.0, *)
+  func test_fund_willCall_requestPost_passingCorrectParams() async throws {
+    // given
+    let portalRequestsSpy = PortalRequestsSpy()
+    let fundResponse = MockConstants.mockFundResponse
+    portalRequestsSpy.returnData = try Data(JSONEncoder().encode(fundResponse))
+    initPortalApiWith(requests: portalRequestsSpy)
+
+    // and given
+    let amount = "0.01"
+    let token = "ETH"
+    let chainId = "eip155:11155111"
+
+    // and given
+    _ = try await api?.fund(chainId: chainId, params: FundParams(amount: amount, token: token))
+
+    // then
+    XCTAssertEqual(portalRequestsSpy.postFromParam?.path() ?? "", "/api/v3/clients/me/fund")
+    XCTAssertEqual(portalRequestsSpy.postAndPayloadParam as? FundRequestBody, FundRequestBody(amount: amount, chainId: chainId, token: token))
+  }
+
+  func test_fund_willThrowCorrectError_whenRequestPostThrowError() async throws {
+    // given
+    let portalRequestsFailMock = PortalRequestsFailMock()
+    initPortalApiWith(requests: portalRequestsFailMock)
+
+    do {
+      // and given
+      _ = try await api?.fund(chainId: "", params: FundParams(amount: "", token: ""))
+      XCTFail("Expected error not thrown when calling PortalApi.eject when Request throws error.")
+    } catch {
+      // then
+      XCTAssertEqual(error as? URLError, portalRequestsFailMock.errorToThrow)
+    }
+  }
 }
 
 // MARK: - getTransactions tests

--- a/Tests/PortalSwiftTests/PortalApi/PortalApiMock.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalApiMock.swift
@@ -23,6 +23,11 @@ class PortalApiMock: PortalApiProtocol {
   func getBalances(_: String) async throws -> [PortalSwift.FetchedBalance] {
     getBalancesReturnValue ?? []
   }
+  
+  var fundReturnValue: PortalSwift.FundResponse?
+  func fund(chainId: String, params: PortalSwift.FundParams) async throws -> PortalSwift.FundResponse {
+    fundReturnValue!
+  }
 
   var getClientReturnValue: PortalSwift.ClientResponse?
   func getClient() async throws -> PortalSwift.ClientResponse {

--- a/Tests/PortalSwiftTests/PortalApi/PortalApiMock.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalApiMock.swift
@@ -23,9 +23,9 @@ class PortalApiMock: PortalApiProtocol {
   func getBalances(_: String) async throws -> [PortalSwift.FetchedBalance] {
     getBalancesReturnValue ?? []
   }
-  
+
   var fundReturnValue: PortalSwift.FundResponse?
-  func fund(chainId: String, params: PortalSwift.FundParams) async throws -> PortalSwift.FundResponse {
+  func fund(chainId _: String, params _: PortalSwift.FundParams) async throws -> PortalSwift.FundResponse {
     fundReturnValue!
   }
 

--- a/Tests/PortalSwiftTests/PortalApi/PortalApiSpy.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalApiSpy.swift
@@ -115,6 +115,32 @@ class PortalApiSpy: PortalApiProtocol {
     getTransactionsOrderParam = order
     return []
   }
+  
+  // Get Transactions method tracking
+  var fundCallsCount: Int = 0
+  var fundChainIdParam: String?
+  var fundParams: FundParams?
+
+  public func fund(chainId: String, params: FundParams) async throws -> FundResponse {
+    fundCallsCount += 1
+    fundChainIdParam = chainId
+    fundParams = params
+    return FundResponse(
+      data: FundResponseData(
+        explorerUrl: "https://sepolia.etherscan.io/tx/0x13aebe28e9661959f73e06c48123d67d47e8e24a3833f626d2fcaa6ef640d0de",
+        txHash: "0x13aebe28e9661959f73e06c48123d67d47e8e24a3833f626d2fcaa6ef640d0de"
+      ),
+      metadata: FundResponseMetadata(
+        amount: "0.01",
+        chainId: "eip155:11155111",
+        clientId: "clientId",
+        custodianId: "custodianId",
+        environmentId: "environmentId",
+        token: "ETH"
+      ),
+      error: FundResponseError(id: "id", message: "message")
+    )
+  }
 
   // Identify method tracking
   var identifyCallsCount: Int = 0

--- a/Tests/PortalSwiftTests/PortalApi/PortalApiSpy.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalApiSpy.swift
@@ -115,7 +115,7 @@ class PortalApiSpy: PortalApiProtocol {
     getTransactionsOrderParam = order
     return []
   }
-  
+
   // Get Transactions method tracking
   var fundCallsCount: Int = 0
   var fundChainIdParam: String?
@@ -125,21 +125,7 @@ class PortalApiSpy: PortalApiProtocol {
     fundCallsCount += 1
     fundChainIdParam = chainId
     fundParams = params
-    return FundResponse(
-      data: FundResponseData(
-        explorerUrl: "https://sepolia.etherscan.io/tx/0x13aebe28e9661959f73e06c48123d67d47e8e24a3833f626d2fcaa6ef640d0de",
-        txHash: "0x13aebe28e9661959f73e06c48123d67d47e8e24a3833f626d2fcaa6ef640d0de"
-      ),
-      metadata: FundResponseMetadata(
-        amount: "0.01",
-        chainId: "eip155:11155111",
-        clientId: "clientId",
-        custodianId: "custodianId",
-        environmentId: "environmentId",
-        token: "ETH"
-      ),
-      error: FundResponseError(id: "id", message: "message")
-    )
+    return FundResponse.stub()
   }
 
   // Identify method tracking

--- a/Tests/PortalSwiftTests/PortalTests.swift
+++ b/Tests/PortalSwiftTests/PortalTests.swift
@@ -1380,3 +1380,118 @@ extension PortalTests {
     XCTAssertEqual(portalApiSpy.getWalletCapabilitiesCallsCount, 1)
   }
 }
+
+// MARK: - receiveTestnetAsset tests
+
+extension PortalTests {
+  func test_receiveTestnetAsset_willCall_api_fund_onlyOnce() async throws {
+    // given
+    let portalApiSpy = PortalApiSpy()
+    try initPortalWithSpy(api: portalApiSpy)
+
+    // and given
+    _ = try await portal.receiveTestnetAsset(chainId: "", params: FundParams(amount: "", token: ""))
+
+    // then
+    XCTAssertEqual(portalApiSpy.fundCallsCount, 1)
+  }
+
+  func test_receiveTestnetAsset_willCall_api_fund_passingCorrectParams() async throws {
+    // given
+    let portalApiSpy = PortalApiSpy()
+    try initPortalWithSpy(api: portalApiSpy)
+
+    // and given
+    let chainId = "eip155:11155111"
+    let amount = "0.01"
+    let token = "ETH"
+
+    // and given
+    _ = try await portal.receiveTestnetAsset(chainId: chainId, params: FundParams(amount: amount, token: token))
+
+    // then
+    XCTAssertEqual(portalApiSpy.fundChainIdParam, chainId)
+    XCTAssertEqual(portalApiSpy.fundParams?.amount, amount)
+    XCTAssertEqual(portalApiSpy.fundParams?.token, token)
+  }
+}
+
+// MARK: - sendAsset tests
+
+extension PortalTests {
+  func test_sendAsset_willCall_portalProvider_request_onlyOnce_for_eip115Chain() async throws {
+    // given
+    let portalApiSpy = PortalApiMock()
+    portalApiSpy.buildEip115TransactionReturnValue = BuildEip115TransactionResponse.stub()
+    try initPortalWithSpy(api: portalApiSpy)
+    let portalProviderSpy = PortalProviderSpy()
+    setToPortal(portalProvider: portalProviderSpy)
+
+    // and given
+    _ = try await portal.sendAsset(chainId: "eip155:11155111", params: SendAssetParams.stub())
+
+    // then
+    XCTAssertEqual(portalProviderSpy.requestAsyncMethodCallsCount, 1)
+  }
+
+  func test_sendAsset_willCall_portalProvider_request_onlyOnce_for_SolanaChain() async throws {
+    // given
+    let portalApiSpy = PortalApiMock()
+    portalApiSpy.buildSolanaTransactionReturnValue = BuildSolanaTransactionResponse.stub()
+    try initPortalWithSpy(api: portalApiSpy)
+    let portalProviderSpy = PortalProviderSpy()
+    setToPortal(portalProvider: portalProviderSpy)
+
+    // and given
+    _ = try await portal.sendAsset(chainId: "solana:11155111", params: SendAssetParams.stub())
+
+    // then
+    XCTAssertEqual(portalProviderSpy.requestAsyncMethodCallsCount, 1)
+  }
+
+  func test_sendAsset_withInvalidNameSpace_willThroughCorrectError() async throws {
+    // given
+    let chainId = ":11155111"
+
+    do {
+      // and given
+      _ = try await portal.sendAsset(chainId: chainId, params: SendAssetParams.stub())
+      XCTFail("Expected error not thrown when calling Portal.sendAsset passing invalid chain id.")
+
+    } catch {
+      // then
+      XCTAssertEqual(error as? PortalClassError, PortalClassError.invalidChainId(chainId))
+    }
+  }
+
+  func test_sendAsset_withInvalidChaninId_willThroughCorrectError() async throws {
+    // given
+    for chainId in ["eip155:", ":", ""] {
+      do {
+        // and given
+        _ = try await portal.sendAsset(chainId: chainId, params: SendAssetParams.stub())
+        XCTFail("Expected error not thrown when calling Portal.sendAsset passing invalid chain id.")
+
+      } catch {
+        // then
+        XCTAssertEqual(error as? PortalClassError, PortalClassError.invalidChainId(chainId))
+      }
+    }
+  }
+
+  func test_sendAsset_withInvalidParams_willThroughCorrectError() async throws {
+    // given
+    do {
+      // and given
+      _ = try await portal.sendAsset(chainId: "eip155:11155111", params: SendAssetParams.stub(to: ""))
+      _ = try await portal.sendAsset(chainId: "eip155:11155111", params: SendAssetParams.stub(amount: ""))
+      _ = try await portal.sendAsset(chainId: "eip155:11155111", params: SendAssetParams.stub(token: ""))
+      _ = try await portal.sendAsset(chainId: "eip155:11155111", params: SendAssetParams.stub(to: "", amount: "", token: ""))
+      XCTFail("Expected error not thrown when calling Portal.sendAsset passing invalid params.")
+
+    } catch {
+      // then
+      XCTAssertEqual(error as? PortalClassError, PortalClassError.invalidParameters("Missing required parameters: to, token, or amount"))
+    }
+  }
+}

--- a/Tests/PortalSwiftTests/Stubs/FundResponse.swift
+++ b/Tests/PortalSwiftTests/Stubs/FundResponse.swift
@@ -1,0 +1,67 @@
+//
+//  FundResponse.swift
+//  Pods
+//
+//  Created by Ahmed Ragab on 07/02/2025.
+//
+
+import Foundation
+@testable import PortalSwift
+
+extension FundResponse {
+  static func stub(
+    data: FundResponseData? = .stub(),
+    metadata: FundResponseMetadata = .stub(),
+    error: FundResponseError? = nil
+  ) -> FundResponse {
+    return FundResponse(
+      data: data,
+      metadata: metadata,
+      error: error
+    )
+  }
+}
+
+extension FundResponseData {
+  static func stub(
+    explorerUrl: String = "https://sepolia.etherscan.io/tx/0x13aebe28e9661959f73e06c48123d67d47e8e24a3833f626d2fcaa6ef640d0de",
+    txHash: String = "0x13aebe28e9661959f73e06c48123d67d47e8e24a3833f626d2fcaa6ef640d0de"
+  ) -> FundResponseData {
+    return FundResponseData(
+      explorerUrl: explorerUrl,
+      txHash: txHash
+    )
+  }
+}
+
+extension FundResponseMetadata {
+  static func stub(
+    amount: String = "0.01",
+    chainId: String = "eip155:11155111",
+    clientId: String = "clientId",
+    custodianId: String = "custodianId",
+    environmentId: String = "environmentId",
+    token: String = "ETH"
+  ) -> FundResponseMetadata {
+    return FundResponseMetadata(
+      amount: amount,
+      chainId: chainId,
+      clientId: clientId,
+      custodianId: custodianId,
+      environmentId: environmentId,
+      token: token
+    )
+  }
+}
+
+extension FundResponseError {
+  static func stub(
+    id: String = "id",
+    message: String = "message"
+  ) -> FundResponseError {
+    return FundResponseError(
+      id: id,
+      message: message
+    )
+  }
+}

--- a/Tests/PortalSwiftTests/Stubs/SendAssetParams.swift
+++ b/Tests/PortalSwiftTests/Stubs/SendAssetParams.swift
@@ -1,0 +1,23 @@
+//
+//  SendAssetParams.swift
+//  Pods
+//
+//  Created by Ahmed Ragab on 07/02/2025.
+//
+
+import Foundation
+@testable import PortalSwift
+
+extension SendAssetParams {
+  static func stub(
+    to: String = "0xabcdef123456789abcdef123456789abcdef123456",
+    amount: String = "0.001",
+    token: String = "ETH"
+  ) -> SendAssetParams {
+    return SendAssetParams(
+      to: to,
+      amount: amount,
+      token: token
+    )
+  }
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR is about. -->
This PR adds `portal.api.fund` and `portal.receiveTestnetAsset`, which currently only supports `eip155:11155111` + `ETH` in the amount of `0.001` or less per client per day.

This PR also adds support for `portal.sendAsset`.

<img width="1217" alt="image" src="https://github.com/user-attachments/assets/5668dba0-2b58-4b40-be08-403c446c18cb" />

<img width="1224" alt="image" src="https://github.com/user-attachments/assets/989af6e6-980f-4a0f-b46f-7b7fd60c0dbd" />

## Details

### Code
- Documentation updated: Pending
  <!-- - If pending, describe what needs to be updated and create a triage ticket for it -->
  <!-- - If yes, link to documentation -->

### Impact
- Breaking Changes: No
  <!-- - Migration steps: [If yes, describe] -->
  <!-- - Backwards compatible: Yes|No -->
- Performance impact: No
  <!-- - If yes, describe: [Describe impact here] -->

### Testing
- Unit tests added: No
  <!-- - If no, reason: [Reason here] -->
- E2E tests added: No
  <!-- - If no, reason: [Reason here] -->

### Misc.
- Metrics, logs, or traces added: No
  <!-- - If yes, describe: [Describe what was added if necessary] -->
