### PR TITLE
feat: Pre-Generatated wallet

### DIFF
--- a/SPM Example/PortalSwift/MainViewController/ViewController.swift
+++ b/SPM Example/PortalSwift/MainViewController/ViewController.swift
@@ -931,7 +931,8 @@ class ViewController: UIViewController, UITextFieldDelegate {
         featureFlags: FeatureFlags(
           isMultiBackupEnabled: true,
           useEnclaveMPCApi: Settings.shared.useEnclaveMPC,
-          usePresignatures: Settings.shared.usePresignatures
+          usePresignatures: Settings.shared.usePresignatures,
+          usePreGeneratedWallet: Settings.shared.usePreGeneratedWallet
         ),
         apiHost: config.apiUrl,
         mpcHost: config.mpcUrl,

--- a/SPM Example/PortalSwift/Settings/Settings.swift
+++ b/SPM Example/PortalSwift/Settings/Settings.swift
@@ -58,6 +58,7 @@ class Settings: ObservableObject {
   var isAccountAbstracted: Bool = false
   var useEnclaveMPC: Bool = false
   var usePresignatures: Bool = false
+  var usePreGeneratedWallet: Bool = true
 }
 
 // MARK: - App Configuration

--- a/SPM Example/PortalSwift/Settings/SettingsView.swift
+++ b/SPM Example/PortalSwift/Settings/SettingsView.swift
@@ -81,6 +81,11 @@ struct SettingsView: View {
         set: { Settings.shared.usePresignatures = $0 }
       ))
 
+      Toggle("Use Pre-Generated Wallet", isOn: Binding(
+        get: { Settings.shared.usePreGeneratedWallet },
+        set: { Settings.shared.usePreGeneratedWallet = $0 }
+      ))
+
       Spacer()
     }
     .padding(.horizontal)

