### PR TITLE
Make webAuthN a default value for setPasskeyConfiguration in iOS

### DIFF
--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -392,7 +392,7 @@ public final class Portal: PortalProtocol {
   /// - Note: Must be called before using passkey backup or recovery methods.
   ///   The relying party should match your application's domain name for security purposes.
   @available(iOS 16, *)
-  public func setPasskeyConfiguration(relyingParty: String, webAuthnHost: String) throws {
+  public func setPasskeyConfiguration(relyingParty: String, webAuthnHost: String = "backup.web.portalhq.io") throws {
     try self.mpc.setPasskeyConfiguration(relyingParty: relyingParty, webAuthnHost: webAuthnHost)
   }
 


### PR DESCRIPTION
## Details
Make webAuthN a default value for setPasskeyConfiguration in iOS

### Code
- Documentation updated: No <!-- Yes|No|Pending -->

### Impact
- Breaking Changes: No <!-- Yes|No -->
- Performance impact: No <!-- Yes|No -->

### Testing
- Unit tests added/updated: No <!-- Yes|No -->
- E2E tests added/updated: No <!-- Yes|No -->

### Misc.
- Metrics, logs, or traces added/updated: No <!-- Yes|No -->
