### PR TITLE
remove the `modals` from the Blockaid.ScanURL call response model.

### DIFF
--- a/SPM Example/PortalSwift/MainViewController/ViewController+BlockaidSecurity.swift
+++ b/SPM Example/PortalSwift/MainViewController/ViewController+BlockaidSecurity.swift
@@ -329,7 +329,7 @@ extension ViewController {
         logger.info("📝 [Blockaid Scan URL] Starting scan...")
 
         let request = BlockaidScanURLRequest(
-          url: "https://app.uniswap.org"
+          url: "https://uniswap.org"
         )
 
         let response = try await portal.security.blockaid.scanURL(request: request)

--- a/Sources/PortalSwift/Core/Api/Blockaid/BlockaidScanURLResponse.swift
+++ b/Sources/PortalSwift/Core/Api/Blockaid/BlockaidScanURLResponse.swift
@@ -33,10 +33,9 @@ public struct BlockaidScanURLRawResponse: Codable {
   public let jsonRpcOperations: [String]?
   public let contractWrite: BlockaidContractOperations?
   public let contractRead: BlockaidContractOperations?
-  public let modals: [String]?
 
   private enum CodingKeys: String, CodingKey {
-    case status, url, modals
+    case status, url
     case scanStartTime = "scan_start_time"
     case scanEndTime = "scan_end_time"
     case maliciousScore = "malicious_score"

--- a/Tests/PortalSwiftTests/Stubs/Blockaid.swift
+++ b/Tests/PortalSwiftTests/Stubs/Blockaid.swift
@@ -395,8 +395,7 @@ extension BlockaidScanURLRawResponse {
     networkOperations: [String]? = nil,
     jsonRpcOperations: [String]? = nil,
     contractWrite: BlockaidContractOperations? = nil,
-    contractRead: BlockaidContractOperations? = nil,
-    modals: [String]? = nil
+    contractRead: BlockaidContractOperations? = nil
   ) -> Self {
     BlockaidScanURLRawResponse(
       status: status,
@@ -411,8 +410,7 @@ extension BlockaidScanURLRawResponse {
       networkOperations: networkOperations,
       jsonRpcOperations: jsonRpcOperations,
       contractWrite: contractWrite,
-      contractRead: contractRead,
-      modals: modals
+      contractRead: contractRead
     )
   }
 }


### PR DESCRIPTION
## Summary
Remove the `modals` from the Blockaid.ScanURL call response model.

> **Copilot Review:** GitHub Copilot will automatically post a review below. Check its comments for additional context and suggestions.
