### PR TITLE
Ragab/sdk 133 relax scaneip712response codable strictness in ios native

### DIFF
--- a/Sources/PortalSwift/Core/Api/Hypernative/ScanEip712Response.swift
+++ b/Sources/PortalSwift/Core/Api/Hypernative/ScanEip712Response.swift
@@ -70,8 +70,8 @@ public struct ScanEip712ParsedActionItem: Codable {
 }
 
 public struct ScanEip712Trace: Codable {
-  public let from: String
-  public let to: String
+  public let from: String?
+  public let to: String?
   public let funcId: String?
   public let callType: String?
   public let value: Int?

--- a/Sources/PortalSwift/Core/Api/Hypernative/ScanSolanaResponse.swift
+++ b/Sources/PortalSwift/Core/Api/Hypernative/ScanSolanaResponse.swift
@@ -89,13 +89,35 @@ public struct ScanSolanaParsedActionItem: Codable {
 public struct ScanSolanaTrace: Codable {
   public let from: String
   public let to: String
-  public let funcId: String?
+  public let funcId: ScanSolanaFuncId?
   public let callType: String?
   public let value: Int?
   public let traceAddress: [Int]?
   public let status: String?
   public let callInput: ScanSolanaTraceCallInput?
   public let extraInfo: [String: String]?
+}
+
+public enum ScanSolanaFuncId: Codable {
+  case string(String)
+  case bytes([Int])
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if let stringValue = try? container.decode(String.self) {
+      self = .string(stringValue)
+    } else if let bytes = try? container.decode([Int].self) {
+      self = .bytes(bytes)
+    } else {
+      self = .string("")
+    }
+  }
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .string(let value): try container.encode(value)
+    case .bytes(let value): try container.encode(value)
+    }
+  }
 }
 
 public struct ScanSolanaTraceCallInput: Codable {

--- a/Tests/PortalSwiftTests/Security/ScanEip712CodableTests.swift
+++ b/Tests/PortalSwiftTests/Security/ScanEip712CodableTests.swift
@@ -1,0 +1,151 @@
+//
+//  ScanEip712CodableTests.swift
+//  PortalSwiftTests
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+@testable import PortalSwift
+import XCTest
+
+final class ScanEip712CodableTests: XCTestCase {
+  var encoder: JSONEncoder!
+  var decoder: JSONDecoder!
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    encoder = JSONEncoder()
+    decoder = JSONDecoder()
+  }
+
+  override func tearDownWithError() throws {
+    encoder = nil
+    decoder = nil
+    try super.tearDownWithError()
+  }
+}
+
+// MARK: - ScanEip712Trace Codable Tests
+
+extension ScanEip712CodableTests {
+  func test_scanEip712Trace_encodesAndDecodesCorrectly() throws {
+    // Given
+    let trace = ScanEip712Trace.stub(
+      funcId: "0x095ea7b3",
+      callType: "call",
+      value: 0,
+      traceAddress: [0],
+      status: 1,
+      callInput: "0xabcdef",
+      extraInfo: ["key": "value"]
+    )
+
+    // When
+    let data = try encoder.encode(trace)
+    let decoded = try decoder.decode(ScanEip712Trace.self, from: data)
+
+    // Then
+    XCTAssertEqual(decoded.from, trace.from)
+    XCTAssertEqual(decoded.to, trace.to)
+    XCTAssertEqual(decoded.funcId, "0x095ea7b3")
+    XCTAssertEqual(decoded.callType, "call")
+    XCTAssertEqual(decoded.value, 0)
+    XCTAssertEqual(decoded.traceAddress, [0])
+    XCTAssertEqual(decoded.status, 1)
+    XCTAssertEqual(decoded.callInput, "0xabcdef")
+    XCTAssertEqual(decoded.extraInfo?["key"], "value")
+  }
+
+  func test_scanEip712Trace_decodesWithoutFromAndTo() throws {
+    // Given: trace JSON missing the now-optional `from` and `to` fields
+    let json = """
+    {
+      "funcId": "0xdeadbeef",
+      "callType": "call",
+      "status": 1
+    }
+    """.data(using: .utf8)!
+
+    // When
+    let decoded = try decoder.decode(ScanEip712Trace.self, from: json)
+
+    // Then
+    XCTAssertNil(decoded.from)
+    XCTAssertNil(decoded.to)
+    XCTAssertEqual(decoded.funcId, "0xdeadbeef")
+    XCTAssertEqual(decoded.callType, "call")
+    XCTAssertEqual(decoded.status, 1)
+  }
+
+  func test_scanEip712Trace_decodesWithExplicitNullFromAndTo() throws {
+    // Given: trace JSON where from/to are explicit null
+    let json = """
+    {
+      "from": null,
+      "to": null,
+      "funcId": "0x095ea7b3"
+    }
+    """.data(using: .utf8)!
+
+    // When
+    let decoded = try decoder.decode(ScanEip712Trace.self, from: json)
+
+    // Then
+    XCTAssertNil(decoded.from)
+    XCTAssertNil(decoded.to)
+    XCTAssertEqual(decoded.funcId, "0x095ea7b3")
+  }
+
+  func test_scanEip712Trace_roundTripsWithNilFromAndTo() throws {
+    // Given
+    let trace = ScanEip712Trace.stub(from: nil, to: nil, funcId: "0x095ea7b3")
+
+    // When
+    let data = try encoder.encode(trace)
+    let decoded = try decoder.decode(ScanEip712Trace.self, from: data)
+
+    // Then
+    XCTAssertNil(decoded.from)
+    XCTAssertNil(decoded.to)
+    XCTAssertEqual(decoded.funcId, "0x095ea7b3")
+  }
+}
+
+// MARK: - ScanEip712Response Codable Tests
+
+extension ScanEip712CodableTests {
+  func test_scanEip712Response_encodesAndDecodesCorrectly() throws {
+    // Given
+    let response = ScanEip712Response.stub()
+
+    // When
+    let data = try encoder.encode(response)
+    let decoded = try decoder.decode(ScanEip712Response.self, from: data)
+
+    // Then
+    XCTAssertNotNil(decoded.data)
+    XCTAssertEqual(decoded.data?.rawResponse.success, true)
+    XCTAssertEqual(decoded.data?.rawResponse.data?.recommendation, "accept")
+    XCTAssertNil(decoded.error)
+  }
+
+  func test_scanEip712Response_withTraceContainingNilFromAndTo() throws {
+    // Given: full response containing a trace with optional from/to set to nil
+    let trace = ScanEip712Trace.stub(from: nil, to: nil, funcId: "0xabc")
+    let riskData = ScanEip712RiskData.stub(trace: [trace])
+    let rawResponse = ScanEip712RawResponse.stub(data: riskData)
+    let response = ScanEip712Response(data: ScanEip712Data(rawResponse: rawResponse), error: nil)
+
+    // When
+    let data = try encoder.encode(response)
+    let decoded = try decoder.decode(ScanEip712Response.self, from: data)
+
+    // Then
+    let decodedTrace = decoded.data?.rawResponse.data?.trace?.first
+    XCTAssertNotNil(decodedTrace)
+    XCTAssertNil(decodedTrace?.from)
+    XCTAssertNil(decodedTrace?.to)
+    XCTAssertEqual(decodedTrace?.funcId, "0xabc")
+  }
+}

