### PR TITLE
Resolve SwiftNIO Dependabot alerts by bumping transitive deps

### DIFF
--- a/PortalSwift.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PortalSwift.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -302,8 +302,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "a18bddb0acf7a40d982b2f128ce73ce4ee31f352",
-        "version" : "2.86.2"
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -311,8 +311,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "a55c3dd3a81d035af8a20ce5718889c0dcab073d",
-        "version" : "1.29.0"
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
       }
     },
     {
@@ -320,8 +320,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "5e9e99ec96c53bc2c18ddd10c1e25a3cd97c55e5",
-        "version" : "1.38.0"
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
       }
     },
     {

--- a/SPM Example/SPM Example.xcodeproj/project.pbxproj
+++ b/SPM Example/SPM Example.xcodeproj/project.pbxproj
@@ -282,6 +282,9 @@
 				F9BF35A02BF8115000BF2862 /* XCRemoteSwiftPackageReference "Web3" */,
 				2510AC502F50C7000021F8F3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				D8PU00072EF2000000000007 /* XCRemoteSwiftPackageReference "Pulse" */,
+				5E10AC010000000000000001 /* XCRemoteSwiftPackageReference "swift-nio" */,
+				5E10AC020000000000000002 /* XCRemoteSwiftPackageReference "swift-nio-http2" */,
+				5E10AC030000000000000003 /* XCRemoteSwiftPackageReference "swift-nio-extras" */,
 			);
 			productRefGroup = 607FACD11AFB9204008FA782 /* Products */;
 			projectDirPath = "";
@@ -758,6 +761,30 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 0.8.8;
+			};
+		};
+		5E10AC010000000000000001 /* XCRemoteSwiftPackageReference "swift-nio" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-nio.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.100.0;
+			};
+		};
+		5E10AC020000000000000002 /* XCRemoteSwiftPackageReference "swift-nio-http2" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-nio-http2.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.44.0;
+			};
+		};
+		5E10AC030000000000000003 /* XCRemoteSwiftPackageReference "swift-nio-extras" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-nio-extras.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.34.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/SPM Example/SPM Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SPM Example/SPM Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5ebf60df0077a2e0841f97dee89e2523a364c4f0d937132fc3f00be19a51335f",
+  "originHash" : "0fc84414ce9edee508b6a91e4e3f66509dcfd3339c9801d3bec59b2407d509c7",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -303,8 +303,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "e932d3c4d8f77433c8f7093b5ebcbf91463948a0",
-        "version" : "2.95.0"
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -312,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "3df009d563dc9f21a5c85b33d8c2e34d2e4f8c3b",
-        "version" : "1.32.1"
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
       }
     },
     {
@@ -321,8 +321,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "b6571f3db40799df5a7fc0e92c399aa71c883edd",
-        "version" : "1.40.0"
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
       }
     },
     {


### PR DESCRIPTION
## Summary
Resolve SwiftNIO Dependabot alerts by bumping transitive deps (ENG-7855)

Clears 5 Dependabot alerts in the SwiftNIO stack, which enters only
through the SPM Example app (Web3.swift -> websocket-kit, and Pulse).
The shipped SDK (Package.swift / PortalSwift.podspec) has no SwiftNIO
dependency, so distributed builds were never affected.

Refresh lockfiles to patched versions (workspace + SPM Example):
  swift-nio         2.86.2 -> 2.101.3   CVE-2026-28980, -43671, -28970 (fixed 2.100.0)
  swift-nio-http2   1.38.0 -> 1.44.0     CVE-2026-28898 (fixed 1.44.0)
  swift-nio-extras  1.29.0 -> 1.34.3     CVE-2026-28975 (fixed 1.34.1)

Pin explicit version floors in the SPM Example project so future
re-resolution cannot regress below the patched versions.

Files:
  PortalSwift.xcworkspace/xcshareddata/swiftpm/Package.resolved
  SPM Example/SPM Example.xcodeproj/project.pbxproj
  SPM Example/SPM Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved


> **Copilot Review:** GitHub Copilot will automatically post a review below. Check its comments for additional context and suggestions.
