### PR TITLE
Release `7.2.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ Possible Types of changes include:
 - Improved
 - Upgraded
 
+## 7.2.1 - 2026-05-20
+- Fixed Hypernative `ScanAddressesResponse` decoding to align with the Hypernative API.
+    - Made `totalIncomingUsd`, `policyId`, `timestamp`, and `flags` optional on `ScanAddressesItem`, and added `totalOutgoingUsd`.
+    - Made `chain` and `events` optional on `ScanAddressesFlag`.
+    - Made `exposurePortion` optional on `ScanAddressesExposure`, and added `direction` and `severity`.
+    - Made `address` and `chain` optional on `ScanAddressesFlaggedInteraction`, and added `entityId`, `entityName`, and `severity`.
+- Relaxed Codable strictness in Hypernative scan transaction response models to prevent decoding failures.
+    - Made `from` and `to` optional on `ScanEip712Trace`.
+    - Changed `funcId` on `ScanSolanaTrace` to a new `ScanSolanaFuncId` enum that accepts either a string or a byte array.
+    - Changed `status` on `ScanEVMTrace` and `ScanEip712Trace` from `Int?` to `Bool?` to align with the Hypernative API.
+- Removed the unused `modals` field from `BlockaidScanURLRawResponse`.
+
 ## 7.2.0 - 2026-03-27
 - Added presignature support for faster signing via `FeatureFlags.usePresignatures`.
     - When enabled, the SDK pre-generates signatures in the background and uses them at signing time for reduced latency.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @kelsonic @AhmedRagabIssa @Maxi-F @ahmdshrif
+* @kelsonic @AhmedRagabIssa @Maxi-F @ahmdshrif @Rshahatit

--- a/SPM Example/PortalSwift/MainViewController/ViewController+BlockaidSecurity.swift
+++ b/SPM Example/PortalSwift/MainViewController/ViewController+BlockaidSecurity.swift
@@ -329,7 +329,7 @@ extension ViewController {
         logger.info("📝 [Blockaid Scan URL] Starting scan...")
 
         let request = BlockaidScanURLRequest(
-          url: "https://app.uniswap.org"
+          url: "https://uniswap.org"
         )
 
         let response = try await portal.security.blockaid.scanURL(request: request)

--- a/SPM Example/PortalSwift/MainViewController/ViewController+HyperNativeSecurity.swift
+++ b/SPM Example/PortalSwift/MainViewController/ViewController+HyperNativeSecurity.swift
@@ -24,8 +24,11 @@ extension ViewController {
     Task {
       logger.info("ViewController.hypernativeScanTx() - 📝 Starting transaction scans...")
 
+      // Test EVM malicious Transaction Scan
+      await testEVMScan(malicious: true)
+      
       // Test EVM Transaction Scan
-      await testEVMScan()
+      await testEVMScan(malicious: false)
 
       // Test EIP-712 Transaction Scan
       await testEip712Scan()
@@ -187,27 +190,25 @@ extension ViewController {
 
   // MARK: - Private Helper Methods
 
-  private func testEVMScan() async {
+  private func testEVMScan(malicious: Bool = false) async {
     do {
-      logger.info("ViewController.testEVMScan() - 📝 Testing EVM transaction scan...")
+      logger.info("ViewController.testEVMScan() - 📝 Testing EVM \(malicious ? "malicious" : "") transaction scan...")
 
       guard let portal = portal else {
         logger.error("ViewController.testEVMScan() - ❌ Portal not initialized")
         return
       }
 
+      let input = malicious
+        ? "0x095ea7b300000000000000000000000066ba61be3bab35c0c00038f335850a390b086fe300000000000000000000000000000000000000000fffffffffffffffffffffff"
+        : "0x"
+
       let transaction = ScanEVMTransaction(
-        chain: "eip155:143",
+        chain: "eip155:1",
         fromAddress: "0x7C01728004d3F2370C1BBC36a4Ad680fE6FE8729",
         toAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-        input: "0x095ea7b300000000000000000000000066ba61be3bab35c0c00038f335850a390b086fe300000000000000000000000000000000000000000fffffffffffffffffffffff",
-        value: 0,
-        nonce: 2340,
-        hash: nil,
-        gas: 3_000_000,
-        gasPrice: 3_000_000,
-        maxPriorityFeePerGas: nil,
-        maxFeePerGas: nil
+        input: input,
+        value: 0
       )
 
       let request = ScanEVMRequest(
@@ -221,11 +222,11 @@ extension ViewController {
 
       let response = try await portal.security.hypernative.scanEVMTx(request: request)
 
-      logger.info("ViewController.testEVMScan() - ✅ EVM scan completed successfully")
+      logger.info("ViewController.testEVMScan() - ✅ EVM \(malicious ? "malicious" : "") transaction scan completed successfully")
       logEVMResult(response)
 
     } catch {
-      logger.error("ViewController.testEVMScan() - ❌ EVM scan failed: \(error.localizedDescription)")
+      logger.error("ViewController.testEVMScan() - ❌ EVM \(malicious ? "malicious" : "") transaction scan failed: \(error.localizedDescription)")
     }
   }
 

--- a/SPM Example/PortalSwift/MainViewController/ViewController+HyperNativeSecurity.swift
+++ b/SPM Example/PortalSwift/MainViewController/ViewController+HyperNativeSecurity.swift
@@ -392,7 +392,7 @@ extension ViewController {
         logger.info("  Address: \(addressResult.address)")
         logger.info("    Recommendation: \(addressResult.recommendation)")
         logger.info("    Severity: \(addressResult.severity)")
-        logger.info("    Flags count: \(addressResult.flags.count)")
+        logger.info("    Flags count: \(addressResult.flags?.count ?? 0)")
       }
     } else if let error = response.error {
       logger.error("ViewController - ❌ Address Scan Error: \(error)")

--- a/Sources/PortalSwift/Core/Api/Blockaid/BlockaidScanURLResponse.swift
+++ b/Sources/PortalSwift/Core/Api/Blockaid/BlockaidScanURLResponse.swift
@@ -33,10 +33,9 @@ public struct BlockaidScanURLRawResponse: Codable {
   public let jsonRpcOperations: [String]?
   public let contractWrite: BlockaidContractOperations?
   public let contractRead: BlockaidContractOperations?
-  public let modals: [String]?
 
   private enum CodingKeys: String, CodingKey {
-    case status, url, modals
+    case status, url
     case scanStartTime = "scan_start_time"
     case scanEndTime = "scan_end_time"
     case maliciousScore = "malicious_score"

--- a/Sources/PortalSwift/Core/Api/Hypernative/ScanAddressesResponse.swift
+++ b/Sources/PortalSwift/Core/Api/Hypernative/ScanAddressesResponse.swift
@@ -24,18 +24,19 @@ public struct ScanAddressesItem: Codable {
   public let address: String
   public let recommendation: String
   public let severity: String
-  public let totalIncomingUsd: Double
-  public let policyId: String
-  public let timestamp: String
-  public let flags: [ScanAddressesFlag]
+  public let totalIncomingUsd: Double?
+  public let totalOutgoingUsd: Double?
+  public let policyId: String?
+  public let timestamp: String?
+  public let flags: [ScanAddressesFlag]?
 }
 
 public struct ScanAddressesFlag: Codable {
   public let title: String
   public let flagId: String
-  public let chain: String
+  public let chain: String?
   public let severity: String
-  public let events: [ScanAddressesEvent]
+  public let events: [ScanAddressesEvent]?
   public let lastUpdate: String?
   public let exposures: [ScanAddressesExposure]
 }
@@ -63,16 +64,21 @@ public struct ScanAddressesEvent: Codable {
 }
 
 public struct ScanAddressesExposure: Codable {
-  public let exposurePortion: Double
+  public let exposurePortion: Double?
   public let exposureType: String?
   public let totalExposureUsd: Double
   public let flaggedInteractions: [ScanAddressesFlaggedInteraction]
+  public let direction: String?
+  public let severity: String?
 }
 
 public struct ScanAddressesFlaggedInteraction: Codable {
-  public let address: String
-  public let chain: String
+  public let address: String?
+  public let chain: String?
   public let alias: String?
   public let minHop: Int
   public let totalExposureUsd: Double
+  public let entityId: String?
+  public let entityName: String?
+  public let severity: String?
 }

--- a/Sources/PortalSwift/Core/Api/Hypernative/ScanEVMResponse.swift
+++ b/Sources/PortalSwift/Core/Api/Hypernative/ScanEVMResponse.swift
@@ -125,7 +125,7 @@ public struct ScanEVMTrace: Codable {
   public let callType: String?
   public let value: Int?
   public let traceAddress: [Int]?
-  public let status: Int?
+  public let status: Bool?
   public let callInput: String?
   public let extraInfo: [String: String]?
 }

--- a/Sources/PortalSwift/Core/Api/Hypernative/ScanEip712Response.swift
+++ b/Sources/PortalSwift/Core/Api/Hypernative/ScanEip712Response.swift
@@ -76,7 +76,7 @@ public struct ScanEip712Trace: Codable {
   public let callType: String?
   public let value: Int?
   public let traceAddress: [Int]?
-  public let status: Int?
+  public let status: Bool?
   public let callInput: String?
   public let extraInfo: [String: String]?
 }

--- a/Sources/PortalSwift/Core/Api/Hypernative/ScanEip712Response.swift
+++ b/Sources/PortalSwift/Core/Api/Hypernative/ScanEip712Response.swift
@@ -70,8 +70,8 @@ public struct ScanEip712ParsedActionItem: Codable {
 }
 
 public struct ScanEip712Trace: Codable {
-  public let from: String
-  public let to: String
+  public let from: String?
+  public let to: String?
   public let funcId: String?
   public let callType: String?
   public let value: Int?

--- a/Sources/PortalSwift/Core/Api/Hypernative/ScanSolanaResponse.swift
+++ b/Sources/PortalSwift/Core/Api/Hypernative/ScanSolanaResponse.swift
@@ -89,13 +89,35 @@ public struct ScanSolanaParsedActionItem: Codable {
 public struct ScanSolanaTrace: Codable {
   public let from: String
   public let to: String
-  public let funcId: String?
+  public let funcId: ScanSolanaFuncId?
   public let callType: String?
   public let value: Int?
   public let traceAddress: [Int]?
   public let status: String?
   public let callInput: ScanSolanaTraceCallInput?
   public let extraInfo: [String: String]?
+}
+
+public enum ScanSolanaFuncId: Codable {
+  case string(String)
+  case bytes([Int])
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if let stringValue = try? container.decode(String.self) {
+      self = .string(stringValue)
+    } else if let bytes = try? container.decode([Int].self) {
+      self = .bytes(bytes)
+    } else {
+      self = .string("")
+    }
+  }
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .string(let value): try container.encode(value)
+    case .bytes(let value): try container.encode(value)
+    }
+  }
 }
 
 public struct ScanSolanaTraceCallInput: Codable {

--- a/Tests/PortalSwiftTests/Core/PortalKeychainTests.swift
+++ b/Tests/PortalSwiftTests/Core/PortalKeychainTests.swift
@@ -35,11 +35,7 @@ final class PortalKeychainTests: XCTestCase {
 extension PortalKeychainTests {
   func initKeychainWith(
     keychainAccess: PortalKeychainAccessProtocol? = nil,
-    api: PortalApiProtocol? = PortalApi(
-      apiKey: MockConstants.mockApiKey,
-      apiHost: MockConstants.mockHost,
-      requests: MockPortalRequests()
-    )
+    api: PortalApiProtocol? = PortalApiMock(client: MockConstants.mockClient)
   ) {
     keychain = PortalKeychain(keychainAccess: keychainAccess)
     self.portalApi = api

--- a/Tests/PortalSwiftTests/Security/ScanAddressesCodableTests.swift
+++ b/Tests/PortalSwiftTests/Security/ScanAddressesCodableTests.swift
@@ -1,0 +1,204 @@
+//
+//  ScanAddressesCodableTests.swift
+//  PortalSwiftTests
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+@testable import PortalSwift
+import XCTest
+
+final class ScanAddressesCodableTests: XCTestCase {
+  var decoder: JSONDecoder!
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    decoder = JSONDecoder()
+  }
+
+  override func tearDownWithError() throws {
+    decoder = nil
+    try super.tearDownWithError()
+  }
+}
+
+// MARK: - Regression Tests for Partial Backend Payloads
+
+extension ScanAddressesCodableTests {
+  /// Regression test: backend may omit `totalIncomingUsd`, `totalOutgoingUsd`,
+  /// `policyId`, `timestamp`, and may return an empty `flags` array (or omit it
+  /// entirely) for items with `recommendation: "Approve"`. Decoding must not
+  /// throw `keyNotFound` for any of these fields.
+  func test_scanAddressesResponse_decodesItemWithMissingOptionalFields() throws {
+    let json = Data("""
+    {
+      "data": {
+        "rawResponse": [
+          {
+            "address": "0x2753a0d37a2ad09be3ccc0afcb650bea8ea57a8f",
+            "recommendation": "Approve",
+            "severity": "N/A",
+            "flags": []
+          }
+        ]
+      }
+    }
+    """.utf8)
+
+    let response = try decoder.decode(ScanAddressesResponse.self, from: json)
+
+    let item = try XCTUnwrap(response.data?.rawResponse.first)
+    XCTAssertEqual(item.address, "0x2753a0d37a2ad09be3ccc0afcb650bea8ea57a8f")
+    XCTAssertEqual(item.recommendation, "Approve")
+    XCTAssertEqual(item.severity, "N/A")
+    XCTAssertNil(item.totalIncomingUsd)
+    XCTAssertNil(item.totalOutgoingUsd)
+    XCTAssertNil(item.policyId)
+    XCTAssertNil(item.timestamp)
+    XCTAssertEqual(item.flags?.count, 0)
+  }
+
+  /// Regression test: `flags` itself may be omitted (not just empty).
+  func test_scanAddressesResponse_decodesItemWithOmittedFlags() throws {
+    let json = Data("""
+    {
+      "data": {
+        "rawResponse": [
+          {
+            "address": "0xabc",
+            "recommendation": "Approve",
+            "severity": "N/A"
+          }
+        ]
+      }
+    }
+    """.utf8)
+
+    let response = try decoder.decode(ScanAddressesResponse.self, from: json)
+    let item = try XCTUnwrap(response.data?.rawResponse.first)
+    XCTAssertNil(item.flags)
+  }
+
+  /// Regression test: a fully-populated "Deny" item (with the newly added
+  /// fields `totalOutgoingUsd`, exposure `direction`/`severity`, and
+  /// flagged-interaction `entityId`/`entityName`/`severity`) decodes and
+  /// preserves all values.
+  func test_scanAddressesResponse_decodesFullyPopulatedDenyItem() throws {
+    let json = Data("""
+    {
+      "data": {
+        "rawResponse": [
+          {
+            "address": "0x31c05d73f2333b5a176cfdbb7c5ef96ec7bb04ac",
+            "recommendation": "Deny",
+            "severity": "High",
+            "totalIncomingUsd": 898761.6875,
+            "totalOutgoingUsd": 2149675.75,
+            "policyId": "ac938c22-4a3b-4f6c-9c1a-e9e7c7e9113d",
+            "timestamp": "2026-05-13T23:09:19.506Z",
+            "flags": [
+              {
+                "title": "Related to Mixing Services",
+                "flagId": "RF1510",
+                "chain": "eip155:1",
+                "severity": "High",
+                "events": [],
+                "lastUpdate": "2023-12-28T21:05:35Z",
+                "exposures": [
+                  {
+                    "exposurePortion": 0.8854220719626247,
+                    "exposureType": "direct",
+                    "totalExposureUsd": 795783.435546875,
+                    "flaggedInteractions": [
+                      {
+                        "address": "0xa160cdab225685da1d56aa342ad8841c3b53f291",
+                        "chain": "eip155:1",
+                        "alias": "Tornado.Cash: 100 ETH",
+                        "minHop": 1,
+                        "totalExposureUsd": 705959,
+                        "entityId": "147b88c2-e008-4c1b-89d2-d08ea9e13e77",
+                        "entityName": "Tornado.Cash",
+                        "severity": "High"
+                      }
+                    ],
+                    "direction": "incoming",
+                    "severity": "High"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+    """.utf8)
+
+    let response = try decoder.decode(ScanAddressesResponse.self, from: json)
+    let item = try XCTUnwrap(response.data?.rawResponse.first)
+
+    XCTAssertEqual(item.totalIncomingUsd, 898761.6875)
+    XCTAssertEqual(item.totalOutgoingUsd, 2149675.75)
+    XCTAssertEqual(item.policyId, "ac938c22-4a3b-4f6c-9c1a-e9e7c7e9113d")
+    XCTAssertEqual(item.timestamp, "2026-05-13T23:09:19.506Z")
+
+    let flag = try XCTUnwrap(item.flags?.first)
+    XCTAssertEqual(flag.flagId, "RF1510")
+    XCTAssertEqual(flag.chain, "eip155:1")
+    XCTAssertEqual(flag.events?.count, 0)
+
+    let exposure = try XCTUnwrap(flag.exposures.first)
+    XCTAssertEqual(exposure.exposurePortion, 0.8854220719626247)
+    XCTAssertEqual(exposure.direction, "incoming")
+    XCTAssertEqual(exposure.severity, "High")
+
+    let interaction = try XCTUnwrap(exposure.flaggedInteractions.first)
+    XCTAssertEqual(interaction.address, "0xa160cdab225685da1d56aa342ad8841c3b53f291")
+    XCTAssertEqual(interaction.chain, "eip155:1")
+    XCTAssertEqual(interaction.alias, "Tornado.Cash: 100 ETH")
+    XCTAssertEqual(interaction.entityId, "147b88c2-e008-4c1b-89d2-d08ea9e13e77")
+    XCTAssertEqual(interaction.entityName, "Tornado.Cash")
+    XCTAssertEqual(interaction.severity, "High")
+  }
+
+  /// Regression test: the full multi-item payload from SDK-136 (one Deny item
+  /// with full flags, one Approve item with no flags/policyId/timestamp/totals)
+  /// decodes successfully.
+  func test_scanAddressesResponse_decodesMixedDenyAndApprovePayload() throws {
+    let json = Data("""
+    {
+      "data": {
+        "rawResponse": [
+          {
+            "address": "0x31c05d73f2333b5a176cfdbb7c5ef96ec7bb04ac",
+            "recommendation": "Deny",
+            "severity": "High",
+            "totalIncomingUsd": 898761.6875,
+            "totalOutgoingUsd": 2149675.75,
+            "policyId": "ac938c22-4a3b-4f6c-9c1a-e9e7c7e9113d",
+            "timestamp": "2026-05-13T23:09:19.506Z",
+            "flags": []
+          },
+          {
+            "address": "0x2753a0d37a2ad09be3ccc0afcb650bea8ea57a8f",
+            "recommendation": "Approve",
+            "severity": "N/A",
+            "policyId": "ac938c22-4a3b-4f6c-9c1a-e9e7c7e9113d",
+            "timestamp": "2026-05-13T23:09:19.506Z",
+            "flags": []
+          }
+        ]
+      }
+    }
+    """.utf8)
+
+    let response = try decoder.decode(ScanAddressesResponse.self, from: json)
+    let items = try XCTUnwrap(response.data?.rawResponse)
+
+    XCTAssertEqual(items.count, 2)
+    XCTAssertEqual(items[0].recommendation, "Deny")
+    XCTAssertEqual(items[1].recommendation, "Approve")
+    XCTAssertNil(items[1].totalIncomingUsd)
+    XCTAssertNil(items[1].totalOutgoingUsd)
+  }
+}

--- a/Tests/PortalSwiftTests/Security/ScanEip712CodableTests.swift
+++ b/Tests/PortalSwiftTests/Security/ScanEip712CodableTests.swift
@@ -1,0 +1,151 @@
+//
+//  ScanEip712CodableTests.swift
+//  PortalSwiftTests
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+@testable import PortalSwift
+import XCTest
+
+final class ScanEip712CodableTests: XCTestCase {
+  var encoder: JSONEncoder!
+  var decoder: JSONDecoder!
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    encoder = JSONEncoder()
+    decoder = JSONDecoder()
+  }
+
+  override func tearDownWithError() throws {
+    encoder = nil
+    decoder = nil
+    try super.tearDownWithError()
+  }
+}
+
+// MARK: - ScanEip712Trace Codable Tests
+
+extension ScanEip712CodableTests {
+  func test_scanEip712Trace_encodesAndDecodesCorrectly() throws {
+    // Given
+    let trace = ScanEip712Trace.stub(
+      funcId: "0x095ea7b3",
+      callType: "call",
+      value: 0,
+      traceAddress: [0],
+      status: 1,
+      callInput: "0xabcdef",
+      extraInfo: ["key": "value"]
+    )
+
+    // When
+    let data = try encoder.encode(trace)
+    let decoded = try decoder.decode(ScanEip712Trace.self, from: data)
+
+    // Then
+    XCTAssertEqual(decoded.from, trace.from)
+    XCTAssertEqual(decoded.to, trace.to)
+    XCTAssertEqual(decoded.funcId, "0x095ea7b3")
+    XCTAssertEqual(decoded.callType, "call")
+    XCTAssertEqual(decoded.value, 0)
+    XCTAssertEqual(decoded.traceAddress, [0])
+    XCTAssertEqual(decoded.status, 1)
+    XCTAssertEqual(decoded.callInput, "0xabcdef")
+    XCTAssertEqual(decoded.extraInfo?["key"], "value")
+  }
+
+  func test_scanEip712Trace_decodesWithoutFromAndTo() throws {
+    // Given: trace JSON missing the now-optional `from` and `to` fields
+    let json = """
+    {
+      "funcId": "0xdeadbeef",
+      "callType": "call",
+      "status": 1
+    }
+    """.data(using: .utf8)!
+
+    // When
+    let decoded = try decoder.decode(ScanEip712Trace.self, from: json)
+
+    // Then
+    XCTAssertNil(decoded.from)
+    XCTAssertNil(decoded.to)
+    XCTAssertEqual(decoded.funcId, "0xdeadbeef")
+    XCTAssertEqual(decoded.callType, "call")
+    XCTAssertEqual(decoded.status, 1)
+  }
+
+  func test_scanEip712Trace_decodesWithExplicitNullFromAndTo() throws {
+    // Given: trace JSON where from/to are explicit null
+    let json = """
+    {
+      "from": null,
+      "to": null,
+      "funcId": "0x095ea7b3"
+    }
+    """.data(using: .utf8)!
+
+    // When
+    let decoded = try decoder.decode(ScanEip712Trace.self, from: json)
+
+    // Then
+    XCTAssertNil(decoded.from)
+    XCTAssertNil(decoded.to)
+    XCTAssertEqual(decoded.funcId, "0x095ea7b3")
+  }
+
+  func test_scanEip712Trace_roundTripsWithNilFromAndTo() throws {
+    // Given
+    let trace = ScanEip712Trace.stub(from: nil, to: nil, funcId: "0x095ea7b3")
+
+    // When
+    let data = try encoder.encode(trace)
+    let decoded = try decoder.decode(ScanEip712Trace.self, from: data)
+
+    // Then
+    XCTAssertNil(decoded.from)
+    XCTAssertNil(decoded.to)
+    XCTAssertEqual(decoded.funcId, "0x095ea7b3")
+  }
+}
+
+// MARK: - ScanEip712Response Codable Tests
+
+extension ScanEip712CodableTests {
+  func test_scanEip712Response_encodesAndDecodesCorrectly() throws {
+    // Given
+    let response = ScanEip712Response.stub()
+
+    // When
+    let data = try encoder.encode(response)
+    let decoded = try decoder.decode(ScanEip712Response.self, from: data)
+
+    // Then
+    XCTAssertNotNil(decoded.data)
+    XCTAssertEqual(decoded.data?.rawResponse.success, true)
+    XCTAssertEqual(decoded.data?.rawResponse.data?.recommendation, "accept")
+    XCTAssertNil(decoded.error)
+  }
+
+  func test_scanEip712Response_withTraceContainingNilFromAndTo() throws {
+    // Given: full response containing a trace with optional from/to set to nil
+    let trace = ScanEip712Trace.stub(from: nil, to: nil, funcId: "0xabc")
+    let riskData = ScanEip712RiskData.stub(trace: [trace])
+    let rawResponse = ScanEip712RawResponse.stub(data: riskData)
+    let response = ScanEip712Response(data: ScanEip712Data(rawResponse: rawResponse), error: nil)
+
+    // When
+    let data = try encoder.encode(response)
+    let decoded = try decoder.decode(ScanEip712Response.self, from: data)
+
+    // Then
+    let decodedTrace = decoded.data?.rawResponse.data?.trace?.first
+    XCTAssertNotNil(decodedTrace)
+    XCTAssertNil(decodedTrace?.from)
+    XCTAssertNil(decodedTrace?.to)
+    XCTAssertEqual(decodedTrace?.funcId, "0xabc")
+  }
+}

--- a/Tests/PortalSwiftTests/Security/ScanEip712CodableTests.swift
+++ b/Tests/PortalSwiftTests/Security/ScanEip712CodableTests.swift
@@ -36,7 +36,7 @@ extension ScanEip712CodableTests {
       callType: "call",
       value: 0,
       traceAddress: [0],
-      status: 1,
+      status: true,
       callInput: "0xabcdef",
       extraInfo: ["key": "value"]
     )
@@ -52,7 +52,7 @@ extension ScanEip712CodableTests {
     XCTAssertEqual(decoded.callType, "call")
     XCTAssertEqual(decoded.value, 0)
     XCTAssertEqual(decoded.traceAddress, [0])
-    XCTAssertEqual(decoded.status, 1)
+    XCTAssertEqual(decoded.status, true)
     XCTAssertEqual(decoded.callInput, "0xabcdef")
     XCTAssertEqual(decoded.extraInfo?["key"], "value")
   }
@@ -63,7 +63,7 @@ extension ScanEip712CodableTests {
     {
       "funcId": "0xdeadbeef",
       "callType": "call",
-      "status": 1
+      "status": true
     }
     """.data(using: .utf8)!
 
@@ -75,7 +75,7 @@ extension ScanEip712CodableTests {
     XCTAssertNil(decoded.to)
     XCTAssertEqual(decoded.funcId, "0xdeadbeef")
     XCTAssertEqual(decoded.callType, "call")
-    XCTAssertEqual(decoded.status, 1)
+    XCTAssertEqual(decoded.status, true)
   }
 
   func test_scanEip712Trace_decodesWithExplicitNullFromAndTo() throws {

--- a/Tests/PortalSwiftTests/Security/ScanSolanaCodableTests.swift
+++ b/Tests/PortalSwiftTests/Security/ScanSolanaCodableTests.swift
@@ -451,3 +451,160 @@ extension ScanSolanaCodableTests {
     XCTAssertEqual(decoded.lamports, info.lamports)
   }
 }
+
+// MARK: - ScanSolanaFuncId (Polymorphic) Codable Tests
+
+extension ScanSolanaCodableTests {
+  func test_scanSolanaFuncId_decodesString() throws {
+    // Given: funcId as string
+    let json = "\"transfer\"".data(using: .utf8)!
+
+    // When
+    let decoded = try decoder.decode(ScanSolanaFuncId.self, from: json)
+
+    // Then
+    if case .string(let value) = decoded {
+      XCTAssertEqual(value, "transfer")
+    } else {
+      XCTFail("Expected .string case, got \(decoded)")
+    }
+  }
+
+  func test_scanSolanaFuncId_decodesBytes() throws {
+    // Given: funcId as array of bytes
+    let json = "[1, 2, 3, 4]".data(using: .utf8)!
+
+    // When
+    let decoded = try decoder.decode(ScanSolanaFuncId.self, from: json)
+
+    // Then
+    if case .bytes(let bytes) = decoded {
+      XCTAssertEqual(bytes, [1, 2, 3, 4])
+    } else {
+      XCTFail("Expected .bytes case, got \(decoded)")
+    }
+  }
+
+  func test_scanSolanaFuncId_invalidPayloadFallsBackToEmptyString() throws {
+    // Given: funcId as an unexpected type (boolean)
+    let json = "true".data(using: .utf8)!
+
+    // When
+    let decoded = try decoder.decode(ScanSolanaFuncId.self, from: json)
+
+    // Then
+    if case .string(let value) = decoded {
+      XCTAssertEqual(value, "")
+    } else {
+      XCTFail("Expected .string fallback, got \(decoded)")
+    }
+  }
+
+  func test_scanSolanaFuncId_encodesString() throws {
+    // Given
+    let funcId = ScanSolanaFuncId.string("transfer")
+
+    // When
+    let data = try encoder.encode(funcId)
+    let decoded = try decoder.decode(ScanSolanaFuncId.self, from: data)
+
+    // Then
+    if case .string(let value) = decoded {
+      XCTAssertEqual(value, "transfer")
+    } else {
+      XCTFail("Expected .string case after round-trip, got \(decoded)")
+    }
+  }
+
+  func test_scanSolanaFuncId_encodesBytes() throws {
+    // Given
+    let funcId = ScanSolanaFuncId.bytes([10, 20, 30])
+
+    // When
+    let data = try encoder.encode(funcId)
+    let decoded = try decoder.decode(ScanSolanaFuncId.self, from: data)
+
+    // Then
+    if case .bytes(let bytes) = decoded {
+      XCTAssertEqual(bytes, [10, 20, 30])
+    } else {
+      XCTFail("Expected .bytes case after round-trip, got \(decoded)")
+    }
+  }
+
+  func test_scanSolanaTrace_decodesFuncIdAsString() throws {
+    // Given: trace JSON where funcId is a string
+    let json = """
+    {
+      "from": "0x123",
+      "to": "0x456",
+      "funcId": "transfer",
+      "status": "True"
+    }
+    """.data(using: .utf8)!
+
+    // When
+    let decoded = try decoder.decode(ScanSolanaTrace.self, from: json)
+
+    // Then
+    if case .string(let value)? = decoded.funcId {
+      XCTAssertEqual(value, "transfer")
+    } else {
+      XCTFail("Expected funcId .string, got \(String(describing: decoded.funcId))")
+    }
+  }
+
+  func test_scanSolanaTrace_decodesFuncIdAsBytes() throws {
+    // Given: trace JSON where funcId is a byte array
+    let json = """
+    {
+      "from": "0x123",
+      "to": "0x456",
+      "funcId": [1, 2, 3, 4],
+      "status": "True"
+    }
+    """.data(using: .utf8)!
+
+    // When
+    let decoded = try decoder.decode(ScanSolanaTrace.self, from: json)
+
+    // Then
+    if case .bytes(let bytes)? = decoded.funcId {
+      XCTAssertEqual(bytes, [1, 2, 3, 4])
+    } else {
+      XCTFail("Expected funcId .bytes, got \(String(describing: decoded.funcId))")
+    }
+  }
+
+  func test_scanSolanaTrace_roundTripsWithFuncIdString() throws {
+    // Given
+    let trace = ScanSolanaTrace.stub(funcId: .string("transfer"))
+
+    // When
+    let data = try encoder.encode(trace)
+    let decoded = try decoder.decode(ScanSolanaTrace.self, from: data)
+
+    // Then
+    if case .string(let value)? = decoded.funcId {
+      XCTAssertEqual(value, "transfer")
+    } else {
+      XCTFail("Expected funcId .string after round-trip, got \(String(describing: decoded.funcId))")
+    }
+  }
+
+  func test_scanSolanaTrace_roundTripsWithFuncIdBytes() throws {
+    // Given
+    let trace = ScanSolanaTrace.stub(funcId: .bytes([7, 8, 9]))
+
+    // When
+    let data = try encoder.encode(trace)
+    let decoded = try decoder.decode(ScanSolanaTrace.self, from: data)
+
+    // Then
+    if case .bytes(let bytes)? = decoded.funcId {
+      XCTAssertEqual(bytes, [7, 8, 9])
+    } else {
+      XCTFail("Expected funcId .bytes after round-trip, got \(String(describing: decoded.funcId))")
+    }
+  }
+}

--- a/Tests/PortalSwiftTests/Stubs/Blockaid.swift
+++ b/Tests/PortalSwiftTests/Stubs/Blockaid.swift
@@ -395,8 +395,7 @@ extension BlockaidScanURLRawResponse {
     networkOperations: [String]? = nil,
     jsonRpcOperations: [String]? = nil,
     contractWrite: BlockaidContractOperations? = nil,
-    contractRead: BlockaidContractOperations? = nil,
-    modals: [String]? = nil
+    contractRead: BlockaidContractOperations? = nil
   ) -> Self {
     BlockaidScanURLRawResponse(
       status: status,
@@ -411,8 +410,7 @@ extension BlockaidScanURLRawResponse {
       networkOperations: networkOperations,
       jsonRpcOperations: jsonRpcOperations,
       contractWrite: contractWrite,
-      contractRead: contractRead,
-      modals: modals
+      contractRead: contractRead
     )
   }
 }

--- a/Tests/PortalSwiftTests/Stubs/Hypernative.swift
+++ b/Tests/PortalSwiftTests/Stubs/Hypernative.swift
@@ -412,16 +412,18 @@ extension ScanAddressesItem {
     address: String = "0x123",
     recommendation: String = "accept",
     severity: String = "low",
-    totalIncomingUsd: Double = 0.0,
-    policyId: String = "test-policy-id",
-    timestamp: String = "2024-01-01T00:00:00Z",
-    flags: [ScanAddressesFlag] = []
+    totalIncomingUsd: Double? = 0.0,
+    totalOutgoingUsd: Double? = 0.0,
+    policyId: String? = "test-policy-id",
+    timestamp: String? = "2024-01-01T00:00:00Z",
+    flags: [ScanAddressesFlag]? = []
   ) -> Self {
     ScanAddressesItem(
       address: address,
       recommendation: recommendation,
       severity: severity,
       totalIncomingUsd: totalIncomingUsd,
+      totalOutgoingUsd: totalOutgoingUsd,
       policyId: policyId,
       timestamp: timestamp,
       flags: flags
@@ -801,9 +803,9 @@ extension ScanAddressesFlag {
   static func stub(
     title: String = "Test Flag",
     flagId: String = "test-flag-id",
-    chain: String = "ethereum",
+    chain: String? = "ethereum",
     severity: String = "low",
-    events: [ScanAddressesEvent] = [],
+    events: [ScanAddressesEvent]? = [],
     lastUpdate: String? = "2024-01-01T00:00:00Z",
     exposures: [ScanAddressesExposure] = []
   ) -> Self {
@@ -1196,34 +1198,44 @@ extension ScanAddressesEvent {
 
 extension ScanAddressesExposure {
   static func stub(
-    exposurePortion: Double = 0.5,
+    exposurePortion: Double? = 0.5,
     exposureType: String? = "direct",
     totalExposureUsd: Double = 1000.0,
-    flaggedInteractions: [ScanAddressesFlaggedInteraction] = []
+    flaggedInteractions: [ScanAddressesFlaggedInteraction] = [],
+    direction: String? = "incoming",
+    severity: String? = "low"
   ) -> Self {
     ScanAddressesExposure(
       exposurePortion: exposurePortion,
       exposureType: exposureType,
       totalExposureUsd: totalExposureUsd,
-      flaggedInteractions: flaggedInteractions
+      flaggedInteractions: flaggedInteractions,
+      direction: direction,
+      severity: severity
     )
   }
 }
 
 extension ScanAddressesFlaggedInteraction {
   static func stub(
-    address: String = "0x123",
-    chain: String = "ethereum",
+    address: String? = "0x123",
+    chain: String? = "ethereum",
     alias: String? = nil,
     minHop: Int = 1,
-    totalExposureUsd: Double = 500.0
+    totalExposureUsd: Double = 500.0,
+    entityId: String? = "test-entity-id",
+    entityName: String? = "Test Entity",
+    severity: String? = "low"
   ) -> Self {
     ScanAddressesFlaggedInteraction(
       address: address,
       chain: chain,
       alias: alias,
       minHop: minHop,
-      totalExposureUsd: totalExposureUsd
+      totalExposureUsd: totalExposureUsd,
+      entityId: entityId,
+      entityName: entityName,
+      severity: severity
     )
   }
 }

--- a/Tests/PortalSwiftTests/Stubs/Hypernative.swift
+++ b/Tests/PortalSwiftTests/Stubs/Hypernative.swift
@@ -781,7 +781,7 @@ extension ScanEVMTrace {
     callType: String? = nil,
     value: Int? = nil,
     traceAddress: [Int]? = nil,
-    status: Int? = 1,
+    status: Bool? = true,
     callInput: String? = nil,
     extraInfo: [String: String]? = nil
   ) -> Self {
@@ -910,7 +910,7 @@ extension ScanEip712Trace {
     callType: String? = nil,
     value: Int? = nil,
     traceAddress: [Int]? = nil,
-    status: Int? = 1,
+    status: Bool? = true,
     callInput: String? = nil,
     extraInfo: [String: String]? = nil
   ) -> Self {

--- a/Tests/PortalSwiftTests/Stubs/Hypernative.swift
+++ b/Tests/PortalSwiftTests/Stubs/Hypernative.swift
@@ -902,8 +902,8 @@ extension ScanSolanaAddressTableLookup {
 
 extension ScanEip712Trace {
   static func stub(
-    from: String = "0x7C01728004d3F2370C1BBC36a4Ad680fE6FE8729",
-    to: String = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    from: String? = "0x7C01728004d3F2370C1BBC36a4Ad680fE6FE8729",
+    to: String? = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     funcId: String? = nil,
     callType: String? = nil,
     value: Int? = nil,
@@ -1098,7 +1098,7 @@ extension ScanSolanaTrace {
   static func stub(
     from: String = "0x123",
     to: String = "0x456",
-    funcId: String? = nil,
+    funcId: ScanSolanaFuncId? = nil,
     callType: String? = nil,
     value: Int? = nil,
     traceAddress: [Int]? = nil,


### PR DESCRIPTION
## Release `7.2.1`
- Fixed Hypernative `ScanAddressesResponse` decoding to align with the Hypernative API.
    - Made `totalIncomingUsd`, `policyId`, `timestamp`, and `flags` optional on `ScanAddressesItem`, and added `totalOutgoingUsd`.
    - Made `chain` and `events` optional on `ScanAddressesFlag`.
    - Made `exposurePortion` optional on `ScanAddressesExposure`, and added `direction` and `severity`.
    - Made `address` and `chain` optional on `ScanAddressesFlaggedInteraction`, and added `entityId`, `entityName`, and `severity`.
- Relaxed Codable strictness in Hypernative scan transaction response models to prevent decoding failures.
    - Made `from` and `to` optional on `ScanEip712Trace`.
    - Changed `funcId` on `ScanSolanaTrace` to a new `ScanSolanaFuncId` enum that accepts either a string or a byte array.
    - Changed `status` on `ScanEVMTrace` and `ScanEip712Trace` from `Int?` to `Bool?` to align with the Hypernative API.
- Removed the unused `modals` field from `BlockaidScanURLRawResponse`.