### PR TITLE
SDK-166: Fix passkey userHandle encoding (registration + assertion)

### DIFF
--- a/Sources/PortalSwift/Storage/Passkey/PasskeyAuth.swift
+++ b/Sources/PortalSwift/Storage/Passkey/PasskeyAuth.swift
@@ -41,7 +41,16 @@ public class PasskeyAuth: NSObject, ASAuthorizationControllerPresentationContext
     let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: domain)
 
     let challenge = options.publicKey.challenge.decodeBase64Url()!
-    let userId = Data(options.publicKey.user.id.utf8)
+    // user.id is a base64url-encoded byte string per the WebAuthn JSON spec
+    // (PublicKeyCredentialUserEntityJSON) and must be decoded to raw bytes.
+    // Previously this stored the UTF-8 bytes of the base64url string itself as
+    // the credential's userHandle, which broke cross-device (iOS -> web)
+    // recovery. See SDK-166 / BAC-162.
+    guard let userId = options.publicKey.user.id.decodeBase64Url() else {
+      self.logger.error("[PasskeyAuth] Unable to decode user.id as base64url")
+      self.continuation?.resume(throwing: PasskeyAuthError.MissingUserID)
+      return
+    }
     let username = options.publicKey.user.displayName
 
     let registrationRequest = publicKeyCredentialProvider.createCredentialRegistrationRequest(challenge: challenge, name: username, userID: userId)
@@ -149,7 +158,14 @@ public class PasskeyAuth: NSObject, ASAuthorizationControllerPresentationContext
                      "clientDataJSON": clientDataJSON.toBase64Url(),
                      "authenticatorData": authenticatorData.toBase64Url(),
                      "signature": signature.toBase64Url(),
