### PR TITLE
fix(hypernative): align ScanAddressesResponse fields with API and Kot…

### DIFF
--- a/SPM Example/PortalSwift/MainViewController/ViewController+HyperNativeSecurity.swift
+++ b/SPM Example/PortalSwift/MainViewController/ViewController+HyperNativeSecurity.swift
@@ -392,7 +392,7 @@ extension ViewController {
         logger.info("  Address: \(addressResult.address)")
         logger.info("    Recommendation: \(addressResult.recommendation)")
         logger.info("    Severity: \(addressResult.severity)")
-        logger.info("    Flags count: \(addressResult.flags.count)")
+        logger.info("    Flags count: \(addressResult.flags?.count ?? 0)")
       }
     } else if let error = response.error {
       logger.error("ViewController - ❌ Address Scan Error: \(error)")

--- a/Sources/PortalSwift/Core/Api/Hypernative/ScanAddressesResponse.swift
+++ b/Sources/PortalSwift/Core/Api/Hypernative/ScanAddressesResponse.swift
@@ -24,18 +24,19 @@ public struct ScanAddressesItem: Codable {
   public let address: String
   public let recommendation: String
   public let severity: String
-  public let totalIncomingUsd: Double
-  public let policyId: String
-  public let timestamp: String
-  public let flags: [ScanAddressesFlag]
+  public let totalIncomingUsd: Double?
+  public let totalOutgoingUsd: Double?
+  public let policyId: String?
+  public let timestamp: String?
+  public let flags: [ScanAddressesFlag]?
 }
 
 public struct ScanAddressesFlag: Codable {
   public let title: String
   public let flagId: String
-  public let chain: String
+  public let chain: String?
   public let severity: String
-  public let events: [ScanAddressesEvent]
+  public let events: [ScanAddressesEvent]?
   public let lastUpdate: String?
   public let exposures: [ScanAddressesExposure]
 }
@@ -63,16 +64,21 @@ public struct ScanAddressesEvent: Codable {
 }
 
 public struct ScanAddressesExposure: Codable {
-  public let exposurePortion: Double
+  public let exposurePortion: Double?
   public let exposureType: String?
   public let totalExposureUsd: Double
   public let flaggedInteractions: [ScanAddressesFlaggedInteraction]
+  public let direction: String?
+  public let severity: String?
 }
 
 public struct ScanAddressesFlaggedInteraction: Codable {
-  public let address: String
-  public let chain: String
+  public let address: String?
+  public let chain: String?
   public let alias: String?
   public let minHop: Int
   public let totalExposureUsd: Double
+  public let entityId: String?
+  public let entityName: String?
+  public let severity: String?
 }

--- a/Tests/PortalSwiftTests/Security/ScanAddressesCodableTests.swift
+++ b/Tests/PortalSwiftTests/Security/ScanAddressesCodableTests.swift
@@ -1,0 +1,204 @@
+//
+//  ScanAddressesCodableTests.swift
+//  PortalSwiftTests
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+@testable import PortalSwift
+import XCTest
+
+final class ScanAddressesCodableTests: XCTestCase {
+  var decoder: JSONDecoder!
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    decoder = JSONDecoder()
+  }
+
+  override func tearDownWithError() throws {
+    decoder = nil
+    try super.tearDownWithError()
+  }
+}
+
+// MARK: - Regression Tests for Partial Backend Payloads
+
+extension ScanAddressesCodableTests {
+  /// Regression test: backend may omit `totalIncomingUsd`, `totalOutgoingUsd`,
+  /// `policyId`, `timestamp`, and may return an empty `flags` array (or omit it
+  /// entirely) for items with `recommendation: "Approve"`. Decoding must not
+  /// throw `keyNotFound` for any of these fields.
+  func test_scanAddressesResponse_decodesItemWithMissingOptionalFields() throws {
+    let json = Data("""
+    {
+      "data": {
+        "rawResponse": [
+          {
+            "address": "0x2753a0d37a2ad09be3ccc0afcb650bea8ea57a8f",
+            "recommendation": "Approve",
+            "severity": "N/A",
+            "flags": []
+          }
+        ]
+      }
+    }
+    """.utf8)
+
+    let response = try decoder.decode(ScanAddressesResponse.self, from: json)
+
+    let item = try XCTUnwrap(response.data?.rawResponse.first)
+    XCTAssertEqual(item.address, "0x2753a0d37a2ad09be3ccc0afcb650bea8ea57a8f")
+    XCTAssertEqual(item.recommendation, "Approve")
+    XCTAssertEqual(item.severity, "N/A")
+    XCTAssertNil(item.totalIncomingUsd)
+    XCTAssertNil(item.totalOutgoingUsd)
+    XCTAssertNil(item.policyId)
+    XCTAssertNil(item.timestamp)
+    XCTAssertEqual(item.flags?.count, 0)
+  }
+
+  /// Regression test: `flags` itself may be omitted (not just empty).
+  func test_scanAddressesResponse_decodesItemWithOmittedFlags() throws {
+    let json = Data("""
+    {
+      "data": {
+        "rawResponse": [
+          {
+            "address": "0xabc",
+            "recommendation": "Approve",
+            "severity": "N/A"
+          }
+        ]
+      }
+    }
+    """.utf8)
+
+    let response = try decoder.decode(ScanAddressesResponse.self, from: json)
+    let item = try XCTUnwrap(response.data?.rawResponse.first)
+    XCTAssertNil(item.flags)
+  }
+
+  /// Regression test: a fully-populated "Deny" item (with the newly added
+  /// fields `totalOutgoingUsd`, exposure `direction`/`severity`, and
+  /// flagged-interaction `entityId`/`entityName`/`severity`) decodes and
+  /// preserves all values.
+  func test_scanAddressesResponse_decodesFullyPopulatedDenyItem() throws {
+    let json = Data("""
+    {
+      "data": {
+        "rawResponse": [
+          {
+            "address": "0x31c05d73f2333b5a176cfdbb7c5ef96ec7bb04ac",
+            "recommendation": "Deny",
+            "severity": "High",
+            "totalIncomingUsd": 898761.6875,
+            "totalOutgoingUsd": 2149675.75,
+            "policyId": "ac938c22-4a3b-4f6c-9c1a-e9e7c7e9113d",
+            "timestamp": "2026-05-13T23:09:19.506Z",
+            "flags": [
+              {
+                "title": "Related to Mixing Services",
+                "flagId": "RF1510",
+                "chain": "eip155:1",
+                "severity": "High",
+                "events": [],
+                "lastUpdate": "2023-12-28T21:05:35Z",
+                "exposures": [
+                  {
+                    "exposurePortion": 0.8854220719626247,
+                    "exposureType": "direct",
+                    "totalExposureUsd": 795783.435546875,
+                    "flaggedInteractions": [
+                      {
+                        "address": "0xa160cdab225685da1d56aa342ad8841c3b53f291",
+                        "chain": "eip155:1",
+                        "alias": "Tornado.Cash: 100 ETH",
+                        "minHop": 1,
+                        "totalExposureUsd": 705959,
+                        "entityId": "147b88c2-e008-4c1b-89d2-d08ea9e13e77",
+                        "entityName": "Tornado.Cash",
+                        "severity": "High"
+                      }
+                    ],
+                    "direction": "incoming",
+                    "severity": "High"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+    """.utf8)
+
+    let response = try decoder.decode(ScanAddressesResponse.self, from: json)
+    let item = try XCTUnwrap(response.data?.rawResponse.first)
+
+    XCTAssertEqual(item.totalIncomingUsd, 898761.6875)
+    XCTAssertEqual(item.totalOutgoingUsd, 2149675.75)
+    XCTAssertEqual(item.policyId, "ac938c22-4a3b-4f6c-9c1a-e9e7c7e9113d")
+    XCTAssertEqual(item.timestamp, "2026-05-13T23:09:19.506Z")
+
+    let flag = try XCTUnwrap(item.flags?.first)
+    XCTAssertEqual(flag.flagId, "RF1510")
+    XCTAssertEqual(flag.chain, "eip155:1")
+    XCTAssertEqual(flag.events?.count, 0)
+
+    let exposure = try XCTUnwrap(flag.exposures.first)
+    XCTAssertEqual(exposure.exposurePortion, 0.8854220719626247)
+    XCTAssertEqual(exposure.direction, "incoming")
+    XCTAssertEqual(exposure.severity, "High")
+
+    let interaction = try XCTUnwrap(exposure.flaggedInteractions.first)
+    XCTAssertEqual(interaction.address, "0xa160cdab225685da1d56aa342ad8841c3b53f291")
+    XCTAssertEqual(interaction.chain, "eip155:1")
+    XCTAssertEqual(interaction.alias, "Tornado.Cash: 100 ETH")
+    XCTAssertEqual(interaction.entityId, "147b88c2-e008-4c1b-89d2-d08ea9e13e77")
+    XCTAssertEqual(interaction.entityName, "Tornado.Cash")
+    XCTAssertEqual(interaction.severity, "High")
+  }
+
+  /// Regression test: the full multi-item payload from SDK-136 (one Deny item
+  /// with full flags, one Approve item with no flags/policyId/timestamp/totals)
+  /// decodes successfully.
+  func test_scanAddressesResponse_decodesMixedDenyAndApprovePayload() throws {
+    let json = Data("""
+    {
+      "data": {
+        "rawResponse": [
+          {
+            "address": "0x31c05d73f2333b5a176cfdbb7c5ef96ec7bb04ac",
+            "recommendation": "Deny",
+            "severity": "High",
+            "totalIncomingUsd": 898761.6875,
+            "totalOutgoingUsd": 2149675.75,
+            "policyId": "ac938c22-4a3b-4f6c-9c1a-e9e7c7e9113d",
+            "timestamp": "2026-05-13T23:09:19.506Z",
+            "flags": []
+          },
+          {
+            "address": "0x2753a0d37a2ad09be3ccc0afcb650bea8ea57a8f",
+            "recommendation": "Approve",
+            "severity": "N/A",
+            "policyId": "ac938c22-4a3b-4f6c-9c1a-e9e7c7e9113d",
+            "timestamp": "2026-05-13T23:09:19.506Z",
+            "flags": []
+          }
+        ]
+      }
+    }
+    """.utf8)
+
+    let response = try decoder.decode(ScanAddressesResponse.self, from: json)
+    let items = try XCTUnwrap(response.data?.rawResponse)
+
+    XCTAssertEqual(items.count, 2)
+    XCTAssertEqual(items[0].recommendation, "Deny")
+    XCTAssertEqual(items[1].recommendation, "Approve")
+    XCTAssertNil(items[1].totalIncomingUsd)
+    XCTAssertNil(items[1].totalOutgoingUsd)
+  }
+}