--- a/Tests/PortalSwiftTests/Security/ScanSolanaCodableTests.swift
+++ b/Tests/PortalSwiftTests/Security/ScanSolanaCodableTests.swift
@@ -451,3 +451,160 @@ extension ScanSolanaCodableTests {
     XCTAssertEqual(decoded.lamports, info.lamports)
   }
 }
+
+// MARK: - ScanSolanaFuncId (Polymorphic) Codable Tests
+
+extension ScanSolanaCodableTests {
+  func test_scanSolanaFuncId_decodesString() throws {
+    // Given: funcId as string
+    let json = "\"transfer\"".data(using: .utf8)!
+
+    // When
+    let decoded = try decoder.decode(ScanSolanaFuncId.self, from: json)
+
+    // Then
+    if case .string(let value) = decoded {
+      XCTAssertEqual(value, "transfer")
+    } else {
+      XCTFail("Expected .string case, got \(decoded)")
+    }
+  }
+
+  func test_scanSolanaFuncId_decodesBytes() throws {
+    // Given: funcId as array of bytes
+    let json = "[1, 2, 3, 4]".data(using: .utf8)!
+
+    // When
+    let decoded = try decoder.decode(ScanSolanaFuncId.self, from: json)
+
+    // Then
+    if case .bytes(let bytes) = decoded {
+      XCTAssertEqual(bytes, [1, 2, 3, 4])
+    } else {
+      XCTFail("Expected .bytes case, got \(decoded)")
+    }
+  }
+
+  func test_scanSolanaFuncId_invalidPayloadFallsBackToEmptyString() throws {
+    // Given: funcId as an unexpected type (boolean)
+    let json = "true".data(using: .utf8)!
+
+    // When
+    let decoded = try decoder.decode(ScanSolanaFuncId.self, from: json)
+
+    // Then
+    if case .string(let value) = decoded {
+      XCTAssertEqual(value, "")
+    } else {
+      XCTFail("Expected .string fallback, got \(decoded)")
+    }
+  }
+
+  func test_scanSolanaFuncId_encodesString() throws {
+    // Given
+    let funcId = ScanSolanaFuncId.string("transfer")
+
+    // When
+    let data = try encoder.encode(funcId)
+    let decoded = try decoder.decode(ScanSolanaFuncId.self, from: data)
+
+    // Then
+    if case .string(let value) = decoded {
+      XCTAssertEqual(value, "transfer")
+    } else {
+      XCTFail("Expected .string case after round-trip, got \(decoded)")
+    }
+  }
+
+  func test_scanSolanaFuncId_encodesBytes() throws {
+    // Given
+    let funcId = ScanSolanaFuncId.bytes([10, 20, 30])
+
+    // When
+    let data = try encoder.encode(funcId)
+    let decoded = try decoder.decode(ScanSolanaFuncId.self, from: data)
+
+    // Then
+    if case .bytes(let bytes) = decoded {
+      XCTAssertEqual(bytes, [10, 20, 30])
+    } else {
+      XCTFail("Expected .bytes case after round-trip, got \(decoded)")
+    }
+  }
+
+  func test_scanSolanaTrace_decodesFuncIdAsString() throws {
+    // Given: trace JSON where funcId is a string
+    let json = """
+    {
+      "from": "0x123",
+      "to": "0x456",
+      "funcId": "transfer",
+      "status": "True"
+    }
+    """.data(using: .utf8)!
+
+    // When
+    let decoded = try decoder.decode(ScanSolanaTrace.self, from: json)
+
+    // Then
+    if case .string(let value)? = decoded.funcId {
+      XCTAssertEqual(value, "transfer")
+    } else {
+      XCTFail("Expected funcId .string, got \(String(describing: decoded.funcId))")
+    }
+  }
+
+  func test_scanSolanaTrace_decodesFuncIdAsBytes() throws {
+    // Given: trace JSON where funcId is a byte array
+    let json = """
+    {
+      "from": "0x123",
+      "to": "0x456",
+      "funcId": [1, 2, 3, 4],
+      "status": "True"
+    }
+    """.data(using: .utf8)!
+
+    // When
+    let decoded = try decoder.decode(ScanSolanaTrace.self, from: json)
+
+    // Then
+    if case .bytes(let bytes)? = decoded.funcId {
+      XCTAssertEqual(bytes, [1, 2, 3, 4])
+    } else {
+      XCTFail("Expected funcId .bytes, got \(String(describing: decoded.funcId))")
+    }
+  }
+
+  func test_scanSolanaTrace_roundTripsWithFuncIdString() throws {
+    // Given
+    let trace = ScanSolanaTrace.stub(funcId: .string("transfer"))
+
+    // When
+    let data = try encoder.encode(trace)
+    let decoded = try decoder.decode(ScanSolanaTrace.self, from: data)
+
+    // Then
+    if case .string(let value)? = decoded.funcId {
+      XCTAssertEqual(value, "transfer")
+    } else {
+      XCTFail("Expected funcId .string after round-trip, got \(String(describing: decoded.funcId))")
+    }
+  }
+
+  func test_scanSolanaTrace_roundTripsWithFuncIdBytes() throws {
+    // Given
+    let trace = ScanSolanaTrace.stub(funcId: .bytes([7, 8, 9]))
+
+    // When
+    let data = try encoder.encode(trace)
+    let decoded = try decoder.decode(ScanSolanaTrace.self, from: data)
+
+    // Then
+    if case .bytes(let bytes)? = decoded.funcId {
+      XCTAssertEqual(bytes, [7, 8, 9])
+    } else {
+      XCTFail("Expected funcId .bytes after round-trip, got \(String(describing: decoded.funcId))")
+    }
+  }
+}

