### PR TITLE
deprecate `Portal.sendSol`

### DIFF
--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -1947,6 +1947,8 @@ public final class Portal: PortalProtocol {
   ///   - The wallet must have a Solana address. Run generate or recover if needed.
   ///   - The transaction is automatically signed and sent to the network
   ///   - The fee is paid by the sender's address
+  /// - Deprecated: Use `sendAsset()` instead.
+  @available(*, deprecated, renamed: "sendAsset", message: "Please use sendAsset().")
   public func sendSol(_ lamports: UInt64, to: String, withChainId chainId: String) async throws -> String {
     guard chainId.split(separator: ":").count > 0 else {
       throw PortalClassError.invalidChainId(chainId)

--- a/Sources/PortalSwift/PortalProtocol.swift
+++ b/Sources/PortalSwift/PortalProtocol.swift
@@ -105,7 +105,6 @@ public protocol PortalProtocol {
   func ethSignTypedData(message: String, completion: @escaping (Result<RequestCompletionResult>) -> Void)
   func personalSign(message: String, completion: @escaping (Result<RequestCompletionResult>) -> Void)
   func request(method: ETHRequestMethods.RawValue, params: [Any], completion: @escaping (Result<RequestCompletionResult>) -> Void)
-  func sendSol(_ lamports: UInt64, to: String, withChainId chainId: String) async throws -> String
   func createPortalConnectInstance(webSocketServer: String) throws -> PortalConnect
   func receiveTestnetAsset(chainId: String, params: FundParams) async throws -> FundResponse
   func sendAsset(chainId: String, params: SendAssetParams) async throws -> SendAssetResponse
@@ -133,4 +132,6 @@ public protocol PortalProtocol {
   func deleteAddress() throws
   @available(*, deprecated, renamed: "deleteShares", message: "The Portal SDK is now multi-wallet. Please update to the multi-wallet-compatible deleteShares() as this function will be removed in the future.")
   func deleteSigningShare() throws
+  @available(*, deprecated, renamed: "sendAsset", message: "Please use sendAsset().")
+  func sendSol(_ lamports: UInt64, to: String, withChainId chainId: String) async throws -> String
 }

--- a/Tests/PortalSwiftTests/Core/EnclaveMobileWrapperTests.swift
+++ b/Tests/PortalSwiftTests/Core/EnclaveMobileWrapperTests.swift
@@ -26,7 +26,7 @@ extension EnclaveMobileWrapperTests {
     portalRequests: PortalRequestsProtocol = PortalRequestsSpy(),
     enclaveMPCHost: String = ""
   ) {
-      enclaveMobileWrapper = EnclaveMobileWrapper(requests: portalRequests, enclaveMPCHost: enclaveMPCHost)
+    enclaveMobileWrapper = EnclaveMobileWrapper(requests: portalRequests, enclaveMPCHost: enclaveMPCHost)
   }
 }
 
@@ -65,7 +65,7 @@ extension EnclaveMobileWrapperTests {
     // given
     let enclaveMPCHost = "mpc-client.portalhq.io"
     let portalRequestsSpy = PortalRequestsSpy()
-      initEnclaveMobileWrapper(portalRequests: portalRequestsSpy, enclaveMPCHost: enclaveMPCHost)
+    initEnclaveMobileWrapper(portalRequests: portalRequestsSpy, enclaveMPCHost: enclaveMPCHost)
 
     let apiKey = "apiKey"
     let host = "host"


### PR DESCRIPTION
- deprecate `Portal.sendSol` and promote `Portal.sendAsset` instead.