-                     "userHandle": String(data: userID, encoding: .utf8)
+                     // The userHandle is raw bytes and must be base64url-encoded for
+                     // the relying party server, exactly like the other binary fields.
+                     // Previously this used String(data:encoding:.utf8), which only
+                     // "worked" for credentials registered by this SDK's old
+                     // UTF-8-mangled registration path, and returned nil (failing the
+                     // whole assertion) for correctly-registered credentials synced
+                     // from web/Android. See SDK-166 / BAC-162.
+                     "userHandle": userID.toBase64Url()
                    ]] as [String: Any]
 
     if let payloadJSONData = try? JSONSerialization.data(withJSONObject: payload, options: .fragmentsAllowed) {

--- a/Tests/PortalSwiftTests/Storage/PasskeyAuthEncodingTests.swift
+++ b/Tests/PortalSwiftTests/Storage/PasskeyAuthEncodingTests.swift
@@ -1,0 +1,68 @@
+//
+//  PasskeyAuthEncodingTests.swift
+//
+//  Golden-vector tests for the base64url helpers used by PasskeyAuth
+//  (SDK-166 / SDK-168 / BAC-162).
+//
+//  Background: the relying party server (trustless-backup-service) serializes
+//  WebAuthn binary fields (user.id, challenge, credentialId, userHandle) as
+//  base64url. Three separate client bugs of the same class (decoding the
+//  base64url string with the wrong scheme, or not decoding it at all) shipped
+//  across our passkey clients before these vectors existed. The vector bytes
+//  below are deliberately NOT valid UTF-8, so a regression to the old
+//  "UTF-8 bytes of the string" behavior fails these tests, and the second
+//  vector contains '-' and '_' so a regression to standard-base64 decoding
+//  fails as well.
+//
+
+@testable import PortalSwift
+import XCTest
+
+final class PasskeyAuthEncodingTests: XCTestCase {
+  // base64url("AZFNK3uGcsipO5tuPfXN7w") <-> 01914d2b7b8672c8a93b9b6e3df5cdef
+  let goldenVectorString = "AZFNK3uGcsipO5tuPfXN7w"
+  let goldenVectorBytes = Data([
+    0x01, 0x91, 0x4D, 0x2B, 0x7B, 0x86, 0x72, 0xC8,
+    0xA9, 0x3B, 0x9B, 0x6E, 0x3D, 0xF5, 0xCD, 0xEF,
+  ])
+
+  func testGoldenVectorIsNotValidUTF8() throws {
+    // Guards the vector itself: if these bytes were valid UTF-8, the test
+    // could not distinguish correct decoding from the old mangled behavior.
+    XCTAssertNil(String(data: goldenVectorBytes, encoding: .utf8))
+  }
+
+  func testDecodeBase64UrlProducesRawBytes() throws {
+    let decoded = goldenVectorString.decodeBase64Url()
+    XCTAssertEqual(decoded, goldenVectorBytes)
+    XCTAssertEqual(decoded?.count, 16)
+  }
+
+  func testDecodeBase64UrlIsNotUTF8Encoding() throws {
+    // The pre-SDK-166 registration path stored Data(user.id.utf8) — 22 ASCII
+    // bytes of the string itself. Assert the helper output differs from that.
+    let utf8Mangled = Data(goldenVectorString.utf8)
+    XCTAssertNotEqual(goldenVectorString.decodeBase64Url(), utf8Mangled)
+  }
+
+  func testToBase64UrlRoundTrip() throws {
+    XCTAssertEqual(goldenVectorBytes.toBase64Url(), goldenVectorString)
+  }
+
+  func testDecodeBase64UrlHandlesUrlSafeCharacters() throws {
+    // 0xFB 0xEF 0xBE repeating encodes to "----" / "____" style output in the
+    // two alphabets; this vector contains both '-' and '_' so a regression to
+    // standard base64 decoding (which rejects or drops them) fails here.
+    let bytes = Data([0xFB, 0xEF, 0xBE, 0xFF, 0xFF, 0xFE])
+    let encoded = bytes.toBase64Url()
+    XCTAssertTrue(encoded.contains("-") || encoded.contains("_"))
+    XCTAssertEqual(encoded.decodeBase64Url(), bytes)
+  }
+
+  func testDecodeBase64UrlHandlesUnpaddedInput() throws {
+    // 22-char base64url (16 bytes) has no '=' padding; the helper must pad
+    // internally rather than reject.
+    XCTAssertEqual(goldenVectorString.count % 4, 2)
+    XCTAssertNotNil(goldenVectorString.decodeBase64Url())
+  }
+}


### PR DESCRIPTION
## ⚠️ DO NOT MERGE/RELEASE before BAC-162 is in production

[BAC-162](https://linear.app/portal-hq/issue/BAC-162) ([trustless-backup-service#104](https://github.com/portal-hq/trustless-backup-service/pull/104)) makes the relying party server stop enforcing the userHandle equality check. With this PR's assertion fix, **existing** iOS-registered credentials send `base64url(<their stored mangled bytes>)` — which only validates once the server ignores userHandle. Releasing this before BAC-162 deploys would break same-platform iOS auth for every existing credential.

Fixes [SDK-166](https://linear.app/portal-hq/issue/SDK-166).

## The two bugs

**Registration** ([PasskeyAuth.swift:44](Sources/PortalSwift/Storage/Passkey/PasskeyAuth.swift)):
```swift
let userId = Data(options.publicKey.user.id.utf8)
```
`user.id` arrives from the RP server as a base64url string per the WebAuthn JSON spec (`PublicKeyCredentialUserEntityJSON`). This stored the UTF-8 bytes of the *string* (22 ASCII bytes) instead of the decoded 16 raw bytes as the credential's permanent userHandle in iCloud Keychain.

**Assertion** ([PasskeyAuth.swift:152](Sources/PortalSwift/Storage/Passkey/PasskeyAuth.swift)):
```swift
"userHandle": String(data: userID, encoding: .utf8)
```
This reproduced the original base64url string for credentials registered by this SDK's buggy path — so same-platform auth passed **only because the two bugs canceled out**. Consequences:
- iOS-registered passkeys failed web recovery with `userHandle and User ID do not match` (same class of failure as the Wigwam incident on RN)
- Correctly-registered credentials synced from web/Android hit `String(data:encoding:)` returning nil on assertion (16 random bytes are rarely valid UTF-8), failing/hanging the flow

## The fix

- Registration: `user.id.decodeBase64Url()` (same helper the challenge already uses), with a guard that resumes the continuation with `PasskeyAuthError.MissingUserID` on decode failure
- Assertion: `userID.toBase64Url()` — same encoding as every other binary field in the payload

## Tests

New `PasskeyAuthEncodingTests` — golden-vector round-trip tests for the base64url helpers:
- Vector `"AZFNK3uGcsipO5tuPfXN7w"` ↔ `01914d2b7b8672c8a93b9b6e3df5cdef` (16 bytes, deliberately **not valid UTF-8**, so a regression to the old UTF-8 behavior fails)
- URL-safe-alphabet vector (contains `-` and `_`) so a regression to standard-base64 decoding fails
- Unpadded-input handling

```
Test Suite 'PasskeyAuthEncodingTests' passed — Executed 6 tests, with 0 failures (iPhone 17 simulator, iOS 26.1)
```

## Rollout notes

- After BAC-162 is live, this is safe for all credential generations: legacy credentials authenticate via the server-side strip; credentials registered with this fix store the correct userHandle
- Flutter-iOS inherits this fix automatically (wraps PortalSwift)
- Release notes must flag the BAC-162 dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)