### PR TITLE
fix(hypernative): align ScanEVM/Eip712 trace status field with API

### DIFF
--- a/SPM Example/PortalSwift/MainViewController/ViewController+HyperNativeSecurity.swift
+++ b/SPM Example/PortalSwift/MainViewController/ViewController+HyperNativeSecurity.swift
@@ -24,8 +24,11 @@ extension ViewController {
     Task {
       logger.info("ViewController.hypernativeScanTx() - 📝 Starting transaction scans...")
 
+      // Test EVM malicious Transaction Scan
+      await testEVMScan(malicious: true)
+      
       // Test EVM Transaction Scan
-      await testEVMScan()
+      await testEVMScan(malicious: false)
 
       // Test EIP-712 Transaction Scan
       await testEip712Scan()
@@ -187,27 +190,25 @@ extension ViewController {
 
   // MARK: - Private Helper Methods
 
-  private func testEVMScan() async {
+  private func testEVMScan(malicious: Bool = false) async {
     do {
-      logger.info("ViewController.testEVMScan() - 📝 Testing EVM transaction scan...")
+      logger.info("ViewController.testEVMScan() - 📝 Testing EVM \(malicious ? "malicious" : "") transaction scan...")
 
       guard let portal = portal else {
         logger.error("ViewController.testEVMScan() - ❌ Portal not initialized")
         return
       }
 
+      let input = malicious
+        ? "0x095ea7b300000000000000000000000066ba61be3bab35c0c00038f335850a390b086fe300000000000000000000000000000000000000000fffffffffffffffffffffff"
+        : "0x"
+
       let transaction = ScanEVMTransaction(
-        chain: "eip155:143",
+        chain: "eip155:1",
         fromAddress: "0x7C01728004d3F2370C1BBC36a4Ad680fE6FE8729",
         toAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-        input: "0x095ea7b300000000000000000000000066ba61be3bab35c0c00038f335850a390b086fe300000000000000000000000000000000000000000fffffffffffffffffffffff",
-        value: 0,
-        nonce: 2340,
-        hash: nil,
-        gas: 3_000_000,
-        gasPrice: 3_000_000,
-        maxPriorityFeePerGas: nil,
-        maxFeePerGas: nil
+        input: input,
+        value: 0
       )
 
       let request = ScanEVMRequest(
@@ -221,11 +222,11 @@ extension ViewController {
 
       let response = try await portal.security.hypernative.scanEVMTx(request: request)
 
-      logger.info("ViewController.testEVMScan() - ✅ EVM scan completed successfully")
+      logger.info("ViewController.testEVMScan() - ✅ EVM \(malicious ? "malicious" : "") transaction scan completed successfully")
       logEVMResult(response)
 
     } catch {
-      logger.error("ViewController.testEVMScan() - ❌ EVM scan failed: \(error.localizedDescription)")
+      logger.error("ViewController.testEVMScan() - ❌ EVM \(malicious ? "malicious" : "") transaction scan failed: \(error.localizedDescription)")
     }
   }
 

--- a/Sources/PortalSwift/Core/Api/Hypernative/ScanEVMResponse.swift
+++ b/Sources/PortalSwift/Core/Api/Hypernative/ScanEVMResponse.swift
@@ -125,7 +125,7 @@ public struct ScanEVMTrace: Codable {
   public let callType: String?
   public let value: Int?
   public let traceAddress: [Int]?
-  public let status: Int?
+  public let status: Bool?
   public let callInput: String?
   public let extraInfo: [String: String]?
 }

--- a/Sources/PortalSwift/Core/Api/Hypernative/ScanEip712Response.swift
+++ b/Sources/PortalSwift/Core/Api/Hypernative/ScanEip712Response.swift
@@ -76,7 +76,7 @@ public struct ScanEip712Trace: Codable {
   public let callType: String?
   public let value: Int?
   public let traceAddress: [Int]?
-  public let status: Int?
+  public let status: Bool?
   public let callInput: String?
   public let extraInfo: [String: String]?
 }

--- a/Tests/PortalSwiftTests/Security/ScanEip712CodableTests.swift
+++ b/Tests/PortalSwiftTests/Security/ScanEip712CodableTests.swift
@@ -36,7 +36,7 @@ extension ScanEip712CodableTests {
       callType: "call",
       value: 0,
       traceAddress: [0],
-      status: 1,
+      status: true,
       callInput: "0xabcdef",
       extraInfo: ["key": "value"]
     )
@@ -52,7 +52,7 @@ extension ScanEip712CodableTests {
     XCTAssertEqual(decoded.callType, "call")
     XCTAssertEqual(decoded.value, 0)
     XCTAssertEqual(decoded.traceAddress, [0])
-    XCTAssertEqual(decoded.status, 1)
+    XCTAssertEqual(decoded.status, true)
     XCTAssertEqual(decoded.callInput, "0xabcdef")
     XCTAssertEqual(decoded.extraInfo?["key"], "value")
   }
@@ -63,7 +63,7 @@ extension ScanEip712CodableTests {
     {
       "funcId": "0xdeadbeef",
       "callType": "call",
-      "status": 1
+      "status": true
     }
     """.data(using: .utf8)!
 
@@ -75,7 +75,7 @@ extension ScanEip712CodableTests {
     XCTAssertNil(decoded.to)
     XCTAssertEqual(decoded.funcId, "0xdeadbeef")
     XCTAssertEqual(decoded.callType, "call")
-    XCTAssertEqual(decoded.status, 1)
+    XCTAssertEqual(decoded.status, true)
   }
 
   func test_scanEip712Trace_decodesWithExplicitNullFromAndTo() throws {

--- a/Tests/PortalSwiftTests/Stubs/Hypernative.swift
+++ b/Tests/PortalSwiftTests/Stubs/Hypernative.swift
@@ -781,7 +781,7 @@ extension ScanEVMTrace {
     callType: String? = nil,
     value: Int? = nil,
     traceAddress: [Int]? = nil,
-    status: Int? = 1,
+    status: Bool? = true,
     callInput: String? = nil,
     extraInfo: [String: String]? = nil
   ) -> Self {
@@ -910,7 +910,7 @@ extension ScanEip712Trace {
     callType: String? = nil,
     value: Int? = nil,
     traceAddress: [Int]? = nil,
-    status: Int? = 1,
+    status: Bool? = true,
     callInput: String? = nil,
     extraInfo: [String: String]? = nil
   ) -> Self {


### PR DESCRIPTION
## Summary
Aligns `ScanEVMResponse` and `ScanEip712Response` trace models with the actual Hypernative API response by changing the `status` field type from `Int?` to `Bool?`. The previous `Int?` typing caused decoding failures whenever the API returned a boolean for trace status.
This follows the same pattern as the recent `ScanEip712Response` (SDK-133) and `ScanAddressesResponse` strictness relaxations.
## Changes
- `ScanEVMResponse.swift`: `ScanEVMTrace.status` changed from `Int?` → `Bool?`.
- `ScanEip712Response.swift`: `ScanEip712Trace.status` changed from `Int?` → `Bool?`.
- `ViewController+HyperNativeSecurity.swift` (Example App):
  - Added a malicious-vs-clean variant to `testEVMScan(malicious:)` so both code paths can be exercised from the example app.
  - Switched the test transaction to `eip155:1` and trimmed unused fields (`nonce`, `gas`, `gasPrice`, `hash`) for a cleaner sample.


> **Copilot Review:** GitHub Copilot will automatically post a review below. Check its comments for additional context and suggestions.