--- a/Tests/PortalSwiftTests/Stubs/Hypernative.swift
+++ b/Tests/PortalSwiftTests/Stubs/Hypernative.swift
@@ -902,8 +902,8 @@ extension ScanSolanaAddressTableLookup {
 
 extension ScanEip712Trace {
   static func stub(
-    from: String = "0x7C01728004d3F2370C1BBC36a4Ad680fE6FE8729",
-    to: String = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    from: String? = "0x7C01728004d3F2370C1BBC36a4Ad680fE6FE8729",
+    to: String? = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     funcId: String? = nil,
     callType: String? = nil,
     value: Int? = nil,
@@ -1098,7 +1098,7 @@ extension ScanSolanaTrace {
   static func stub(
     from: String = "0x123",
     to: String = "0x456",
-    funcId: String? = nil,
+    funcId: ScanSolanaFuncId? = nil,
     callType: String? = nil,
     value: Int? = nil,
     traceAddress: [Int]? = nil,


### PR DESCRIPTION
## Summary
Relaxes codable strictness on the Hypernative scan transaction response models so the iOS SDK no longer fails to decode valid responses, and updates the unit tests to match.
### Model changes (`Sources/PortalSwift/Core/Api/Hypernative/`)
- **`ScanEip712Response`**: `ScanEip712Trace.from` and `ScanEip712Trace.to` are now optional (`String?`) — Hypernative may omit these on certain traces.
- **`ScanSolanaResponse`**:
  - `ScanSolanaTrace.funcId` changed from `String?` to a new polymorphic `ScanSolanaFuncId?` enum.
  - New `ScanSolanaFuncId` enum decodes either a `String` (`.string`) or a byte array (`.bytes([Int])`), with a safe fallback to `.string("")` for unexpected payloads. Mirrors the existing `ScanSolanaTraceCallInputInfo` pattern.
### Test changes (`Tests/PortalSwiftTests/`)
- **Stubs (`Stubs/Hypernative.swift`)**:
  - `ScanSolanaTrace.stub` updated to accept `ScanSolanaFuncId?` (fixes test target compile break).
  - `ScanEip712Trace.stub` `from`/`to` relaxed to `String?` so tests can construct traces with `nil` values.
- **`Security/ScanSolanaCodableTests.swift`**: 9 new tests covering `ScanSolanaFuncId` decode/encode for `.string` and `.bytes`, the empty-string fallback, and round-trip of `ScanSolanaTrace.funcId` in both variants.
- **`Security/ScanEip712CodableTests.swift`** (new file): 6 tests covering `ScanEip712Trace` with the now-optional `from`/`to` (missing keys, explicit `null`, round-trip with `nil`) plus a full `ScanEip712Response` round-trip containing such a trace.


> **Copilot Review:** GitHub Copilot will automatically post a review below. Check its comments for additional context and suggestions.
