### PR TITLE
remove the usage of `TARGET_OS_SIMULATOR` for Xcode 16.3

### DIFF
--- a/Sources/PortalSwift/Storage/ICloudStorage.swift
+++ b/Sources/PortalSwift/Storage/ICloudStorage.swift
@@ -39,7 +39,6 @@ public class ICloudStorage: Storage, PortalStorage {
 
   public let encryption: PortalEncryptionProtocol
 
-  private let isSimulator = TARGET_OS_SIMULATOR != 0
   private let storage: PortalKeyValueStoreProtocol
   private var filenameHashes: [String: String]?
 


### PR DESCRIPTION
## Details

remove the usage of `TARGET_OS_SIMULATOR` for Xcode 16.3

### Code
- Documentation updated: No <!-- Yes|No|Pending -->

### Impact
- Breaking Changes: No <!-- Yes|No -->
- Performance impact: No <!-- Yes|No -->

### Testing
- Unit tests added/updated: No <!-- Yes|No -->
- E2E tests added/updated: No <!-- Yes|No -->

### Misc.
- Metrics, logs, or traces added/updated: No <!-- Yes|No -->
