### PR TITLE
Ahmed/eng 5886 ios deprecate the `portal.request` func that takes a `completion`

### DIFF
--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -2029,6 +2029,7 @@ public final class Portal: PortalProtocol {
     )
   }
 
+  @available(*, deprecated, renamed: "request", message: "Please use the async/await implementation of request().")
   public func request(
     method: ETHRequestMethods.RawValue,
     params: [Any],

--- a/Sources/PortalSwift/PortalProtocol.swift
+++ b/Sources/PortalSwift/PortalProtocol.swift
@@ -108,12 +108,13 @@ public protocol PortalProtocol {
   func ethSignTypedData(message: String, completion: @escaping (Result<RequestCompletionResult>) -> Void)
   func personalSign(message: String, completion: @escaping (Result<RequestCompletionResult>) -> Void)
   func rawSign(message: String, chainId: String) async throws -> PortalProviderResult
-  func request(method: ETHRequestMethods.RawValue, params: [Any], completion: @escaping (Result<RequestCompletionResult>) -> Void)
   func createPortalConnectInstance(webSocketServer: String) throws -> PortalConnect
   func receiveTestnetAsset(chainId: String, params: FundParams) async throws -> FundResponse
   func sendAsset(chainId: String, params: SendAssetParams) async throws -> SendAssetResponse
 
   // Deprecated functions
+  @available(*, deprecated, renamed: "request", message: "Please use the async/await implementation of request().")
+  func request(method: ETHRequestMethods.RawValue, params: [Any], completion: @escaping (Result<RequestCompletionResult>) -> Void)
   @available(*, deprecated, message: "Use setGDriveConfiguration(clientId:backupOption:) instead.")
   func setGDriveConfiguration(clientId: String, folderName: String) throws
   @available(*, deprecated, renamed: "evaluateTransaction", message: "Please use evaluateTransaction().")


### PR DESCRIPTION
## Details
deprecate the `portal.request` function that takes a `completion`

### Code
- Documentation updated: No <!-- Yes|No|Pending -->

### Impact
- Breaking Changes: No <!-- Yes|No -->
- Performance impact: No <!-- Yes|No -->

### Testing
- Unit tests added/updated: No <!-- Yes|No -->
- E2E tests added/updated: No <!-- Yes|No -->

### Misc.
- Metrics, logs, or traces added/updated: No <!-- Yes|No -->