--- a/Sources/PortalSwift/Core/Api/PortalApi.swift
+++ b/Sources/PortalSwift/Core/Api/PortalApi.swift
@@ -29,6 +29,7 @@ public protocol PortalApiProtocol: AnyObject {
   func getTransactions(_ chainId: String, limit: Int?, offset: Int?, order: TransactionOrder?) async throws -> [FetchedTransaction]
   func identify(_ traits: [String: AnyCodable]) async throws -> MetricsResponse
   func prepareEject(_ walletId: String, _ backupMethod: BackupMethods) async throws -> String
+  func generatePreGeneratedShares(metadataStr: String) async throws -> GenerateApiResponse
   func refreshClient() async throws
   func updateShareStatus(_ type: PortalSharePairType, status: SharePairUpdateStatus, sharePairIds: [String]) async throws
   func storeClientCipherText(_ backupSharePairId: String, cipherText: String) async throws -> Bool
@@ -92,6 +93,7 @@ public class PortalApi: PortalApiProtocol {
   private let _clientStorage = ThreadSafeClientWrapper()
   private var apiKey: String
   private var baseUrl: String
+  private let enclaveMPCHost: String
   private let decoder = JSONDecoder()
   private var httpRequests: HttpRequester
   private let logger = PortalLogger.shared
@@ -173,12 +175,14 @@ public class PortalApi: PortalApiProtocol {
   public init(
     apiKey: String,
     apiHost: String = "api.portalhq.io",
+    enclaveMPCHost: String = "mpc-client.portalhq.io",
     provider: PortalProviderProtocol? = nil,
     featureFlags: FeatureFlags? = nil,
     requests: PortalRequestsProtocol? = nil
   ) {
     self.apiKey = apiKey
     self.baseUrl = apiHost.starts(with: "localhost") ? "http://\(apiHost)" : "https://\(apiHost)"
+    self.enclaveMPCHost = enclaveMPCHost
     self.featureFlags = featureFlags
     self.provider = provider
     self.requests = requests ?? PortalRequests()
@@ -495,6 +499,21 @@ public class PortalApi: PortalApiProtocol {
     }
 
     throw URLError(.badURL)
+  }
+
+  public func generatePreGeneratedShares(metadataStr: String) async throws -> GenerateApiResponse {
+    guard let url = URL(string: "https://\(enclaveMPCHost)/v1/generate") else {
+      self.logger.error("PortalApi.generatePreGeneratedShares() - Unable to build request URL.")
+      throw URLError(.badURL)
+    }
+
+    do {
+      let payload = GenerateApiRequest(usePreGenerated: true, metadataStr: metadataStr)
+      return try await self.post(url, withBearerToken: self.apiKey, andPayload: payload, mappingInResponse: GenerateApiResponse.self)
+    } catch {
+      self.logger.error("PortalApi.generatePreGeneratedShares() - Unable to generate pre-generated shares: \(error.localizedDescription)")
+      throw error
+    }
   }
 
   public func updateShareStatus(

--- a/Sources/PortalSwift/Core/Mpc/PortalMpc.swift
+++ b/Sources/PortalSwift/Core/Mpc/PortalMpc.swift
@@ -394,12 +394,19 @@ public class PortalMpc: PortalMpcProtocol {
     do {
       let generateResponse: PortalMpcGenerateResponse
       if self.featureFlags?.usePreGeneratedWallet == true {
-        // Try the pre-generated wallet HTTP path, falling back to the binary on any failure
-        // so that wallet creation never regresses.
+        // Try the pre-generated wallet HTTP path, falling back to the binary DKG flow ONLY on a
+        // server-side (5xx) failure, which is transient and safe to retry. Every other failure —
+        // 4xx client errors (e.g. the enclave "wallet already exists" precheck), auth failures,
+        // network/URL errors, and share decode/validation failures — is surfaced immediately,
+        // since a binary retry would not resolve them and would only add a full DKG round of latency.
         do {
           generateResponse = try await self.generateSigningSharesViaApi(withProgressCallback: withProgressCallback)
         } catch {
-          self.logger.error("[PortalMpc] Pre-generated wallet generation failed, falling back to the binary: \(error.localizedDescription)")
+          guard PortalMpc.isRetryableServerError(error) else {
+            self.logger.error("[PortalMpc] Pre-generated wallet generation failed with a non-retryable error; not falling back to the binary: \(error.localizedDescription)")
+            throw error
+          }
+          self.logger.error("[PortalMpc] Pre-generated wallet generation failed with a server (5xx) error, falling back to the binary: \(error.localizedDescription)")
           generateResponse = try await self.generateSigningSharesViaBinary(withProgressCallback: withProgressCallback)
         }
       } else {
@@ -462,7 +469,7 @@ public class PortalMpc: PortalMpcProtocol {
           // Parse SECP256K1 Share
           let secp256k1ShareData = try self.encoder.encode(secp256k1MpcShare)
           guard let secp256k1ShareString = String(data: secp256k1ShareData, encoding: .utf8) else {
-            throw MpcError.unexpectedErrorOnGenerate("Unable to stringify ED25519 share.")
+            throw MpcError.unexpectedErrorOnGenerate("Unable to stringify SECP256K1 share.")
           }
           generateResponse["SECP256K1"] = PortalMpcGeneratedShare(
             id: secp256k1MpcShare.signingSharePairId ?? "",
@@ -522,7 +529,28 @@ public class PortalMpc: PortalMpcProtocol {
       throw MpcError.unexpectedErrorOnGenerate("Unable to stringify \(forCurve.rawValue) share.")
     }
 
-    return PortalMpcGeneratedShare(id: curveShare.id, share: shareString)
+    // Use the decoded `signingSharePairId` (not the response envelope `id`) so the stored
+    // share id matches exactly what the binary path produces. Downstream `updateShareStatus`
+    // is keyed off this id, so the two paths must stay identical.
+    return PortalMpcGeneratedShare(id: signingSharePairId, share: shareString)
+  }
+
+  /// Reports whether an error from the pre-generated wallet API is a server-side (5xx) failure —
+  /// the only case where we fall back to the on-device binary DKG flow, since a 5xx is transient
+  /// and safe to retry. Every other failure (4xx client errors such as "wallet already exists",
+  /// auth failures, network/URL errors, and share decode/validation failures) is surfaced
+  /// immediately, because a binary retry would not resolve it and would only add DKG latency.
+  static func isRetryableServerError(_ error: Error) -> Bool {
+    guard let requestError = error as? PortalRequestsError else {
+      return false
+    }
+
+    switch requestError {
+    case .internalServerError:
+      return true
+    default:
+      return false
+    }
   }
 
   /// Decodes a standard-alphabet base64 string into `Data`. The Enclave MPC API returns shares as

--- a/Sources/PortalSwift/Core/Mpc/PortalMpc.swift
+++ b/Sources/PortalSwift/Core/Mpc/PortalMpc.swift
@@ -392,47 +392,18 @@ public class PortalMpc: PortalMpcProtocol {
     try await walletModificationOperationGuard.acquire(for: "generate")
 
     do {
-      // Generate both backup shares in parallel
-      let generateResponse = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<PortalMpcGenerateResponse, Error>) in
-        Task { [self] in
-          do {
-            withProgressCallback?(MpcStatus(status: .generatingShare, done: false))
-
-            var generateResponse: PortalMpcGenerateResponse = [:]
-
-            async let ed25519Generate = try self.getSigningShare(.ED25519)
-            async let secp256k1Generate = try self.getSigningShare(.SECP256K1)
-
-            let (ed25519MpcShare, secp256k1MpcShare) = try await (ed25519Generate, secp256k1Generate)
-
-            withProgressCallback?(MpcStatus(status: .parsingShare, done: false))
-
-            // Parse ED25519 Share
-            let ed25519ShareData = try self.encoder.encode(ed25519MpcShare)
-            guard let ed25519ShareString = String(data: ed25519ShareData, encoding: .utf8) else {
-              throw MpcError.unexpectedErrorOnGenerate("Unable to stringify ED25519 share.")
-            }
-            generateResponse["ED25519"] = PortalMpcGeneratedShare(
-              id: ed25519MpcShare.signingSharePairId ?? "",
-              share: ed25519ShareString
-            )
-
-            // Parse SECP256K1 Share
-            let secp256k1ShareData = try self.encoder.encode(secp256k1MpcShare)
-            guard let secp256k1ShareString = String(data: secp256k1ShareData, encoding: .utf8) else {
-              throw MpcError.unexpectedErrorOnGenerate("Unable to stringify ED25519 share.")
-            }
-            generateResponse["SECP256K1"] = PortalMpcGeneratedShare(
-              id: secp256k1MpcShare.signingSharePairId ?? "",
-              share: secp256k1ShareString
-            )
-
-            continuation.resume(returning: generateResponse)
-          } catch {
-            continuation.resume(throwing: error)
-            return
-          }
+      let generateResponse: PortalMpcGenerateResponse
+      if self.featureFlags?.usePreGeneratedWallet == true {
+        // Try the pre-generated wallet HTTP path, falling back to the binary on any failure
+        // so that wallet creation never regresses.
+        do {
+          generateResponse = try await self.generateSigningSharesViaApi(withProgressCallback: withProgressCallback)
+        } catch {
+          self.logger.error("[PortalMpc] Pre-generated wallet generation failed, falling back to the binary: \(error.localizedDescription)")
+          generateResponse = try await self.generateSigningSharesViaBinary(withProgressCallback: withProgressCallback)
         }
+      } else {
+        generateResponse = try await self.generateSigningSharesViaBinary(withProgressCallback: withProgressCallback)
       }
 
       withProgressCallback?(MpcStatus(status: .storingShare, done: false))
@@ -458,6 +429,112 @@ public class PortalMpc: PortalMpcProtocol {
       await walletModificationOperationGuard.release()
       throw error
     }
+  }
+
+  /// Generates both signing shares using the MPC binary (the default, on-device DKG flow).
+  private func generateSigningSharesViaBinary(withProgressCallback: ((MpcStatus) -> Void)? = nil) async throws -> PortalMpcGenerateResponse {
+    // Generate both signing shares in parallel
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<PortalMpcGenerateResponse, Error>) in
+      Task { [self] in
+        do {
+          self.logger.info("Generating wallet: generating signing shares using the binary MPC flow.")
+          withProgressCallback?(MpcStatus(status: .generatingShare, done: false))
+
+          var generateResponse: PortalMpcGenerateResponse = [:]
+
+          async let ed25519Generate = try self.getSigningShare(.ED25519)
+          async let secp256k1Generate = try self.getSigningShare(.SECP256K1)
+
+          let (ed25519MpcShare, secp256k1MpcShare) = try await (ed25519Generate, secp256k1Generate)
+
+          withProgressCallback?(MpcStatus(status: .parsingShare, done: false))
+
+          // Parse ED25519 Share
+          let ed25519ShareData = try self.encoder.encode(ed25519MpcShare)
+          guard let ed25519ShareString = String(data: ed25519ShareData, encoding: .utf8) else {
+            throw MpcError.unexpectedErrorOnGenerate("Unable to stringify ED25519 share.")
+          }
+          generateResponse["ED25519"] = PortalMpcGeneratedShare(
+            id: ed25519MpcShare.signingSharePairId ?? "",
+            share: ed25519ShareString
+          )
+
+          // Parse SECP256K1 Share
+          let secp256k1ShareData = try self.encoder.encode(secp256k1MpcShare)
+          guard let secp256k1ShareString = String(data: secp256k1ShareData, encoding: .utf8) else {
+            throw MpcError.unexpectedErrorOnGenerate("Unable to stringify ED25519 share.")
+          }
+          generateResponse["SECP256K1"] = PortalMpcGeneratedShare(
+            id: secp256k1MpcShare.signingSharePairId ?? "",
+            share: secp256k1ShareString
+          )
+
+          continuation.resume(returning: generateResponse)
+        } catch {
+          continuation.resume(throwing: error)
+          return
+        }
+      }
+    }
+  }
+
+  /// Generates both signing shares via the Enclave MPC API `POST /v1/generate` endpoint, opting
+  /// into the pre-generated wallet pool. The API returns both curves in a single call.
+  private func generateSigningSharesViaApi(withProgressCallback: ((MpcStatus) -> Void)? = nil) async throws -> PortalMpcGenerateResponse {
+    self.logger.info("Generating wallet: generating signing shares using the API MPC Enclave flow.")
+    withProgressCallback?(MpcStatus(status: .generatingShare, done: false))
+
+    guard let api = self.api else {
+      throw MpcError.unexpectedErrorOnGenerate("Portal API is unavailable for pre-generated wallet generation.")
+    }
+
+    // Send the same metadata we send to the binary. The per-curve `curve` is irrelevant here
+    // because the API generates both curves in a single request.
+    let metadataString = try self.mpcMetadata.jsonString()
+
+    let apiResponse = try await api.generatePreGeneratedShares(metadataStr: metadataString)
+
+    withProgressCallback?(MpcStatus(status: .parsingShare, done: false))
+
+    var generateResponse: PortalMpcGenerateResponse = [:]
+    generateResponse["ED25519"] = try self.makeGeneratedShare(from: apiResponse.ed25519, forCurve: .ED25519)
+    generateResponse["SECP256K1"] = try self.makeGeneratedShare(from: apiResponse.secp256k1, forCurve: .SECP256K1)
+
+    return generateResponse
+  }
+
+  /// Transforms an API curve share (base64-encoded `MpcShare`) into the same stored format the
+  /// binary path produces (a JSON-stringified `MpcShare`).
+  private func makeGeneratedShare(from curveShare: GenerateApiCurveShare, forCurve: PortalCurve) throws -> PortalMpcGeneratedShare {
+    guard let shareData = PortalMpc.decodeStandardBase64(curveShare.share) else {
+      throw MpcError.unableToDecodeShare
+    }
+
+    let mpcShare = try self.decoder.decode(MpcShare.self, from: shareData)
+
+    guard let signingSharePairId = mpcShare.signingSharePairId, !signingSharePairId.isEmpty else {
+      throw MpcError.unexpectedErrorOnGenerate("Missing signingSharePairId for \(forCurve.rawValue) pre-generated share.")
+    }
+
+    // Re-encode to a JSON string to match exactly what the binary path stores.
+    let reEncodedData = try self.encoder.encode(mpcShare)
+    guard let shareString = String(data: reEncodedData, encoding: .utf8) else {
+      throw MpcError.unexpectedErrorOnGenerate("Unable to stringify \(forCurve.rawValue) share.")
+    }
+
+    return PortalMpcGeneratedShare(id: curveShare.id, share: shareString)
+  }
+
+  /// Decodes a standard-alphabet base64 string into `Data`. The Enclave MPC API returns shares as
+  /// base64 `RawStdEncoding` (no `=` padding), while `Data(base64Encoded:)` requires correct
+  /// padding, so we re-add it. The standard (not URL-safe) alphabet is used intentionally.
+  static func decodeStandardBase64(_ value: String) -> Data? {
+    var base64 = value
+    let remainder = base64.count % 4
+    if remainder > 0 {
+      base64.append(String(repeating: "=", count: 4 - remainder))
+    }
+    return Data(base64Encoded: base64)
   }
 
   public func recover(

--- a/Sources/PortalSwift/Core/Mpc/PortalMpcTypes.swift
+++ b/Sources/PortalSwift/Core/Mpc/PortalMpcTypes.swift
@@ -159,6 +159,30 @@ struct GenerateResult: Codable {
   public var error: PortalError
 }
 
+/// The request body for the Enclave MPC API `POST /v1/generate` endpoint.
+struct GenerateApiRequest: Codable {
+  let usePreGenerated: Bool
+  let metadataStr: String
+}
+
+/// A single curve's share returned by the Enclave MPC API `POST /v1/generate` endpoint.
+/// `share` is the base64 (standard alphabet, no padding) of the serialized `MpcShare`.
+public struct GenerateApiCurveShare: Decodable {
+  public let share: String
+  public let id: String
+}
+
+/// The response from the Enclave MPC API `POST /v1/generate` endpoint.
+public struct GenerateApiResponse: Decodable {
+  public let secp256k1: GenerateApiCurveShare
+  public let ed25519: GenerateApiCurveShare
+
+  enum CodingKeys: String, CodingKey {
+    case secp256k1 = "SECP256K1"
+    case ed25519 = "ED25519"
+  }
+}
+
 /// The data for RotateResult.
 public struct RotateData: Codable {
   public var share: MpcShare

--- a/Sources/PortalSwift/Mocks/Constants.swift
+++ b/Sources/PortalSwift/Mocks/Constants.swift
@@ -415,6 +415,15 @@ public enum MockConstants {
     }
   }
 
+  /// Base64-encoded (standard alphabet, no padding) JSON of `mockMpcShare`, mimicking what the
+  /// Enclave MPC API `POST /v1/generate` returns for each curve's `share`.
+  public static var mockBase64EncodedMpcShare: String {
+    get throws {
+      let mockMpcShareData = try JSONEncoder().encode(mockMpcShare)
+      return mockMpcShareData.base64EncodedString().replacingOccurrences(of: "=", with: "")
+    }
+  }
+
   public static var mockCreateWalletResponse: PortalCreateWalletResponse {
     let mockCreateWalletResponse: PortalCreateWalletResponse = (
       ethereum: mockEip155Address,

--- a/Sources/PortalSwift/Mocks/Utils/MockPortalRequests.swift
+++ b/Sources/PortalSwift/Mocks/Utils/MockPortalRequests.swift
@@ -9,8 +9,14 @@ import Foundation
 
 public actor MockPortalRequests: PortalRequestsProtocol {
   private let encoder = JSONEncoder()
+  private let failEnclaveGenerate: Bool
 
-  public init() {}
+  /// Number of times the `/v1/generate` (pre-generated wallet) endpoint was requested.
+  public private(set) var generateCallsCount = 0
+
+  public init(failEnclaveGenerate: Bool = false) {
+    self.failEnclaveGenerate = failEnclaveGenerate
+  }
 
   public func delete(_ url: URL, withBearerToken _: String? = nil) async throws -> Data {
     switch url.path {
@@ -100,6 +106,17 @@ public actor MockPortalRequests: PortalRequestsProtocol {
     postAndPayloadParam = andPayload
 
     switch url.path {
+    case "/v1/generate":
+      self.generateCallsCount += 1
+      if self.failEnclaveGenerate {
+        throw PortalRequestsError.internalServerError("500 - simulated pre-generated wallet failure", url: url.absoluteString)
+      }
+      let share = try MockConstants.mockBase64EncodedMpcShare
+      let json = "{\"SECP256K1\":{\"share\":\"\(share)\",\"id\":\"\(MockConstants.mockMpcShareId)\"},\"ED25519\":{\"share\":\"\(share)\",\"id\":\"\(MockConstants.mockMpcShareId)\"}}"
+      guard let data = json.data(using: .utf8) else {
+        throw PortalRequestsError.couldNotParseHttpResponse
+      }
+      return data
     case "/api/v1/analytics/identify", "/api/v1/analytics/track":
       let mockMetricsResponseData = try encoder.encode(MockConstants.mockMetricsResponse)
       return mockMetricsResponseData

--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -136,7 +136,7 @@ public final class Portal: PortalProtocol {
 
     // Creating this as a variable first so it's usable to
     // fetch the client in the Task at the end of the initializer
-    let api = api ?? PortalApi(apiKey: apiKey, apiHost: apiHost, provider: provider)
+    let api = api ?? PortalApi(apiKey: apiKey, apiHost: apiHost, enclaveMPCHost: enclaveMPCHost, provider: provider)
     self.api = api
     self.keychain.api = api
     self.provider.api = api

--- a/Sources/PortalSwift/PortalTypes.swift
+++ b/Sources/PortalSwift/PortalTypes.swift
@@ -38,15 +38,18 @@ public struct FeatureFlags {
   public var isMultiBackupEnabled: Bool?
   public var useEnclaveMPCApi: Bool?
   public var usePresignatures: Bool?
+  public var usePreGeneratedWallet: Bool?
 
   public init(
     isMultiBackupEnabled: Bool? = nil,
     useEnclaveMPCApi: Bool? = nil,
-    usePresignatures: Bool? = nil
+    usePresignatures: Bool? = nil,
+    usePreGeneratedWallet: Bool? = nil
   ) {
     self.isMultiBackupEnabled = isMultiBackupEnabled
     self.useEnclaveMPCApi = useEnclaveMPCApi
     self.usePresignatures = usePresignatures
+    self.usePreGeneratedWallet = usePreGeneratedWallet
   }
 }
 

--- a/Tests/PortalSwiftTests/Core/PortalApiTests.swift
+++ b/Tests/PortalSwiftTests/Core/PortalApiTests.swift
@@ -86,6 +86,84 @@ extension PortalApiTests {
   }
 }
 
+// MARK: - generatePreGeneratedShares tests
+
+extension PortalApiTests {
+  func test_generatePreGeneratedShares_onSuccess_returnsBothCurveShares() async throws {
+    // given
+    let mockRequests = MockPortalRequests()
+    initPortalApiWith(requests: mockRequests)
+
+    // and given
+    let response = try await api?.generatePreGeneratedShares(metadataStr: "{\"clientPlatform\":\"NATIVE_IOS\"}")
+
+    // then: decode the base64 shares back into MpcShare and compare (base64 string key ordering is not stable)
+    let secpData = try XCTUnwrap(PortalMpc.decodeStandardBase64(try XCTUnwrap(response?.secp256k1.share)))
+    let edData = try XCTUnwrap(PortalMpc.decodeStandardBase64(try XCTUnwrap(response?.ed25519.share)))
+    let secpShare = try JSONDecoder().decode(MpcShare.self, from: secpData)
+    let edShare = try JSONDecoder().decode(MpcShare.self, from: edData)
+    XCTAssertEqual(secpShare, MockConstants.mockMpcShare)
+    XCTAssertEqual(edShare, MockConstants.mockMpcShare)
+    XCTAssertEqual(response?.secp256k1.id, MockConstants.mockMpcShareId)
+    XCTAssertEqual(response?.ed25519.id, MockConstants.mockMpcShareId)
+
+    let generateCallsCount = await mockRequests.generateCallsCount
+    XCTAssertEqual(generateCallsCount, 1)
+  }
+
+  func test_generatePreGeneratedShares_sendsCorrectRequest() async throws {
+    // given
+    let mockRequests = MockPortalRequests()
+    initPortalApiWith(requests: mockRequests)
+
+    // and given
+    let metadata = "{\"clientPlatform\":\"NATIVE_IOS\"}"
+    _ = try await api?.generatePreGeneratedShares(metadataStr: metadata)
+
+    // then: the request targets /v1/generate on the enclave host with the correct body
+    let request = await mockRequests.executeRequestParam
+    XCTAssertEqual(request?.url.path, "/v1/generate")
+    XCTAssertEqual(request?.url.absoluteString, "https://mpc-client.portalhq.io/v1/generate")
+    XCTAssertEqual(request?.method, .post)
+    let payload = request?.payload as? GenerateApiRequest
+    XCTAssertEqual(payload?.usePreGenerated, true)
+    XCTAssertEqual(payload?.metadataStr, metadata)
+  }
+
+  func test_generatePreGeneratedShares_usesCustomEnclaveHost() async throws {
+    // given
+    let mockRequests = MockPortalRequests()
+    let customApi = PortalApi(
+      apiKey: MockConstants.mockApiKey,
+      apiHost: MockConstants.mockHost,
+      enclaveMPCHost: "mpc-client.portalhq.dev",
+      requests: mockRequests
+    )
+
+    // and given
+    _ = try await customApi.generatePreGeneratedShares(metadataStr: "{}")
+
+    // then
+    let request = await mockRequests.executeRequestParam
+    XCTAssertEqual(request?.url.absoluteString, "https://mpc-client.portalhq.dev/v1/generate")
+  }
+
+  func test_generatePreGeneratedShares_onServerError_throws() async throws {
+    // given
+    let mockRequests = MockPortalRequests(failEnclaveGenerate: true)
+    initPortalApiWith(requests: mockRequests)
+
+    do {
+      // and given
+      _ = try await api?.generatePreGeneratedShares(metadataStr: "{}")
+      XCTFail("Expected error not thrown when the enclave generate endpoint fails.")
+    } catch {
+      // then
+      XCTAssertNotNil(error)
+    }
+  }
+}
+
 // MARK: - eject tests
 
 extension PortalApiTests {

--- a/Tests/PortalSwiftTests/Core/PortalMpcTests.swift
+++ b/Tests/PortalSwiftTests/Core/PortalMpcTests.swift
@@ -1087,7 +1087,7 @@ extension PortalMpcTests {
   }
 
   @available(iOS 16, *)
-  func test_generate_whenApiShareHasEmptySigningSharePairId_fallsBackToBinary() async throws {
+  func test_generate_whenApiShareHasEmptySigningSharePairId_surfacesErrorAndDoesNotFallBackToBinary() async throws {
     // given: an API response whose decoded MpcShare has no signingSharePairId
     let apiMock = PortalApiMock()
     let badJson = "{\"clientId\":\"\",\"signingSharePairId\":\"\",\"share\":\"s\",\"ssid\":\"x\"}"
@@ -1101,18 +1101,21 @@ extension PortalMpcTests {
     mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
     initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
 
-    // and given
-    let addresses = try await mpc?.generate()
+    // and given / then: a validation failure is not a 5xx, so it surfaces without a binary retry
+    do {
+      _ = try await mpc?.generate()
+      XCTFail("Expected generate() to rethrow the share-validation error")
+    } catch {
+      // expected
+    }
 
-    // then: API was attempted, transform failed, binary fallback created the wallet
     XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1)
-    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 1)
-    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 1)
-    XCTAssertEqual(addresses?[.eip155], MockConstants.mockEip155Address)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 0)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 0)
   }
 
   @available(iOS 16, *)
-  func test_generate_whenApiShareHasInvalidBase64_fallsBackToBinary() async throws {
+  func test_generate_whenApiShareHasInvalidBase64_surfacesErrorAndDoesNotFallBackToBinary() async throws {
     // given: an API response with an undecodable base64 share
     let apiMock = PortalApiMock()
     apiMock.generatePreGeneratedSharesReturnValue = GenerateApiResponse(
@@ -1124,21 +1127,50 @@ extension PortalMpcTests {
     mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
     initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
 
-    // and given
-    let addresses = try await mpc?.generate()
+    // and given / then: a decode failure is not a 5xx, so it surfaces without a binary retry
+    do {
+      _ = try await mpc?.generate()
+      XCTFail("Expected generate() to rethrow the share-decode error")
+    } catch {
+      // expected
+    }
 
-    // then: the binary fallback ran and created the wallet
     XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1)
-    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 1)
-    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 1)
-    XCTAssertEqual(addresses?[.eip155], MockConstants.mockEip155Address)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 0)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 0)
   }
 
   @available(iOS 16, *)
-  func test_generate_whenApiThrows_fallsBackToBinary_viaApiDouble() async throws {
-    // given: the API method itself throws
+  func test_generate_whenApiThrowsNon5xxError_surfacesErrorAndDoesNotFallBackToBinary() async throws {
+    // given: the API method throws a non-5xx error (e.g. a network timeout)
     let apiMock = PortalApiMock()
     apiMock.generatePreGeneratedSharesErrorToThrow = URLError(.timedOut)
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given / then: only 5xx errors fall back, so this surfaces without a binary retry
+    do {
+      _ = try await mpc?.generate()
+      XCTFail("Expected generate() to rethrow the non-5xx error")
+    } catch {
+      // expected
+    }
+
+    XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 0)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 0)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenApiThrows5xxError_fallsBackToBinary_viaApiDouble() async throws {
+    // given: the API method throws a server-side (5xx) error
+    let apiMock = PortalApiMock()
+    apiMock.generatePreGeneratedSharesErrorToThrow = PortalRequestsError.internalServerError(
+      "500 - simulated pre-generated wallet failure",
+      url: "https://mpc-client.portalhq.io/v1/generate"
+    )
     let mobileSpy = MobileSpy()
     mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
     mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
@@ -1147,11 +1179,232 @@ extension PortalMpcTests {
     // and given
     let addresses = try await mpc?.generate()
 
-    // then
+    // then: the 5xx triggered the binary fallback, which created the wallet
     XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1)
     XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 1)
     XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 1)
     XCTAssertEqual(addresses?[.eip155], MockConstants.mockEip155Address)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenUsePreGeneratedWalletEnabled_storesDecodedSigningSharePairId_notEnvelopeId() async throws {
+    // given: an API response whose envelope `id` differs from the share's decoded signingSharePairId
+    let apiSpy = PortalApiSpy()
+    apiSpy.generatePreGeneratedSharesReturnValue = try Self.makePreGeneratedApiResponse(id: "envelope-id-that-differs")
+    let keychainSpy = PortalKeychainSpy()
+    initPortalMpcWith(portalApi: apiSpy, keychain: keychainSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given
+    _ = try await mpc?.generate()
+
+    // then: the stored id (and the id sent to updateShareStatus) uses the decoded
+    // signingSharePairId, keeping the API path identical to the binary path.
+    let stored = keychainSpy.setSharesParams.first
+    XCTAssertEqual(stored?["SECP256K1"]?.id, MockConstants.mockMpcShareId)
+    XCTAssertEqual(stored?["ED25519"]?.id, MockConstants.mockMpcShareId)
+    XCTAssertEqual(apiSpy.updateShareStatusSharePairIdsParam, [MockConstants.mockMpcShareId, MockConstants.mockMpcShareId])
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenApiRejectsWith4xx_surfacesErrorAndDoesNotFallBackToBinary() async throws {
+    // given: the enclave rejects the claim with a 4xx client error (e.g. "wallet already exists")
+    let apiMock = PortalApiMock()
+    apiMock.generatePreGeneratedSharesErrorToThrow = PortalRequestsError.clientError(
+      "400 - {\"error\":\"Wallet already exists\"}",
+      url: "https://mpc-client.portalhq.io/v1/generate"
+    )
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given / then: a 4xx is not retryable, so it surfaces rather than falling back
+    do {
+      _ = try await mpc?.generate()
+      XCTFail("Expected generate() to rethrow the 4xx client error")
+    } catch {
+      XCTAssertFalse(PortalMpc.isRetryableServerError(error))
+    }
+
+    // and: the binary fallback was NOT attempted
+    XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 0)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 0)
+  }
+
+  // MARK: isRetryableServerError classifier (exhaustive)
+
+  func test_isRetryableServerError_returnsTrue_forInternalServerError() {
+    // The SDK maps any 5xx response to `.internalServerError` (see PortalRequests.buildError),
+    // so classification is by error-class, independent of the specific status code or body.
+    XCTAssertTrue(PortalMpc.isRetryableServerError(
+      PortalRequestsError.internalServerError("500 - internal error", url: "u")
+    ))
+    XCTAssertTrue(PortalMpc.isRetryableServerError(
+      PortalRequestsError.internalServerError("502 - bad gateway", url: "u")
+    ))
+    XCTAssertTrue(PortalMpc.isRetryableServerError(
+      PortalRequestsError.internalServerError("503 - service unavailable", url: "u")
+    ))
+    XCTAssertTrue(PortalMpc.isRetryableServerError(
+      PortalRequestsError.internalServerError("", url: "")
+    ))
+  }
+
+  func test_isRetryableServerError_returnsFalse_forClientError() {
+    XCTAssertFalse(PortalMpc.isRetryableServerError(
+      PortalRequestsError.clientError("400 - {\"error\":\"Wallet already exists\"}", url: "u")
+    ))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(
+      PortalRequestsError.clientError("404 - not found", url: "u")
+    ))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(
+      PortalRequestsError.clientError("429 - too many requests", url: "u")
+    ))
+  }
+
+  func test_isRetryableServerError_returnsFalse_forOtherPortalRequestsErrors() {
+    XCTAssertFalse(PortalMpc.isRetryableServerError(PortalRequestsError.unauthorized))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(PortalRequestsError.redirectError("302 - redirect")))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(PortalRequestsError.couldNotParseHttpResponse))
+  }
+
+  func test_isRetryableServerError_returnsFalse_forNonRequestErrors() {
+    // Network/transport errors are not classed as 5xx and therefore do not fall back.
+    XCTAssertFalse(PortalMpc.isRetryableServerError(URLError(.timedOut)))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(URLError(.networkConnectionLost)))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(URLError(.cannotConnectToHost)))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(URLError(.notConnectedToInternet)))
+    // Share transform/validation failures are not retryable either.
+    XCTAssertFalse(PortalMpc.isRetryableServerError(MpcError.unableToDecodeShare))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(MpcError.unexpectedErrorOnGenerate("boom")))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(NSError(domain: "com.portal.test", code: 42)))
+  }
+
+  // MARK: generate() retry — errors that surface without falling back
+
+  @available(iOS 16, *)
+  func test_generate_whenApiThrowsUnauthorized_surfacesErrorAndDoesNotFallBackToBinary() async {
+    await assertGenerateSurfacesWithoutBinaryFallback(apiError: PortalRequestsError.unauthorized)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenApiThrowsRedirectError_surfacesErrorAndDoesNotFallBackToBinary() async {
+    await assertGenerateSurfacesWithoutBinaryFallback(apiError: PortalRequestsError.redirectError("302 - redirect"))
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenApiThrowsCouldNotParseHttpResponse_surfacesErrorAndDoesNotFallBackToBinary() async {
+    await assertGenerateSurfacesWithoutBinaryFallback(apiError: PortalRequestsError.couldNotParseHttpResponse)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenApiThrowsClientError_surfacesErrorAndDoesNotFallBackToBinary() async {
+    await assertGenerateSurfacesWithoutBinaryFallback(apiError: PortalRequestsError.clientError("404 - not found", url: "u"))
+  }
+
+  // MARK: generate() retry — 5xx fallback edge cases
+
+  @available(iOS 16, *)
+  func test_generate_when5xxAndBinaryAlsoFails_surfacesError() async throws {
+    // given: the API returns a 5xx (so we fall back) but the binary DKG also fails
+    let apiMock = PortalApiMock()
+    apiMock.generatePreGeneratedSharesErrorToThrow = PortalRequestsError.internalServerError("500 - boom", url: "u")
+    // MobileSpy defaults its generate return values to "", which fails to decode -> binary throws.
+    let mobileSpy = MobileSpy()
+    initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given / then: the binary failure surfaces (no infinite retry, no swallowing)
+    do {
+      _ = try await mpc?.generate()
+      XCTFail("Expected generate() to rethrow when both the API and the binary fallback fail")
+    } catch {
+      // expected
+    }
+
+    // and: the API was tried once, then the binary was attempted once per curve
+    XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 1)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_when5xxFallback_runsPostGenerateLifecycleWithBinaryShares() async throws {
+    // given: the API returns a 5xx, so generation falls back to the binary path
+    let apiSpy = PortalApiSpy()
+    apiSpy.generatePreGeneratedSharesErrorToThrow = PortalRequestsError.internalServerError("500 - boom", url: "u")
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    let keychainSpy = PortalKeychainSpy()
+    initPortalMpcWith(portalApi: apiSpy, keychain: keychainSpy, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given
+    _ = try await mpc?.generate()
+
+    // then: the API was attempted once and the binary produced both curves
+    XCTAssertEqual(apiSpy.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 1)
+
+    // and: the shared post-generate lifecycle still runs on the binary shares
+    XCTAssertEqual(keychainSpy.setSharesCallCount, 1)
+    XCTAssertEqual(apiSpy.updateShareStatusCallsCount, 1)
+    XCTAssertEqual(apiSpy.updateShareStatusTypeParam, .signing)
+    XCTAssertEqual(apiSpy.updateShareStatusStatusParam, .STORED_CLIENT)
+    XCTAssertEqual(apiSpy.refreshClientCallsCount, 1)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_when5xxFallback_callsApiExactlyOnce_andDoesNotRetryApi() async throws {
+    // given: a 5xx from the API, with a working binary fallback
+    let apiMock = PortalApiMock()
+    apiMock.generatePreGeneratedSharesErrorToThrow = PortalRequestsError.internalServerError("503 - service unavailable", url: "u")
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given
+    let addresses = try await mpc?.generate()
+
+    // then: the API path is tried exactly once (single attempt, then binary), never retried
+    XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 1)
+    XCTAssertEqual(addresses?[.eip155], MockConstants.mockEip155Address)
+  }
+
+  // MARK: Retry test helpers
+
+  /// Drives `generate()` with the pre-generated flag enabled and the API stubbed to throw
+  /// `apiError`, asserting the error surfaces (is rethrown) and the binary fallback is NOT
+  /// attempted. Used for the family of non-retryable (non-5xx) errors.
+  @available(iOS 16, *)
+  private func assertGenerateSurfacesWithoutBinaryFallback(
+    apiError: Error,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) async {
+    let apiMock = PortalApiMock()
+    apiMock.generatePreGeneratedSharesErrorToThrow = apiError
+    let mobileSpy = MobileSpy()
+    // Give the binary a valid response so, if a fallback ever fired, generation would succeed —
+    // making an incorrect fallback observable as a test failure rather than a decode error.
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    do {
+      _ = try await mpc?.generate()
+      XCTFail("Expected generate() to rethrow the non-retryable error", file: file, line: line)
+    } catch {
+      XCTAssertFalse(PortalMpc.isRetryableServerError(error), "Test error should be classified non-retryable", file: file, line: line)
+    }
+
+    XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1, "API should be attempted exactly once", file: file, line: line)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 0, "Binary ED25519 must not run for a non-retryable error", file: file, line: line)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 0, "Binary SECP256K1 must not run for a non-retryable error", file: file, line: line)
   }
 
   private static func makePreGeneratedApiResponse(id: String = MockConstants.mockMpcShareId) throws -> GenerateApiResponse {

--- a/Tests/PortalSwiftTests/Core/PortalMpcTests.swift
+++ b/Tests/PortalSwiftTests/Core/PortalMpcTests.swift
@@ -43,6 +43,7 @@ extension PortalMpcTests {
     portalApi: PortalApiProtocol = PortalApi(apiKey: MockConstants.mockApiKey, requests: MockPortalRequests()),
     keychain: PortalKeychainProtocol = MockPortalKeychain(),
     mobile: Mobile = MockMobileWrapper(),
+    featureFlags: FeatureFlags? = nil,
     gDriveStorage: PortalStorage? = nil,
     passwordStorage: PortalStorage? = nil,
     iCloudStorage: PortalStorage? = nil,
@@ -55,7 +56,8 @@ extension PortalMpcTests {
       apiKey: MockConstants.mockApiKey,
       api: self.portalApi,
       keychain: self.keychain,
-      mobile: mobile
+      mobile: mobile,
+      featureFlags: featureFlags
     )
 
     if let gDriveStorage {
@@ -909,6 +911,255 @@ extension PortalMpcTests {
     _ = try await mpc?.generate()
 
     XCTAssertEqual(portalApiMock.refreshClientCallsCount, 1)
+  }
+
+  // MARK: - Pre-generated wallet (usePreGeneratedWallet) Tests
+
+  func test_featureFlags_usePreGeneratedWallet_defaultsToOff() {
+    // given a FeatureFlags created without specifying usePreGeneratedWallet
+    let featureFlags = FeatureFlags()
+
+    // then it defaults to nil (off) and is not treated as enabled
+    XCTAssertNil(featureFlags.usePreGeneratedWallet)
+    XCTAssertNotEqual(featureFlags.usePreGeneratedWallet, true)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenUsePreGeneratedWalletEnabled_usesApiAndNotBinary() async throws {
+    // given
+    let mockRequests = MockPortalRequests()
+    let api = PortalApi(apiKey: MockConstants.mockApiKey, requests: mockRequests)
+    let mobileSpy = MobileSpy()
+    initPortalMpcWith(
+      portalApi: api,
+      mobile: mobileSpy,
+      featureFlags: FeatureFlags(usePreGeneratedWallet: true)
+    )
+
+    // and given
+    let addresses = try await mpc?.generate()
+
+    // then: the API path was used (single /v1/generate call) and the binary was not invoked
+    let generateCallsCount = await mockRequests.generateCallsCount
+    XCTAssertEqual(generateCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 0)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 0)
+    XCTAssertEqual(addresses?[.eip155], MockConstants.mockEip155Address)
+    XCTAssertEqual(addresses?[.solana], MockConstants.mockSolanaAddress)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenUsePreGeneratedWalletEnabled_andApiFails_fallsBackToBinary() async throws {
+    // given
+    let mockRequests = MockPortalRequests(failEnclaveGenerate: true)
+    let api = PortalApi(apiKey: MockConstants.mockApiKey, requests: mockRequests)
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(
+      portalApi: api,
+      mobile: mobileSpy,
+      featureFlags: FeatureFlags(usePreGeneratedWallet: true)
+    )
+
+    // and given
+    let addresses = try await mpc?.generate()
+
+    // then: API was attempted, then the binary fallback ran and the wallet was created
+    let generateCallsCount = await mockRequests.generateCallsCount
+    XCTAssertEqual(generateCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 1)
+    XCTAssertEqual(addresses?[.eip155], MockConstants.mockEip155Address)
+    XCTAssertEqual(addresses?[.solana], MockConstants.mockSolanaAddress)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenUsePreGeneratedWalletDisabled_usesBinaryAndNotApi() async throws {
+    // given
+    let mockRequests = MockPortalRequests()
+    let api = PortalApi(apiKey: MockConstants.mockApiKey, requests: mockRequests)
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(
+      portalApi: api,
+      mobile: mobileSpy,
+      featureFlags: FeatureFlags(usePreGeneratedWallet: false)
+    )
+
+    // and given
+    _ = try await mpc?.generate()
+
+    // then: the binary path was used and the API was never called
+    let generateCallsCount = await mockRequests.generateCallsCount
+    XCTAssertEqual(generateCallsCount, 0)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 1)
+  }
+
+  func test_decodeStandardBase64_roundTripsMpcShare() throws {
+    // given a base64 (no padding) of an MpcShare, as the Enclave MPC API returns
+    let shareData = try JSONEncoder().encode(MockConstants.mockMpcShare)
+    let base64NoPadding = shareData.base64EncodedString().replacingOccurrences(of: "=", with: "")
+
+    // when
+    let decoded = PortalMpc.decodeStandardBase64(base64NoPadding)
+
+    // then it decodes back into an equivalent MpcShare
+    XCTAssertNotNil(decoded)
+    let mpcShare = try JSONDecoder().decode(MpcShare.self, from: decoded!)
+    XCTAssertEqual(mpcShare.signingSharePairId, MockConstants.mockMpcShareId)
+  }
+
+  func test_decodeStandardBase64_handlesAllPaddingRemainders() {
+    // Standard-alphabet base64 with the `=` padding stripped, as the API returns.
+    XCTAssertEqual(PortalMpc.decodeStandardBase64("YWJj").flatMap { String(data: $0, encoding: .utf8) }, "abc") // len 4, no padding needed
+    XCTAssertEqual(PortalMpc.decodeStandardBase64("YQ").flatMap { String(data: $0, encoding: .utf8) }, "a") // remainder 2
+    XCTAssertEqual(PortalMpc.decodeStandardBase64("YWI").flatMap { String(data: $0, encoding: .utf8) }, "ab") // remainder 3
+    XCTAssertEqual(PortalMpc.decodeStandardBase64("YWJjZA").flatMap { String(data: $0, encoding: .utf8) }, "abcd") // remainder 2
+  }
+
+  func test_decodeStandardBase64_returnsNil_forInvalidInput() {
+    XCTAssertNil(PortalMpc.decodeStandardBase64("@@@@"))
+    XCTAssertNil(PortalMpc.decodeStandardBase64("not base64!"))
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenUsePreGeneratedWalletEnabled_stillUpdatesShareStatusAndRefreshesClient() async throws {
+    // given
+    let apiSpy = PortalApiSpy()
+    apiSpy.generatePreGeneratedSharesReturnValue = try Self.makePreGeneratedApiResponse()
+    initPortalMpcWith(portalApi: apiSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given
+    _ = try await mpc?.generate()
+
+    // then: the post-generate lifecycle steps still run exactly as with the binary path
+    XCTAssertEqual(apiSpy.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(apiSpy.updateShareStatusCallsCount, 1)
+    XCTAssertEqual(apiSpy.updateShareStatusTypeParam, .signing)
+    XCTAssertEqual(apiSpy.updateShareStatusStatusParam, .STORED_CLIENT)
+    XCTAssertEqual(apiSpy.updateShareStatusSharePairIdsParam, [MockConstants.mockMpcShareId, MockConstants.mockMpcShareId])
+    XCTAssertEqual(apiSpy.refreshClientCallsCount, 1)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenUsePreGeneratedWalletEnabled_passesIosMetadataToApi() async throws {
+    // given
+    let apiMock = PortalApiMock()
+    apiMock.generatePreGeneratedSharesReturnValue = try Self.makePreGeneratedApiResponse()
+    initPortalMpcWith(portalApi: apiMock, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given
+    _ = try await mpc?.generate()
+
+    // then: the same metadata we send to the binary is forwarded to the API
+    let metadataStr = apiMock.generatePreGeneratedSharesMetadataParam ?? ""
+    XCTAssertFalse(metadataStr.isEmpty)
+    let metadata = try JSONDecoder().decode(MpcMetadata.self, from: Data(metadataStr.utf8))
+    XCTAssertEqual(metadata.clientPlatform, "NATIVE_IOS")
+    XCTAssertEqual(metadata.mpcServerVersion, "v6")
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenUsePreGeneratedWalletEnabled_storesTransformedShares() async throws {
+    // given
+    let mockRequests = MockPortalRequests()
+    let api = PortalApi(apiKey: MockConstants.mockApiKey, requests: mockRequests)
+    let keychainSpy = PortalKeychainSpy()
+    initPortalMpcWith(portalApi: api, keychain: keychainSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given
+    _ = try await mpc?.generate()
+
+    // then: the base64 API shares are transformed into the same stored format as the binary path
+    XCTAssertEqual(keychainSpy.setSharesCallCount, 1)
+    let stored = keychainSpy.setSharesParams.first
+    XCTAssertNotNil(stored?["ED25519"])
+    XCTAssertNotNil(stored?["SECP256K1"])
+    XCTAssertEqual(stored?["SECP256K1"]?.id, MockConstants.mockMpcShareId)
+
+    let storedShareString = stored?["SECP256K1"]?.share ?? ""
+    let decodedMpcShare = try JSONDecoder().decode(MpcShare.self, from: Data(storedShareString.utf8))
+    XCTAssertEqual(decodedMpcShare.signingSharePairId, MockConstants.mockMpcShareId)
+    XCTAssertEqual(decodedMpcShare, MockConstants.mockMpcShare)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenApiShareHasEmptySigningSharePairId_fallsBackToBinary() async throws {
+    // given: an API response whose decoded MpcShare has no signingSharePairId
+    let apiMock = PortalApiMock()
+    let badJson = "{\"clientId\":\"\",\"signingSharePairId\":\"\",\"share\":\"s\",\"ssid\":\"x\"}"
+    let badShare = Data(badJson.utf8).base64EncodedString().replacingOccurrences(of: "=", with: "")
+    apiMock.generatePreGeneratedSharesReturnValue = GenerateApiResponse(
+      secp256k1: GenerateApiCurveShare(share: badShare, id: "id"),
+      ed25519: GenerateApiCurveShare(share: badShare, id: "id")
+    )
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given
+    let addresses = try await mpc?.generate()
+
+    // then: API was attempted, transform failed, binary fallback created the wallet
+    XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 1)
+    XCTAssertEqual(addresses?[.eip155], MockConstants.mockEip155Address)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenApiShareHasInvalidBase64_fallsBackToBinary() async throws {
+    // given: an API response with an undecodable base64 share
+    let apiMock = PortalApiMock()
+    apiMock.generatePreGeneratedSharesReturnValue = GenerateApiResponse(
+      secp256k1: GenerateApiCurveShare(share: "@@@@", id: "id"),
+      ed25519: GenerateApiCurveShare(share: "@@@@", id: "id")
+    )
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given
+    let addresses = try await mpc?.generate()
+
+    // then: the binary fallback ran and created the wallet
+    XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 1)
+    XCTAssertEqual(addresses?[.eip155], MockConstants.mockEip155Address)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenApiThrows_fallsBackToBinary_viaApiDouble() async throws {
+    // given: the API method itself throws
+    let apiMock = PortalApiMock()
+    apiMock.generatePreGeneratedSharesErrorToThrow = URLError(.timedOut)
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given
+    let addresses = try await mpc?.generate()
+
+    // then
+    XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 1)
+    XCTAssertEqual(addresses?[.eip155], MockConstants.mockEip155Address)
+  }
+
+  private static func makePreGeneratedApiResponse(id: String = MockConstants.mockMpcShareId) throws -> GenerateApiResponse {
+    let share = try MockConstants.mockBase64EncodedMpcShare
+    return GenerateApiResponse(
+      secp256k1: GenerateApiCurveShare(share: share, id: id),
+      ed25519: GenerateApiCurveShare(share: share, id: id)
+    )
   }
 }
 

--- a/Tests/PortalSwiftTests/PortalApi/PortalApiMock.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalApiMock.swift
@@ -114,6 +114,22 @@ class PortalApiMock: PortalApiProtocol {
     refreshClientCallsCount += 1
   }
 
+  var generatePreGeneratedSharesCallsCount = 0
+  var generatePreGeneratedSharesMetadataParam: String?
+  var generatePreGeneratedSharesReturnValue: PortalSwift.GenerateApiResponse?
+  var generatePreGeneratedSharesErrorToThrow: Error?
+  func generatePreGeneratedShares(metadataStr: String) async throws -> PortalSwift.GenerateApiResponse {
+    generatePreGeneratedSharesCallsCount += 1
+    generatePreGeneratedSharesMetadataParam = metadataStr
+    if let error = generatePreGeneratedSharesErrorToThrow {
+      throw error
+    }
+    guard let value = generatePreGeneratedSharesReturnValue else {
+      throw URLError(.badURL)
+    }
+    return value
+  }
+
   var simulateTransactionReturnValue: PortalSwift.SimulatedTransaction?
   func simulateTransaction(_: Any, withChainId _: String) async throws -> PortalSwift.SimulatedTransaction {
     return simulateTransactionReturnValue ?? SimulatedTransaction(changes: [])

--- a/Tests/PortalSwiftTests/PortalApi/PortalApiSpy.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalApiSpy.swift
@@ -202,6 +202,24 @@ class PortalApiSpy: PortalApiProtocol {
     refreshClientCallsCount += 1
   }
 
+  // Generate pre-generated shares method tracking
+  var generatePreGeneratedSharesCallsCount: Int = 0
+  var generatePreGeneratedSharesMetadataParam: String?
+  var generatePreGeneratedSharesReturnValue: GenerateApiResponse?
+  var generatePreGeneratedSharesErrorToThrow: Error?
+
+  public func generatePreGeneratedShares(metadataStr: String) async throws -> GenerateApiResponse {
+    generatePreGeneratedSharesCallsCount += 1
+    generatePreGeneratedSharesMetadataParam = metadataStr
+    if let error = generatePreGeneratedSharesErrorToThrow {
+      throw error
+    }
+    guard let value = generatePreGeneratedSharesReturnValue else {
+      throw URLError(.badURL)
+    }
+    return value
+  }
+
   // Simulate Transaction method tracking
   var simulateTransactionCallsCount: Int = 0
   var simulateTransactionTransactionParam: Any?


### PR DESCRIPTION
## Summary
Adds an opt-in usePreGeneratedWallet feature flag that generates wallets via the Enclave MPC API POST /v1/generate with { "usePreGenerated": true }, transforming the response into the existing MpcShare storage format. Falls back to the current binary DKG flow on PortalRequestsError.internalServerError (5xx), so wallet creation never regresses.

Changes:
- FeatureFlags: new usePreGeneratedWallet flag (defaults to off).
- PortalApi: new generatePreGeneratedShares(metadataStr:) that owns the /v1/generate call against enclaveMPCHost; enclaveMPCHost now injected into PortalApi.
- PortalMpc.generate(): branches on the flag — calls the API path (base64-decode → MpcShare transform) when enabled, otherwise the binary path; transparently falls back to the binary on HTTP/decode/validation failure. Post-generate lifecycle (store → STORED_CLIENT → refreshClient) unchanged.
- SPM Example: added a "Use Pre-Generated Wallet" settings toggle.

> **Copilot Review:** GitHub Copilot will automatically post a review below. Check its comments for additional context and suggestions.
