### PR TITLE
Fixing an issue with the `PortalRequests` String decoding logic + Example App ETH Eject.

### DIFF
--- a/SPM Example/PortalSwift/ViewController.swift
+++ b/SPM Example/PortalSwift/ViewController.swift
@@ -268,7 +268,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
       }
 
       let organizationBackupShareRequest = PortalAPIRequest(url: organizationBackupShareUrl)
-      let organizationBackupShareResponse = try await requests.execute(request: cipherTextRequest, mappingInResponse: OrgShareResult.self)
+      let organizationBackupShareResponse = try await requests.execute(request: organizationBackupShareRequest, mappingInResponse: OrgShareResult.self)
 
       organizationShare = organizationBackupShareResponse.orgShare
     } else {

--- a/Sources/PortalSwift/Utils/PortalRequests.swift
+++ b/Sources/PortalSwift/Utils/PortalRequests.swift
@@ -81,6 +81,8 @@ public class PortalRequests: PortalRequestsProtocol {
     if ResponseType.self == Data.self {
       // Force cast is safe here because we've checked the type
       return data as! ResponseType
+    } else if ResponseType.self == String.self {
+        return (String(data: data, encoding: .utf8) ?? "") as! ResponseType
     }
 
     // decode the response for all other types other than Data


### PR DESCRIPTION
## Summary
- Fixing an issue with the `PortalRequests` String decoding logic.
- Fixing an issue with the non-portal-managed backups eject ETH in the Example App.

### Code
- Documentation updated: No 

### Impact
- Breaking Changes: No <!-- Yes|No -->
- Performance impact: No <!-- Yes|No -->

### Testing
- Unit tests added/updated: No <!-- Yes|No -->
- E2E tests added/updated: No <!-- Yes|No -->

### Misc.
- Metrics, logs, or traces added/updated: No <!-- Yes|No -->