--- a/Tests/PortalSwiftTests/Stubs/Hypernative.swift
+++ b/Tests/PortalSwiftTests/Stubs/Hypernative.swift
@@ -412,16 +412,18 @@ extension ScanAddressesItem {
     address: String = "0x123",
     recommendation: String = "accept",
     severity: String = "low",
-    totalIncomingUsd: Double = 0.0,
-    policyId: String = "test-policy-id",
-    timestamp: String = "2024-01-01T00:00:00Z",
-    flags: [ScanAddressesFlag] = []
+    totalIncomingUsd: Double? = 0.0,
+    totalOutgoingUsd: Double? = 0.0,
+    policyId: String? = "test-policy-id",
+    timestamp: String? = "2024-01-01T00:00:00Z",
+    flags: [ScanAddressesFlag]? = []
   ) -> Self {
     ScanAddressesItem(
       address: address,
       recommendation: recommendation,
       severity: severity,
       totalIncomingUsd: totalIncomingUsd,
+      totalOutgoingUsd: totalOutgoingUsd,
       policyId: policyId,
       timestamp: timestamp,
       flags: flags
@@ -801,9 +803,9 @@ extension ScanAddressesFlag {
   static func stub(
     title: String = "Test Flag",
     flagId: String = "test-flag-id",
-    chain: String = "ethereum",
+    chain: String? = "ethereum",
     severity: String = "low",
-    events: [ScanAddressesEvent] = [],
+    events: [ScanAddressesEvent]? = [],
     lastUpdate: String? = "2024-01-01T00:00:00Z",
     exposures: [ScanAddressesExposure] = []
   ) -> Self {
@@ -1196,34 +1198,44 @@ extension ScanAddressesEvent {
 
 extension ScanAddressesExposure {
   static func stub(
-    exposurePortion: Double = 0.5,
+    exposurePortion: Double? = 0.5,
     exposureType: String? = "direct",
     totalExposureUsd: Double = 1000.0,
-    flaggedInteractions: [ScanAddressesFlaggedInteraction] = []
+    flaggedInteractions: [ScanAddressesFlaggedInteraction] = [],
+    direction: String? = "incoming",
+    severity: String? = "low"
   ) -> Self {
     ScanAddressesExposure(
       exposurePortion: exposurePortion,
       exposureType: exposureType,
       totalExposureUsd: totalExposureUsd,
-      flaggedInteractions: flaggedInteractions
+      flaggedInteractions: flaggedInteractions,
+      direction: direction,
+      severity: severity
     )
   }
 }
 
 extension ScanAddressesFlaggedInteraction {
   static func stub(
-    address: String = "0x123",
-    chain: String = "ethereum",
+    address: String? = "0x123",
+    chain: String? = "ethereum",
     alias: String? = nil,
     minHop: Int = 1,
-    totalExposureUsd: Double = 500.0
+    totalExposureUsd: Double = 500.0,
+    entityId: String? = "test-entity-id",
+    entityName: String? = "Test Entity",
+    severity: String? = "low"
   ) -> Self {
     ScanAddressesFlaggedInteraction(
       address: address,
       chain: chain,
       alias: alias,
       minHop: minHop,
-      totalExposureUsd: totalExposureUsd
+      totalExposureUsd: totalExposureUsd,
+      entityId: entityId,
+      entityName: entityName,
+      severity: severity
     )
   }
 }


### PR DESCRIPTION

## Summary

The Swift `ScanAddressesResponse` model declared several fields as non-optional that the backend may omit, causing `JSONDecoder` to throw `keyNotFound` for valid responses (e.g. an item with `recommendation: "Approve"` and no `totalIncomingUsd` / `flags`). It was also missing fields that exist in the API response and in the Kotlin SDK model. This PR aligns the Swift model with both, updates the related stubs, and fixes one example-app call site.

## Changes

### `Sources/PortalSwift/Core/Api/Hypernative/ScanAddressesResponse.swift`

| Type | Field | Before | After |
| --- | --- | --- | --- |
| `ScanAddressesItem` | `totalIncomingUsd` | `Double` | `Double?` |
| `ScanAddressesItem` | `totalOutgoingUsd` | _missing_ | `Double?` (added) |
| `ScanAddressesItem` | `policyId` | `String` | `String?` |
| `ScanAddressesItem` | `timestamp` | `String` | `String?` |
| `ScanAddressesItem` | `flags` | `[ScanAddressesFlag]` | `[ScanAddressesFlag]?` |
| `ScanAddressesFlag` | `chain` | `String` | `String?` |
| `ScanAddressesFlag` | `events` | `[ScanAddressesEvent]` | `[ScanAddressesEvent]?` |
| `ScanAddressesExposure` | `exposurePortion` | `Double` | `Double?` |
| `ScanAddressesExposure` | `direction` | _missing_ | `String?` (added) |
| `ScanAddressesExposure` | `severity` | _missing_ | `String?` (added) |
| `ScanAddressesFlaggedInteraction` | `address` | `String` | `String?` |
| `ScanAddressesFlaggedInteraction` | `chain` | `String` | `String?` |
| `ScanAddressesFlaggedInteraction` | `entityId` | _missing_ | `String?` (added) |
| `ScanAddressesFlaggedInteraction` | `entityName` | _missing_ | `String?` (added) |
| `ScanAddressesFlaggedInteraction` | `severity` | _missing_ | `String?` (added) |

### `Tests/PortalSwiftTests/Stubs/Hypernative.swift`

- Updated stub signatures for `ScanAddressesItem`, `ScanAddressesFlag`, `ScanAddressesExposure`, and `ScanAddressesFlaggedInteraction` to match the model. Default values were preserved (just promoted to optional), so existing tests continue to work without modification.

### `SPM Example/PortalSwift/MainViewController/ViewController+HyperNativeSecurity.swift`

- `addressResult.flags.count` → `addressResult.flags?.count ?? 0` to safely unwrap the now-optional `flags`.

> **Copilot Review:** GitHub Copilot will automatically post a review below. Check its comments for additional context and suggestions.
