### PR TITLE
Release `7.3.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,31 @@ Possible Types of changes include:
 - Improved
 - Upgraded
 
+## 7.3.0 - 2026-07-21
+- Added Noah on/off-ramp integration for fiat payins, payouts, and KYC via the new `portal.ramps` namespace.
+    - Added `portal.ramps.noah.initiateKyc`
+    - Added `portal.ramps.noah.initiatePayin` and `portal.ramps.noah.simulatePayin`
+    - Added `portal.ramps.noah.getPaymentMethods`
+    - Added `portal.ramps.noah.getPayoutCountries`, `portal.ramps.noah.getPayoutChannels`, and `portal.ramps.noah.getPayoutChannelForm`
+    - Added `portal.ramps.noah.getPayoutQuote` and `portal.ramps.noah.initiatePayout`
+- Added high-level Li.Fi swap methods for one-call cross-chain bridging.
+    - Added `portal.trading.lifi.tradeAsset` — fetches routes and, for each step, signs, submits, waits for on-chain confirmation, and polls Li.Fi status until the transfer completes.
+    - Added `portal.trading.lifi.pollStatus` to poll a transfer's status until it is done, with an optional progress callback and polling controlled by `LifiPollStatusOptions`.
+- Added high-level Yield.xyz deposit and withdraw methods.
+    - Added `portal.yield.yieldxyz.deposit` and `portal.yield.yieldxyz.withdraw`, which resolve the yield, build the transactions, then sign, submit, and confirm each step for you.
+    - Added `portal.yield.yieldxyz.getValidators` (and the convenience `portal.yield.getValidators`) for native-staking validators.
+    - Target a yield by explicit `yieldId` or by chain and token, and track progress and tune polling via `YieldSubmitOptions`.
+    - Added the `lending` case to `YieldXyzSource`.
+- Added high-level delegation methods that construct and broadcast a transaction in a single call.
+    - Added `portal.delegations.approveAndSubmit`, `portal.delegations.revokeAndSubmit`, and `portal.delegations.transferAndSubmit`.
+    - Added `portal.delegations.setSignAndSendTransaction` to override the default signer, or supply a per-call override and progress callback via `DelegationSubmitOptions`.
+- Added pre-generated wallet support via the `FeatureFlags.usePreGeneratedWallet` flag.
+    - When enabled, wallet generation draws from the pre-generated wallet pool, with automatic fallback to on-device generation on transient server errors.
+- Added request tracing via an `X-Portal-Trace-Id` header attached to all client API requests for end-to-end request correlation.
+    - Multi-step flows (such as `sendAsset`, MPC generate/backup/recover, and `upgradeTo7702`) share a single trace ID across their underlying calls.
+    - Added an optional `traceId` parameter to `SendAssetParams` and `RequestOptions`; if omitted, one is generated automatically.
+- Bumped `swift-nio` to 2.101.3, `swift-nio-http2` to 1.44.0, and `swift-nio-extras` to 1.34.3.
+
 ## 7.2.1 - 2026-05-20
 - Fixed Hypernative `ScanAddressesResponse` decoding to align with the Hypernative API.
     - Made `totalIncomingUsd`, `policyId`, `timestamp`, and `flags` optional on `ScanAddressesItem`, and added `totalOutgoingUsd`.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @kelsonic @AhmedRagabIssa @Maxi-F @ahmdshrif @Rshahatit
+* @kelsonic @AhmedRagabIssa @Maxi-F @Rshahatit

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @kelsonic @AhmedRagabIssa @Maxi-F @ahmdshrif @Rshahatit
+* @kelsonic @valentagliaferro @FranciscoArmendariz @AhmedRagabIssa @Rshahatit @dscrobonia @Maxi-F @lsrzar

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
+    {
       "identity" : "anycodable",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Flight-School/AnyCodable.git",
@@ -28,6 +37,60 @@
       }
     },
     {
+      "identity" : "bigint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attaswift/BigInt.git",
+      "state" : {
+        "revision" : "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
+        "version" : "5.7.0"
+      }
+    },
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
+        "version" : "1.10.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "state" : {
+        "revision" : "fdc352fabaf5916e7faa1f96ad02b1957e93e5a5",
+        "version" : "11.15.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "a2d0f1f1666de591eb1a811f40b1706f5c63a2ed",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "45ce435e9406d3c674dd249a042b932bee006f60",
+        "version" : "11.15.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
       "identity" : "googlesignin-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleSignIn-iOS.git",
@@ -43,6 +106,15 @@
       "state" : {
         "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
         "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
       }
     },
     {
@@ -64,6 +136,42 @@
       }
     },
     {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promisekit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mxcl/PromiseKit.git",
+      "state" : {
+        "revision" : "8a98e31a47854d3180882c8068cc4d9381bf382d",
+        "version" : "6.22.1"
+      }
+    },
+    {
       "identity" : "promises",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
@@ -73,12 +181,219 @@
       }
     },
     {
+      "identity" : "pulse",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Pulse",
+      "state" : {
+        "revision" : "a4e5bc2b0439552d4ff5fc9667c389be6ef5bd52",
+        "version" : "5.2.2"
+      }
+    },
+    {
+      "identity" : "secp256k1.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Boilertalk/secp256k1.swift.git",
+      "state" : {
+        "revision" : "cd187c632fb812fd93711a9f7e644adb7e5f97f0",
+        "version" : "0.1.7"
+      }
+    },
+    {
       "identity" : "starscream",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/daltoniam/Starscream.git",
       "state" : {
         "revision" : "c6bfd1af48efcc9a9ad203665db12375ba6b145a",
         "version" : "4.0.8"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "d0b4a06d0f173a2f3be27d3ea21b3c3aa18db440",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
+        "version" : "1.19.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "2aed77ae5ec9a86d8fe42c12275e4c2653a286ee",
+        "version" : "1.13.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "57c0a08a331aaea9f5d7a932ad94ef43be942a95",
+        "version" : "2.100.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "d2eeec0339074034f11a040a74aa2a341a2c4506",
+        "version" : "1.34.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "f6506eaa86ed2e01cb0ae14a75035b7fdbf0918f",
+        "version" : "1.38.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "669763cfd5806a67e21972d7e5e2d6b80b1ea985",
+        "version" : "1.6.5"
+      }
+    },
+    {
+      "identity" : "web3.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Boilertalk/Web3.swift",
+      "state" : {
+        "revision" : "b85187ddf230a10b04fa8574c44980f3369ddff5",
+        "version" : "0.8.8"
+      }
+    },
+    {
+      "identity" : "websocket-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/websocket-kit",
+      "state" : {
+        "revision" : "90bbbdab3ede12c803cfbe91646f291c092517a3",
+        "version" : "2.16.2"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "abseil-cpp-binary",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/abseil-cpp-binary.git",
-      "state" : {
-        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
-        "version" : "1.2024072200.0"
-      }
-    },
-    {
       "identity" : "anycodable",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Flight-School/AnyCodable.git",
@@ -37,60 +28,6 @@
       }
     },
     {
-      "identity" : "bigint",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/attaswift/BigInt.git",
-      "state" : {
-        "revision" : "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
-        "version" : "5.7.0"
-      }
-    },
-    {
-      "identity" : "cryptoswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
-      "state" : {
-        "revision" : "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
-        "version" : "1.10.0"
-      }
-    },
-    {
-      "identity" : "firebase-ios-sdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
-      "state" : {
-        "revision" : "fdc352fabaf5916e7faa1f96ad02b1957e93e5a5",
-        "version" : "11.15.0"
-      }
-    },
-    {
-      "identity" : "google-ads-on-device-conversion-ios-sdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
-      "state" : {
-        "revision" : "a2d0f1f1666de591eb1a811f40b1706f5c63a2ed",
-        "version" : "2.3.0"
-      }
-    },
-    {
-      "identity" : "googleappmeasurement",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleAppMeasurement.git",
-      "state" : {
-        "revision" : "45ce435e9406d3c674dd249a042b932bee006f60",
-        "version" : "11.15.0"
-      }
-    },
-    {
-      "identity" : "googledatatransport",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleDataTransport.git",
-      "state" : {
-        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
-        "version" : "10.1.0"
-      }
-    },
-    {
       "identity" : "googlesignin-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleSignIn-iOS.git",
@@ -106,15 +43,6 @@
       "state" : {
         "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
         "version" : "8.1.0"
-      }
-    },
-    {
-      "identity" : "grpc-binary",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/grpc-binary.git",
-      "state" : {
-        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
-        "version" : "1.69.1"
       }
     },
     {
@@ -136,42 +64,6 @@
       }
     },
     {
-      "identity" : "interop-ios-for-google-sdks",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
-      "state" : {
-        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
-        "version" : "101.0.0"
-      }
-    },
-    {
-      "identity" : "leveldb",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/leveldb.git",
-      "state" : {
-        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
-        "version" : "1.22.5"
-      }
-    },
-    {
-      "identity" : "nanopb",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/nanopb.git",
-      "state" : {
-        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
-        "version" : "2.30910.0"
-      }
-    },
-    {
-      "identity" : "promisekit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mxcl/PromiseKit.git",
-      "state" : {
-        "revision" : "8a98e31a47854d3180882c8068cc4d9381bf382d",
-        "version" : "6.22.1"
-      }
-    },
-    {
       "identity" : "promises",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
@@ -181,219 +73,12 @@
       }
     },
     {
-      "identity" : "pulse",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kean/Pulse",
-      "state" : {
-        "revision" : "a4e5bc2b0439552d4ff5fc9667c389be6ef5bd52",
-        "version" : "5.2.2"
-      }
-    },
-    {
-      "identity" : "secp256k1.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Boilertalk/secp256k1.swift.git",
-      "state" : {
-        "revision" : "cd187c632fb812fd93711a9f7e644adb7e5f97f0",
-        "version" : "0.1.7"
-      }
-    },
-    {
       "identity" : "starscream",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/daltoniam/Starscream.git",
       "state" : {
         "revision" : "c6bfd1af48efcc9a9ad203665db12375ba6b145a",
         "version" : "4.0.8"
-      }
-    },
-    {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms.git",
-      "state" : {
-        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
-        "version" : "1.2.1"
-      }
-    },
-    {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
-        "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-async-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-async-algorithms.git",
-      "state" : {
-        "revision" : "d0b4a06d0f173a2f3be27d3ea21b3c3aa18db440",
-        "version" : "1.1.4"
-      }
-    },
-    {
-      "identity" : "swift-atomics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics.git",
-      "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-certificates",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-certificates.git",
-      "state" : {
-        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
-        "version" : "1.19.1"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
-        "version" : "1.5.1"
-      }
-    },
-    {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
-        "version" : "4.5.0"
-      }
-    },
-    {
-      "identity" : "swift-http-structured-headers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-structured-headers.git",
-      "state" : {
-        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
-        "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-http-types",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-types.git",
-      "state" : {
-        "revision" : "db774a277f60063a32d854f2980299caf06da041",
-        "version" : "1.6.0"
-      }
-    },
-    {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log.git",
-      "state" : {
-        "revision" : "2aed77ae5ec9a86d8fe42c12275e4c2653a286ee",
-        "version" : "1.13.1"
-      }
-    },
-    {
-      "identity" : "swift-nio",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio.git",
-      "state" : {
-        "revision" : "57c0a08a331aaea9f5d7a932ad94ef43be942a95",
-        "version" : "2.100.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-extras.git",
-      "state" : {
-        "revision" : "d2eeec0339074034f11a040a74aa2a341a2c4506",
-        "version" : "1.34.1"
-      }
-    },
-    {
-      "identity" : "swift-nio-http2",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-http2.git",
-      "state" : {
-        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
-        "version" : "1.44.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-ssl",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-ssl.git",
-      "state" : {
-        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
-        "version" : "2.37.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-transport-services",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-transport-services.git",
-      "state" : {
-        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
-        "version" : "1.28.0"
-      }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics.git",
-      "state" : {
-        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version" : "1.1.1"
-      }
-    },
-    {
-      "identity" : "swift-protobuf",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-protobuf.git",
-      "state" : {
-        "revision" : "f6506eaa86ed2e01cb0ae14a75035b7fdbf0918f",
-        "version" : "1.38.0"
-      }
-    },
-    {
-      "identity" : "swift-service-lifecycle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
-      "state" : {
-        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
-        "version" : "2.11.0"
-      }
-    },
-    {
-      "identity" : "swift-system",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
-      "state" : {
-        "revision" : "669763cfd5806a67e21972d7e5e2d6b80b1ea985",
-        "version" : "1.6.5"
-      }
-    },
-    {
-      "identity" : "web3.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Boilertalk/Web3.swift",
-      "state" : {
-        "revision" : "b85187ddf230a10b04fa8574c44980f3369ddff5",
-        "version" : "0.8.8"
-      }
-    },
-    {
-      "identity" : "websocket-kit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vapor/websocket-kit",
-      "state" : {
-        "revision" : "90bbbdab3ede12c803cfbe91646f291c092517a3",
-        "version" : "2.16.2"
       }
     }
   ],

--- a/PortalSwift.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PortalSwift.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -302,8 +302,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "a18bddb0acf7a40d982b2f128ce73ce4ee31f352",
-        "version" : "2.86.2"
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -311,8 +311,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "a55c3dd3a81d035af8a20ce5718889c0dcab073d",
-        "version" : "1.29.0"
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
       }
     },
     {
@@ -320,8 +320,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "5e9e99ec96c53bc2c18ddd10c1e25a3cd97c55e5",
-        "version" : "1.38.0"
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
       }
     },
     {

--- a/SPM Example/PortalSwift/Base.lproj/Main.storyboard
+++ b/SPM Example/PortalSwift/Base.lproj/Main.storyboard
@@ -588,7 +588,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RIl-6u-QAe">
-                                <rect key="frame" x="14" y="1854" width="339" height="39"/>
+                                <rect key="frame" x="14" y="1901" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Deprecated Swap">
@@ -601,7 +601,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3wx-Nc-CEh">
-                                <rect key="frame" x="14" y="1901" width="339" height="39"/>
+                                <rect key="frame" x="14" y="1948" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Test ZeroX Trading">
@@ -614,7 +614,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vdB-AW-DWU">
-                                <rect key="frame" x="14" y="1948" width="339" height="39"/>
+                                <rect key="frame" x="14" y="1995" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="ZeroX Get Sources">
@@ -627,7 +627,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XPc-NC-pP2">
-                                <rect key="frame" x="14" y="1995" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2042" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="ZeroX Get Quote">
@@ -705,8 +705,21 @@
                                     <action selector="handleGetRoutes" destination="vXZ-lx-hvc" eventType="touchUpInside" id="RtS-2t-Cnn"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="lifiTradeAssetButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LfT-rd-As1">
+                                <rect key="frame" x="15" y="1807" width="339" height="39"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="LiFi Trade Asset"/>
+                                <buttonConfiguration key="configuration" style="filled" title="LiFi Trade Asset">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" red="0.027450980390000001" green="0.054901960780000002" blue="0.086274509799999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="handleLifiTradeAsset" destination="vXZ-lx-hvc" eventType="touchUpInside" id="LfT-rd-Ac1"/>
+                                </connections>
+                            </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="testGasSponsor" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NoB-qq-VG2">
-                                <rect key="frame" x="14" y="1807" width="339" height="39"/>
+                                <rect key="frame" x="14" y="1854" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Test Gas Sponsor - 6 test cases">
@@ -719,7 +732,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="058-vH-XLY">
-                                <rect key="frame" x="15" y="2042" width="339" height="39"/>
+                                <rect key="frame" x="15" y="2089" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="ZeroX Price Check">
@@ -732,7 +745,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hyn-Tx-Sc1">
-                                <rect key="frame" x="15" y="2123" width="339" height="39"/>
+                                <rect key="frame" x="15" y="2170" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Hypernative Scan Tx">
@@ -745,7 +758,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hyn-Ad-Sc1">
-                                <rect key="frame" x="15" y="2170" width="339" height="39"/>
+                                <rect key="frame" x="15" y="2217" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Hypernative Scan Addresses">
@@ -758,7 +771,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hyn-Nf-Sc1">
-                                <rect key="frame" x="15" y="2217" width="339" height="39"/>
+                                <rect key="frame" x="15" y="2264" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Hypernative Scan NFTs">
@@ -771,7 +784,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hyn-Tk-Sc1">
-                                <rect key="frame" x="15" y="2264" width="339" height="39"/>
+                                <rect key="frame" x="15" y="2311" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Hypernative Scan Tokens">
@@ -784,7 +797,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hyn-Ur-Sc1">
-                                <rect key="frame" x="15" y="2311" width="339" height="39"/>
+                                <rect key="frame" x="15" y="2358" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Hypernative Scan URL">
@@ -797,21 +810,21 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Hypernative - Security" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="G8W-ZF-6Ea">
-                                <rect key="frame" x="99" y="2094" width="171" height="21"/>
+                                <rect key="frame" x="99" y="2141" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Blockaid - Security" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-Lbl-1a">
-                                <rect key="frame" x="99" y="2362" width="171" height="21"/>
+                                <rect key="frame" x="99" y="2409" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-EV-Sc1">
-                                <rect key="frame" x="14" y="2387" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2434" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Blockaid Scan EVM Tx">
@@ -824,7 +837,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-So-Sc1">
-                                <rect key="frame" x="14" y="2434" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2481" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Blockaid Scan Solana Tx">
@@ -837,7 +850,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-Ad-Sc1">
-                                <rect key="frame" x="14" y="2481" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2528" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Blockaid Scan Address">
@@ -850,7 +863,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-Tk-Sc1">
-                                <rect key="frame" x="14" y="2528" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2575" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Blockaid Scan Tokens">
@@ -863,7 +876,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-Ur-Sc1">
-                                <rect key="frame" x="14" y="2575" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2622" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Blockaid Scan URL">
@@ -876,21 +889,21 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Delegations" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Del-Lbl-1a">
-                                <rect key="frame" x="99" y="2636" width="171" height="21"/>
+                                <rect key="frame" x="99" y="2683" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Upgarade to 7702" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lOv-mm-Fuc">
-                                <rect key="frame" x="106" y="3216" width="171" height="21"/>
+                                <rect key="frame" x="106" y="3263" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-AE-Bt1">
-                                <rect key="frame" x="14" y="2669" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2716" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Approve (ETH)">
@@ -903,7 +916,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-AS-Bt1">
-                                <rect key="frame" x="14" y="2719" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2766" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Approve (SOL)">
@@ -916,7 +929,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-RE-Bt1">
-                                <rect key="frame" x="14" y="2769" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2816" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Revoke (ETH)">
@@ -929,7 +942,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-RS-Bt1">
-                                <rect key="frame" x="14" y="2819" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2866" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Revoke (SOL)">
@@ -942,7 +955,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-TE-Bt1">
-                                <rect key="frame" x="14" y="2869" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2916" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation TransferFrom (ETH)">
@@ -955,7 +968,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-TS-Bt1">
-                                <rect key="frame" x="14" y="2919" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2966" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation TransferFrom (SOL)">
@@ -968,7 +981,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-GE-Bt1">
-                                <rect key="frame" x="14" y="2969" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3016" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Get Status (ETH)">
@@ -981,7 +994,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-GS-Bt1">
-                                <rect key="frame" x="14" y="3019" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3066" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Get Status (SOL)">
@@ -994,7 +1007,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-APS-Bt1">
-                                <rect key="frame" x="14" y="3069" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3116" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Approve &amp; Submit">
@@ -1007,7 +1020,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-RVS-Bt1">
-                                <rect key="frame" x="14" y="3119" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3166" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Revoke &amp; Submit">
@@ -1020,7 +1033,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-TRS-Bt1">
-                                <rect key="frame" x="14" y="3169" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3216" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Transfer &amp; Submit">
@@ -1033,7 +1046,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EVM-7702-Bt1">
-                                <rect key="frame" x="14" y="3243" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3290" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="EVM Account getStatus">
@@ -1046,7 +1059,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pGp-Ux-Xpk">
-                                <rect key="frame" x="15" y="3290" width="339" height="39"/>
+                                <rect key="frame" x="15" y="3337" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Upgrade AA to EIP7702">
@@ -1059,7 +1072,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EVM-GA-Bt1">
-                                <rect key="frame" x="14" y="3337" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3384" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="EVM Account getAddresses">
@@ -1072,7 +1085,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bnc-SA-Bt1">
-                                <rect key="frame" x="14" y="3417" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3464" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Benchmark Send Asset (10x)">
@@ -1085,7 +1098,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bnc-PS-Bt1">
-                                <rect key="frame" x="14" y="3465" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3512" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Benchmark Personal Sign (10x)">
@@ -1112,21 +1125,21 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Benchmark" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bnc-Lbl-1a">
-                                <rect key="frame" x="132" y="3388" width="171" height="21"/>
+                                <rect key="frame" x="132" y="3435" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Noah Ramps" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-Lb-Bt1">
-                                <rect key="frame" x="99" y="3523" width="171" height="21"/>
+                                <rect key="frame" x="99" y="3570" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-IK-Bt1">
-                                <rect key="frame" x="14" y="3556" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3603" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Initiate KYC">
@@ -1139,7 +1152,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-IP-Bt1">
-                                <rect key="frame" x="14" y="3606" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3653" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Initiate Payin">
@@ -1152,7 +1165,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-SP-Bt1">
-                                <rect key="frame" x="14" y="3656" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3703" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Simulate Payin">
@@ -1165,7 +1178,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-PM-Bt1">
-                                <rect key="frame" x="14" y="3706" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3753" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Get Payment Methods">
@@ -1178,7 +1191,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-PC-Bt1">
-                                <rect key="frame" x="14" y="3756" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3803" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Get Payout Countries">
@@ -1191,7 +1204,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-CH-Bt1">
-                                <rect key="frame" x="14" y="3806" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3853" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Get Payout Channels">
@@ -1204,7 +1217,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-CF-Bt1">
-                                <rect key="frame" x="14" y="3856" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3903" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Get Channel Form">
@@ -1217,7 +1230,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-QT-Bt1">
-                                <rect key="frame" x="14" y="3906" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3953" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Get Payout Quote">
@@ -1230,7 +1243,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-PO-Bt1">
-                                <rect key="frame" x="14" y="3956" width="339" height="39"/>
+                                <rect key="frame" x="14" y="4003" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Initiate Payout">

--- a/SPM Example/PortalSwift/Base.lproj/Main.storyboard
+++ b/SPM Example/PortalSwift/Base.lproj/Main.storyboard
@@ -288,7 +288,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4ip-nJ-KlN">
-                                <rect key="frame" x="14" y="949" width="343" height="35"/>
+                                <rect key="frame" x="14" y="992" width="343" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Solana Send Trx">
@@ -314,13 +314,13 @@
                                 </connections>
                             </button>
                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="https://lab.web3modal.com/library/ethers-all/" borderStyle="roundedRect" placeholder="URL" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5Yb-DH-Pnv" userLabel="Username">
-                                <rect key="frame" x="14" y="992" width="343" height="34"/>
+                                <rect key="frame" x="14" y="1035" width="343" height="34"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qcu-G8-SAB">
-                                <rect key="frame" x="14" y="1034" width="343" height="35"/>
+                                <rect key="frame" x="14" y="1077" width="343" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Dapp Browser">
@@ -333,7 +333,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="portalConnectButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Oix-QY-d5L" userLabel="Discover Yields Button">
-                                <rect key="frame" x="12" y="1078" width="345" height="35"/>
+                                <rect key="frame" x="12" y="1121" width="345" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Portal Connect">
@@ -346,7 +346,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="discoverYieldsButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KOk-ae-1Rq">
-                                <rect key="frame" x="15" y="1449" width="152" height="35"/>
+                                <rect key="frame" x="15" y="1492" width="152" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Discover Yields">
@@ -359,7 +359,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="enterYieldButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="d4M-Fz-xPZ">
-                                <rect key="frame" x="205" y="1449" width="152" height="35"/>
+                                <rect key="frame" x="205" y="1492" width="152" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Enter Yield">
@@ -372,7 +372,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="getYieldPositionButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3Kv-vO-rEF">
-                                <rect key="frame" x="16" y="1492" width="339" height="35"/>
+                                <rect key="frame" x="16" y="1535" width="339" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Get Yield Position">
@@ -385,7 +385,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="manageYieldButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9QG-3B-yfJ">
-                                <rect key="frame" x="16" y="1535" width="152" height="35"/>
+                                <rect key="frame" x="16" y="1578" width="152" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Manage Yield">
@@ -398,7 +398,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="yieldDepositButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yd1-Dp-aa1">
-                                <rect key="frame" x="15" y="1578" width="152" height="35"/>
+                                <rect key="frame" x="15" y="1621" width="152" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Yield Deposit">
@@ -411,7 +411,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="yieldWithdrawButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yw1-Wd-bb2">
-                                <rect key="frame" x="205" y="1578" width="152" height="35"/>
+                                <rect key="frame" x="205" y="1621" width="152" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Yield Withdraw">
@@ -424,7 +424,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="yieldGetValidatorsButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yv1-Gv-cc3">
-                                <rect key="frame" x="16" y="1621" width="339" height="35"/>
+                                <rect key="frame" x="16" y="1664" width="339" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Yield Get Validators">
@@ -437,7 +437,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="nftsTrxsBalancesButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zxl-zt-jSZ">
-                                <rect key="frame" x="14" y="1121" width="342" height="35"/>
+                                <rect key="frame" x="14" y="1164" width="342" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="API Methods">
@@ -450,7 +450,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="transactionDetailsButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tDt-Qx-7kL">
-                                <rect key="frame" x="14" y="1164" width="342" height="35"/>
+                                <rect key="frame" x="14" y="1207" width="342" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Get Transaction Details">
@@ -476,7 +476,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="ejectButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xhu-mS-abX">
-                                <rect key="frame" x="14" y="1207" width="342" height="35"/>
+                                <rect key="frame" x="14" y="1250" width="342" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Eject Ethereum with Password">
@@ -497,7 +497,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="ejectAllButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V5k-BN-vvY">
-                                <rect key="frame" x="15" y="1250" width="342" height="35"/>
+                                <rect key="frame" x="15" y="1293" width="342" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Eject All with Password">
@@ -510,7 +510,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hXu-Hw-ELJ">
-                                <rect key="frame" x="15" y="1351" width="342" height="41"/>
+                                <rect key="frame" x="15" y="1394" width="342" height="41"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Generate Solana and backup shares">
@@ -549,7 +549,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="edD-nv-uVc">
-                                <rect key="frame" x="17" y="1400" width="342" height="41"/>
+                                <rect key="frame" x="17" y="1443" width="342" height="41"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="ETH Provider Helper Method">
@@ -575,7 +575,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sUo-7k-Qp3">
-                                <rect key="frame" x="16" y="907" width="343" height="35"/>
+                                <rect key="frame" x="16" y="949" width="343" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Sign UserOperation - AA">
@@ -588,7 +588,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RIl-6u-QAe">
-                                <rect key="frame" x="14" y="1811" width="339" height="39"/>
+                                <rect key="frame" x="14" y="1854" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Deprecated Swap">
@@ -601,7 +601,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3wx-Nc-CEh">
-                                <rect key="frame" x="14" y="1858" width="339" height="39"/>
+                                <rect key="frame" x="14" y="1901" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Test ZeroX Trading">
@@ -614,7 +614,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vdB-AW-DWU">
-                                <rect key="frame" x="14" y="1905" width="339" height="39"/>
+                                <rect key="frame" x="14" y="1948" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="ZeroX Get Sources">
@@ -627,7 +627,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XPc-NC-pP2">
-                                <rect key="frame" x="14" y="1952" width="339" height="39"/>
+                                <rect key="frame" x="14" y="1995" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="ZeroX Get Quote">
@@ -653,7 +653,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="exitYieldButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sja-sf-HVJ">
-                                <rect key="frame" x="203" y="1535" width="152" height="35"/>
+                                <rect key="frame" x="203" y="1578" width="152" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Exit Yield">
@@ -666,7 +666,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ePx-1g-j7r">
-                                <rect key="frame" x="14" y="1293" width="160" height="41"/>
+                                <rect key="frame" x="14" y="1336" width="160" height="41"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Send Asset (ETH)">
@@ -680,7 +680,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="getAQuoteButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pKT-gV-Hpo">
-                                <rect key="frame" x="15" y="1670" width="339" height="39"/>
+                                <rect key="frame" x="15" y="1713" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Get Trading Quote + Sign">
@@ -693,7 +693,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="getRoutesButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gRt-1s-Btn">
-                                <rect key="frame" x="15" y="1717" width="339" height="39"/>
+                                <rect key="frame" x="15" y="1760" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Get Routes">
@@ -706,7 +706,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="testGasSponsor" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NoB-qq-VG2">
-                                <rect key="frame" x="14" y="1764" width="339" height="39"/>
+                                <rect key="frame" x="14" y="1807" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Test Gas Sponsor - 6 test cases">
@@ -719,7 +719,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="058-vH-XLY">
-                                <rect key="frame" x="15" y="1999" width="339" height="39"/>
+                                <rect key="frame" x="15" y="2042" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="ZeroX Price Check">
@@ -732,7 +732,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hyn-Tx-Sc1">
-                                <rect key="frame" x="15" y="2080" width="339" height="39"/>
+                                <rect key="frame" x="15" y="2123" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Hypernative Scan Tx">
@@ -745,7 +745,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hyn-Ad-Sc1">
-                                <rect key="frame" x="15" y="2127" width="339" height="39"/>
+                                <rect key="frame" x="15" y="2170" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Hypernative Scan Addresses">
@@ -758,7 +758,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hyn-Nf-Sc1">
-                                <rect key="frame" x="15" y="2174" width="339" height="39"/>
+                                <rect key="frame" x="15" y="2217" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Hypernative Scan NFTs">
@@ -771,7 +771,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hyn-Tk-Sc1">
-                                <rect key="frame" x="15" y="2221" width="339" height="39"/>
+                                <rect key="frame" x="15" y="2264" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Hypernative Scan Tokens">
@@ -784,7 +784,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hyn-Ur-Sc1">
-                                <rect key="frame" x="15" y="2268" width="339" height="39"/>
+                                <rect key="frame" x="15" y="2311" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Hypernative Scan URL">
@@ -797,21 +797,21 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Hypernative - Security" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="G8W-ZF-6Ea">
-                                <rect key="frame" x="99" y="2051" width="171" height="21"/>
+                                <rect key="frame" x="99" y="2094" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Blockaid - Security" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-Lbl-1a">
-                                <rect key="frame" x="99" y="2319" width="171" height="21"/>
+                                <rect key="frame" x="99" y="2362" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-EV-Sc1">
-                                <rect key="frame" x="14" y="2344" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2387" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Blockaid Scan EVM Tx">
@@ -824,7 +824,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-So-Sc1">
-                                <rect key="frame" x="14" y="2391" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2434" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Blockaid Scan Solana Tx">
@@ -837,7 +837,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-Ad-Sc1">
-                                <rect key="frame" x="14" y="2438" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2481" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Blockaid Scan Address">
@@ -850,7 +850,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-Tk-Sc1">
-                                <rect key="frame" x="14" y="2485" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2528" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Blockaid Scan Tokens">
@@ -863,7 +863,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-Ur-Sc1">
-                                <rect key="frame" x="14" y="2532" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2575" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Blockaid Scan URL">
@@ -876,21 +876,21 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Delegations" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Del-Lbl-1a">
-                                <rect key="frame" x="99" y="2593" width="171" height="21"/>
+                                <rect key="frame" x="99" y="2636" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Upgarade to 7702" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lOv-mm-Fuc">
-                                <rect key="frame" x="106" y="3023" width="171" height="21"/>
+                                <rect key="frame" x="106" y="3216" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-AE-Bt1">
-                                <rect key="frame" x="14" y="2626" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2669" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Approve (ETH)">
@@ -903,7 +903,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-AS-Bt1">
-                                <rect key="frame" x="14" y="2676" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2719" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Approve (SOL)">
@@ -916,7 +916,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-RE-Bt1">
-                                <rect key="frame" x="14" y="2726" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2769" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Revoke (ETH)">
@@ -929,7 +929,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-RS-Bt1">
-                                <rect key="frame" x="14" y="2776" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2819" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Revoke (SOL)">
@@ -942,7 +942,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-TE-Bt1">
-                                <rect key="frame" x="14" y="2826" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2869" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation TransferFrom (ETH)">
@@ -955,7 +955,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-TS-Bt1">
-                                <rect key="frame" x="14" y="2876" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2919" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation TransferFrom (SOL)">
@@ -968,7 +968,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-GE-Bt1">
-                                <rect key="frame" x="14" y="2926" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2969" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Get Status (ETH)">
@@ -981,7 +981,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-GS-Bt1">
-                                <rect key="frame" x="14" y="2976" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3019" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Get Status (SOL)">
@@ -993,8 +993,47 @@
                                     <action selector="delegationGetStatusSOL:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Del-GS-Ac1"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-APS-Bt1">
+                                <rect key="frame" x="14" y="3069" width="339" height="39"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Delegation Approve &amp; Submit">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="delegationApproveAndSubmit:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Del-APS-Ac1"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-RVS-Bt1">
+                                <rect key="frame" x="14" y="3119" width="339" height="39"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Delegation Revoke &amp; Submit">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="delegationRevokeAndSubmit:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Del-RVS-Ac1"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-TRS-Bt1">
+                                <rect key="frame" x="14" y="3169" width="339" height="39"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Delegation Transfer &amp; Submit">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="delegationTransferAndSubmit:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Del-TRS-Ac1"/>
+                                </connections>
+                            </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EVM-7702-Bt1">
-                                <rect key="frame" x="14" y="3050" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3243" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="EVM Account getStatus">
@@ -1007,7 +1046,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pGp-Ux-Xpk">
-                                <rect key="frame" x="15" y="3097" width="339" height="39"/>
+                                <rect key="frame" x="15" y="3290" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Upgrade AA to EIP7702">
@@ -1020,7 +1059,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EVM-GA-Bt1">
-                                <rect key="frame" x="14" y="3144" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3337" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="EVM Account getAddresses">
@@ -1033,7 +1072,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bnc-SA-Bt1">
-                                <rect key="frame" x="14" y="3224" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3417" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Benchmark Send Asset (10x)">
@@ -1046,7 +1085,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bnc-PS-Bt1">
-                                <rect key="frame" x="14" y="3272" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3465" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Benchmark Personal Sign (10x)">
@@ -1059,7 +1098,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="weH-pZ-F1n">
-                                <rect key="frame" x="182" y="1293" width="172" height="41"/>
+                                <rect key="frame" x="182" y="1336" width="172" height="41"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Receive Asset (ETH)">
@@ -1073,21 +1112,21 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Benchmark" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bnc-Lbl-1a">
-                                <rect key="frame" x="132" y="3195" width="171" height="21"/>
+                                <rect key="frame" x="132" y="3388" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Noah Ramps" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-Lb-Bt1">
-                                <rect key="frame" x="99" y="3330" width="171" height="21"/>
+                                <rect key="frame" x="99" y="3523" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-IK-Bt1">
-                                <rect key="frame" x="14" y="3363" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3556" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Initiate KYC">
@@ -1100,7 +1139,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-IP-Bt1">
-                                <rect key="frame" x="14" y="3413" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3606" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Initiate Payin">
@@ -1113,7 +1152,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-SP-Bt1">
-                                <rect key="frame" x="14" y="3463" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3656" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Simulate Payin">
@@ -1126,7 +1165,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-PM-Bt1">
-                                <rect key="frame" x="14" y="3513" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3706" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Get Payment Methods">
@@ -1139,7 +1178,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-PC-Bt1">
-                                <rect key="frame" x="14" y="3563" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3756" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Get Payout Countries">
@@ -1152,7 +1191,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-CH-Bt1">
-                                <rect key="frame" x="14" y="3613" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3806" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Get Payout Channels">
@@ -1165,7 +1204,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-CF-Bt1">
-                                <rect key="frame" x="14" y="3663" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3856" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Get Channel Form">
@@ -1178,7 +1217,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-QT-Bt1">
-                                <rect key="frame" x="14" y="3713" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3906" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Get Payout Quote">
@@ -1191,7 +1230,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-PO-Bt1">
-                                <rect key="frame" x="14" y="3763" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3956" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Initiate Payout">
@@ -1211,7 +1250,7 @@
                             </mask>
                         </variation>
                     </scrollView>
-                    <size key="freeformSize" width="375" height="3850"/>
+                    <size key="freeformSize" width="375" height="4043"/>
                     <connections>
                         <outlet property="addressInformation" destination="0fE-Dt-jQE" id="FgG-eb-2eu"/>
                         <outlet property="dappBrowserButton" destination="qcu-G8-SAB" id="A5q-1k-dxD"/>

--- a/SPM Example/PortalSwift/Base.lproj/Main.storyboard
+++ b/SPM Example/PortalSwift/Base.lproj/Main.storyboard
@@ -17,7 +17,7 @@
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
                     </layoutGuides>
                     <scrollView key="view" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="mainViewController" id="kh9-bI-dsS">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="3244"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="3628"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WxW-BK-2tM">
@@ -397,6 +397,45 @@
                                     <action selector="handleManageYield" destination="vXZ-lx-hvc" eventType="touchUpInside" id="xzI-Wb-rqs"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="yieldDepositButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yd1-Dp-aa1">
+                                <rect key="frame" x="15" y="1578" width="152" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Yield Deposit">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" red="0.027450980390000001" green="0.054901960780000002" blue="0.086274509799999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="handleYieldDeposit" destination="vXZ-lx-hvc" eventType="touchUpInside" id="yd1-Ac-aa1"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="yieldWithdrawButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yw1-Wd-bb2">
+                                <rect key="frame" x="205" y="1578" width="152" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Yield Withdraw">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" red="0.027450980390000001" green="0.054901960780000002" blue="0.086274509799999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="handleYieldWithdraw" destination="vXZ-lx-hvc" eventType="touchUpInside" id="yw1-Ac-bb2"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="yieldGetValidatorsButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yv1-Gv-cc3">
+                                <rect key="frame" x="16" y="1621" width="339" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Yield Get Validators">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" red="0.027450980390000001" green="0.054901960780000002" blue="0.086274509799999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="handleYieldGetValidators" destination="vXZ-lx-hvc" eventType="touchUpInside" id="yv1-Ac-cc3"/>
+                                </connections>
+                            </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="nftsTrxsBalancesButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zxl-zt-jSZ">
                                 <rect key="frame" x="14" y="1121" width="342" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -549,7 +588,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RIl-6u-QAe">
-                                <rect key="frame" x="14" y="1717" width="339" height="39"/>
+                                <rect key="frame" x="14" y="1811" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Deprecated Swap">
@@ -562,7 +601,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3wx-Nc-CEh">
-                                <rect key="frame" x="14" y="1764" width="339" height="39"/>
+                                <rect key="frame" x="14" y="1858" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Test ZeroX Trading">
@@ -575,7 +614,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vdB-AW-DWU">
-                                <rect key="frame" x="14" y="1811" width="339" height="39"/>
+                                <rect key="frame" x="14" y="1905" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="ZeroX Get Sources">
@@ -588,7 +627,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XPc-NC-pP2">
-                                <rect key="frame" x="14" y="1858" width="339" height="39"/>
+                                <rect key="frame" x="14" y="1952" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="ZeroX Get Quote">
@@ -641,7 +680,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="getAQuoteButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pKT-gV-Hpo">
-                                <rect key="frame" x="15" y="1576" width="339" height="39"/>
+                                <rect key="frame" x="15" y="1670" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Get Trading Quote + Sign">
@@ -654,7 +693,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="getRoutesButton" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gRt-1s-Btn">
-                                <rect key="frame" x="15" y="1623" width="339" height="39"/>
+                                <rect key="frame" x="15" y="1717" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Get Routes">
@@ -667,7 +706,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="testGasSponsor" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NoB-qq-VG2">
-                                <rect key="frame" x="14" y="1670" width="339" height="39"/>
+                                <rect key="frame" x="14" y="1764" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Test Gas Sponsor - 6 test cases">
@@ -680,7 +719,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="058-vH-XLY">
-                                <rect key="frame" x="15" y="1905" width="339" height="39"/>
+                                <rect key="frame" x="15" y="1999" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="ZeroX Price Check">
@@ -693,7 +732,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hyn-Tx-Sc1">
-                                <rect key="frame" x="15" y="1986" width="339" height="39"/>
+                                <rect key="frame" x="15" y="2080" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Hypernative Scan Tx">
@@ -706,7 +745,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hyn-Ad-Sc1">
-                                <rect key="frame" x="15" y="2033" width="339" height="39"/>
+                                <rect key="frame" x="15" y="2127" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Hypernative Scan Addresses">
@@ -719,7 +758,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hyn-Nf-Sc1">
-                                <rect key="frame" x="15" y="2080" width="339" height="39"/>
+                                <rect key="frame" x="15" y="2174" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Hypernative Scan NFTs">
@@ -732,7 +771,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hyn-Tk-Sc1">
-                                <rect key="frame" x="15" y="2127" width="339" height="39"/>
+                                <rect key="frame" x="15" y="2221" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Hypernative Scan Tokens">
@@ -745,7 +784,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hyn-Ur-Sc1">
-                                <rect key="frame" x="15" y="2174" width="339" height="39"/>
+                                <rect key="frame" x="15" y="2268" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Hypernative Scan URL">
@@ -758,21 +797,21 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Hypernative - Security" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="G8W-ZF-6Ea">
-                                <rect key="frame" x="99" y="1957" width="171" height="21"/>
+                                <rect key="frame" x="99" y="2051" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Blockaid - Security" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-Lbl-1a">
-                                <rect key="frame" x="99" y="2225" width="171" height="21"/>
+                                <rect key="frame" x="99" y="2319" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-EV-Sc1">
-                                <rect key="frame" x="14" y="2250" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2344" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Blockaid Scan EVM Tx">
@@ -785,7 +824,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-So-Sc1">
-                                <rect key="frame" x="14" y="2297" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2391" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Blockaid Scan Solana Tx">
@@ -798,7 +837,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-Ad-Sc1">
-                                <rect key="frame" x="14" y="2344" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2438" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Blockaid Scan Address">
@@ -811,7 +850,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-Tk-Sc1">
-                                <rect key="frame" x="14" y="2391" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2485" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Blockaid Scan Tokens">
@@ -824,7 +863,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Blk-Ur-Sc1">
-                                <rect key="frame" x="14" y="2438" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2532" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Blockaid Scan URL">
@@ -837,21 +876,21 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Delegations" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Del-Lbl-1a">
-                                <rect key="frame" x="99" y="2499" width="171" height="21"/>
+                                <rect key="frame" x="99" y="2593" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Upgarade to 7702" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lOv-mm-Fuc">
-                                <rect key="frame" x="106" y="2929" width="171" height="21"/>
+                                <rect key="frame" x="106" y="3023" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-AE-Bt1">
-                                <rect key="frame" x="14" y="2532" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2626" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Approve (ETH)">
@@ -864,7 +903,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-AS-Bt1">
-                                <rect key="frame" x="14" y="2582" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2676" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Approve (SOL)">
@@ -877,7 +916,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-RE-Bt1">
-                                <rect key="frame" x="14" y="2632" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2726" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Revoke (ETH)">
@@ -890,7 +929,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-RS-Bt1">
-                                <rect key="frame" x="14" y="2682" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2776" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Revoke (SOL)">
@@ -903,7 +942,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-TE-Bt1">
-                                <rect key="frame" x="14" y="2732" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2826" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation TransferFrom (ETH)">
@@ -916,7 +955,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-TS-Bt1">
-                                <rect key="frame" x="14" y="2782" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2876" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation TransferFrom (SOL)">
@@ -929,7 +968,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-GE-Bt1">
-                                <rect key="frame" x="14" y="2832" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2926" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Get Status (ETH)">
@@ -942,7 +981,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Del-GS-Bt1">
-                                <rect key="frame" x="14" y="2882" width="339" height="39"/>
+                                <rect key="frame" x="14" y="2976" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Delegation Get Status (SOL)">
@@ -955,7 +994,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EVM-7702-Bt1">
-                                <rect key="frame" x="14" y="2956" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3050" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="EVM Account getStatus">
@@ -968,7 +1007,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pGp-Ux-Xpk">
-                                <rect key="frame" x="15" y="3003" width="339" height="39"/>
+                                <rect key="frame" x="15" y="3097" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Upgrade AA to EIP7702">
@@ -981,7 +1020,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EVM-GA-Bt1">
-                                <rect key="frame" x="14" y="3050" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3144" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="EVM Account getAddresses">
@@ -994,7 +1033,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bnc-SA-Bt1">
-                                <rect key="frame" x="14" y="3130" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3224" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Benchmark Send Asset (10x)">
@@ -1007,7 +1046,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bnc-PS-Bt1">
-                                <rect key="frame" x="14" y="3178" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3272" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Benchmark Personal Sign (10x)">
@@ -1034,21 +1073,21 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Benchmark" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bnc-Lbl-1a">
-                                <rect key="frame" x="132" y="3101" width="171" height="21"/>
+                                <rect key="frame" x="132" y="3195" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Noah Ramps" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-Lb-Bt1">
-                                <rect key="frame" x="99" y="3243" width="171" height="21"/>
+                                <rect key="frame" x="99" y="3330" width="171" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-IK-Bt1">
-                                <rect key="frame" x="14" y="3276" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3363" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Initiate KYC">
@@ -1061,7 +1100,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-IP-Bt1">
-                                <rect key="frame" x="14" y="3326" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3413" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Initiate Payin">
@@ -1074,7 +1113,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-SP-Bt1">
-                                <rect key="frame" x="14" y="3376" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3463" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Simulate Payin">
@@ -1087,7 +1126,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-PM-Bt1">
-                                <rect key="frame" x="14" y="3426" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3513" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Get Payment Methods">
@@ -1100,7 +1139,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-PC-Bt1">
-                                <rect key="frame" x="14" y="3476" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3563" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Get Payout Countries">
@@ -1113,7 +1152,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-CH-Bt1">
-                                <rect key="frame" x="14" y="3526" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3613" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Get Payout Channels">
@@ -1126,7 +1165,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-CF-Bt1">
-                                <rect key="frame" x="14" y="3576" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3663" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Get Channel Form">
@@ -1139,7 +1178,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-QT-Bt1">
-                                <rect key="frame" x="14" y="3626" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3713" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Get Payout Quote">
@@ -1152,7 +1191,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-PO-Bt1">
-                                <rect key="frame" x="14" y="3676" width="339" height="39"/>
+                                <rect key="frame" x="14" y="3763" width="339" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Noah Initiate Payout">
@@ -1172,7 +1211,7 @@
                             </mask>
                         </variation>
                     </scrollView>
-                    <size key="freeformSize" width="375" height="3742"/>
+                    <size key="freeformSize" width="375" height="3850"/>
                     <connections>
                         <outlet property="addressInformation" destination="0fE-Dt-jQE" id="FgG-eb-2eu"/>
                         <outlet property="dappBrowserButton" destination="qcu-G8-SAB" id="A5q-1k-dxD"/>
@@ -1221,7 +1260,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="93.599999999999994" y="466.86656671664173"/>
+            <point key="canvasLocation" x="93.599999999999994" y="629.68515742128943"/>
         </scene>
         <!--Web View Controller-->
         <scene sceneID="AeA-zC-7Sc">

--- a/SPM Example/PortalSwift/Base.lproj/Main.storyboard
+++ b/SPM Example/PortalSwift/Base.lproj/Main.storyboard
@@ -1040,6 +1040,130 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Noah Ramps" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-Lb-Bt1">
+                                <rect key="frame" x="99" y="3243" width="171" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-IK-Bt1">
+                                <rect key="frame" x="14" y="3276" width="339" height="39"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Noah Initiate KYC">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="noahInitiateKyc:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Noh-IK-Ac1"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-IP-Bt1">
+                                <rect key="frame" x="14" y="3326" width="339" height="39"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Noah Initiate Payin">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="noahInitiatePayin:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Noh-IP-Ac1"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-SP-Bt1">
+                                <rect key="frame" x="14" y="3376" width="339" height="39"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Noah Simulate Payin">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="noahSimulatePayin:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Noh-SP-Ac1"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-PM-Bt1">
+                                <rect key="frame" x="14" y="3426" width="339" height="39"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Noah Get Payment Methods">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="noahGetPaymentMethods:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Noh-PM-Ac1"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-PC-Bt1">
+                                <rect key="frame" x="14" y="3476" width="339" height="39"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Noah Get Payout Countries">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="noahGetPayoutCountries:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Noh-PC-Ac1"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-CH-Bt1">
+                                <rect key="frame" x="14" y="3526" width="339" height="39"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Noah Get Payout Channels">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="noahGetPayoutChannels:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Noh-CH-Ac1"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-CF-Bt1">
+                                <rect key="frame" x="14" y="3576" width="339" height="39"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Noah Get Channel Form">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="noahGetPayoutChannelForm:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Noh-CF-Ac1"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-QT-Bt1">
+                                <rect key="frame" x="14" y="3626" width="339" height="39"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Noah Get Payout Quote">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="noahGetPayoutQuote:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Noh-QT-Ac1"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Noh-PO-Bt1">
+                                <rect key="frame" x="14" y="3676" width="339" height="39"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Noah Initiate Payout">
+                                    <backgroundConfiguration key="background"/>
+                                    <color key="baseForegroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="baseBackgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="noahInitiatePayout:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Noh-PO-Ac1"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <variation key="default">
@@ -1048,7 +1172,7 @@
                             </mask>
                         </variation>
                     </scrollView>
-                    <size key="freeformSize" width="375" height="3244"/>
+                    <size key="freeformSize" width="375" height="3742"/>
                     <connections>
                         <outlet property="addressInformation" destination="0fE-Dt-jQE" id="FgG-eb-2eu"/>
                         <outlet property="dappBrowserButton" destination="qcu-G8-SAB" id="A5q-1k-dxD"/>

--- a/SPM Example/PortalSwift/MainViewController/ViewController+Delegations.swift
+++ b/SPM Example/PortalSwift/MainViewController/ViewController+Delegations.swift
@@ -291,6 +291,134 @@ extension ViewController {
     }
   }
 
+  // MARK: - Delegation Approve & Submit (high-level)
+
+  @IBAction func delegationApproveAndSubmit(_: Any) {
+    startLoading()
+
+    Task { @MainActor in
+      defer { stopLoading() }
+
+      guard let portal = portal else {
+        logger.error("❌ [Delegation Approve & Submit] Portal not initialized")
+        showStatusView(message: "\(failureStatus) Portal not initialized")
+        return
+      }
+
+      do {
+        logger.info("📝 [Delegation Approve & Submit] Starting...")
+
+        let request = ApproveDelegationRequest(
+          chain: "eip155:10143",
+          token: "USDC",
+          delegateAddress: "0xf83f7449fb81332c4f37834182cdcb5dd6ea47db",
+          amount: "0.01"
+        )
+
+        let result = try await portal.delegations.approveAndSubmit(
+          request: request,
+          options: DelegationSubmitOptions(onProgress: logDelegationProgress)
+        )
+
+        logger.info("✅ [Delegation Approve & Submit] Broadcasted \(result.hashes.count) tx(s): \(result.hashes)")
+        showStatusView(message: "\(successStatus) Approve & Submit completed: \(result.hashes)")
+
+      } catch {
+        logger.error("❌ [Delegation Approve & Submit] Error: \(error.localizedDescription)")
+        showStatusView(message: "\(failureStatus) Approve & Submit failed: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  // MARK: - Delegation Revoke & Submit (high-level)
+
+  @IBAction func delegationRevokeAndSubmit(_: Any) {
+    startLoading()
+
+    Task { @MainActor in
+      defer { stopLoading() }
+
+      guard let portal = portal else {
+        logger.error("❌ [Delegation Revoke & Submit] Portal not initialized")
+        showStatusView(message: "\(failureStatus) Portal not initialized")
+        return
+      }
+
+      do {
+        logger.info("📝 [Delegation Revoke & Submit] Starting...")
+
+        let request = RevokeDelegationRequest(
+          chain: "eip155:10143",
+          token: "USDC",
+          delegateAddress: "0xf83f7449fb81332c4f37834182cdcb5dd6ea47db"
+        )
+
+        let result = try await portal.delegations.revokeAndSubmit(
+          request: request,
+          options: DelegationSubmitOptions(onProgress: logDelegationProgress)
+        )
+
+        logger.info("✅ [Delegation Revoke & Submit] Broadcasted \(result.hashes.count) tx(s): \(result.hashes)")
+        showStatusView(message: "\(successStatus) Revoke & Submit completed: \(result.hashes)")
+
+      } catch {
+        logger.error("❌ [Delegation Revoke & Submit] Error: \(error.localizedDescription)")
+        showStatusView(message: "\(failureStatus) Revoke & Submit failed: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  // MARK: - Delegation Transfer & Submit (high-level)
+
+  @IBAction func delegationTransferAndSubmit(_: Any) {
+    startLoading()
+
+    Task { @MainActor in
+      defer { stopLoading() }
+
+      guard let portal = portal else {
+        logger.error("❌ [Delegation Transfer & Submit] Portal not initialized")
+        showStatusView(message: "\(failureStatus) Portal not initialized")
+        return
+      }
+
+      do {
+        logger.info("📝 [Delegation Transfer & Submit] Starting...")
+        logger.info("ℹ️ NOTE: This must be called from the delegate's client account")
+
+        let request = TransferFromRequest(
+          chain: "eip155:10143",
+          token: "USDC",
+          fromAddress: "0xad9c2b19c9b24b11d3a458121a53f211abe0db31",
+          toAddress: "0xdFd8302f44727A6348F702fF7B594f127dE3A902",
+          amount: "0.01"
+        )
+
+        let result = try await portal.delegations.transferAndSubmit(
+          request: request,
+          options: DelegationSubmitOptions(onProgress: logDelegationProgress)
+        )
+
+        logger.info("✅ [Delegation Transfer & Submit] Broadcasted \(result.hashes.count) tx(s): \(result.hashes)")
+        showStatusView(message: "\(successStatus) Transfer & Submit completed: \(result.hashes)")
+
+      } catch {
+        logger.error("❌ [Delegation Transfer & Submit] Error: \(error.localizedDescription)")
+        showStatusView(message: "\(failureStatus) Transfer & Submit failed: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  /// Logs a high-level delegation submit progress event.
+  private func logDelegationProgress(_ event: DelegationSubmitProgress) {
+    switch event.step {
+    case .signing:
+      logger.info("✍️ [Delegation Submit] Signing tx \(event.index + 1)/\(event.total)...")
+    case .submitted:
+      logger.info("✅ [Delegation Submit] Submitted tx \(event.index + 1)/\(event.total): \(event.hash ?? "")")
+    }
+  }
+
   // MARK: - Delegation Get Status (ETH)
 
   @IBAction func delegationGetStatusETH(_: Any) {
@@ -311,7 +439,7 @@ extension ViewController {
         let request = GetDelegationStatusRequest(
           chain: "eip155:10143",
           token: "USDC",
-          delegateAddress: "0xa944e86eb36f039becd1843132347eb5b8501562"
+          delegateAddress: "0xf83f7449fb81332c4f37834182cdcb5dd6ea47db"
         )
 
         let response = try await portal.delegations.getStatus(request: request)

--- a/SPM Example/PortalSwift/MainViewController/ViewController+Noah.swift
+++ b/SPM Example/PortalSwift/MainViewController/ViewController+Noah.swift
@@ -1,0 +1,485 @@
+//
+//  ViewController+Noah.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+//  Noah on/off-ramp testing functionality
+//
+
+import AnyCodable
+import Foundation
+import PortalSwift
+import UIKit
+
+@available(iOS 16.0, *)
+extension ViewController {
+  // MARK: - Noah Initiate KYC
+
+  @IBAction func noahInitiateKyc(_: Any) {
+    startLoading()
+
+    Task { @MainActor in
+      defer { stopLoading() }
+
+      guard let portal = portal else {
+        logger.error("❌ [Noah Initiate KYC] Portal not initialized")
+        showStatusView(message: "\(failureStatus) Portal not initialized")
+        return
+      }
+
+      do {
+        logger.info("📝 [Noah Initiate KYC] Starting KYC flow...")
+
+        let request = NoahInitiateKycRequest(
+          returnUrl: "https://example.com/kyc-return",
+          fiatOptions: [NoahFiatOption(fiatCurrencyCode: "USD")],
+          customerType: .individual
+        )
+
+        let response = try await portal.ramps.noah.initiateKyc(request: request)
+
+        let hostedUrl = response.data.hostedUrl
+        logger.info("✅ [Noah Initiate KYC] Hosted URL: \(hostedUrl)")
+        showStatusView(message: "\(successStatus) KYC URL ready: \(hostedUrl)")
+        presentNoahKycAlert(hostedUrl: hostedUrl)
+      } catch {
+        logger.error("❌ [Noah Initiate KYC] Error: \(error.localizedDescription)")
+        showStatusView(message: "\(failureStatus) KYC failed: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  // MARK: - Noah KYC Alert
+
+  private func presentNoahKycAlert(hostedUrl: String) {
+    let alert = UIAlertController(
+      title: "KYC Initiated",
+      message: "Noah KYC was initiated successfully. Open the verification page to continue.",
+      preferredStyle: .alert
+    )
+
+    alert.addAction(UIAlertAction(title: "Open in Safari", style: .default) { _ in
+      guard let url = URL(string: hostedUrl), UIApplication.shared.canOpenURL(url) else {
+        self.logger.error("❌ [Noah Initiate KYC] Invalid hosted URL: \(hostedUrl)")
+        return
+      }
+      UIApplication.shared.open(url)
+    })
+
+    alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+
+    present(alert, animated: true)
+  }
+
+  // MARK: - Noah Initiate Payin
+
+  @IBAction func noahInitiatePayin(_: Any) {
+    startLoading()
+
+    Task { @MainActor in
+      defer { stopLoading() }
+
+      guard let portal = portal else {
+        logger.error("❌ [Noah Initiate Payin] Portal not initialized")
+        showStatusView(message: "\(failureStatus) Portal not initialized")
+        return
+      }
+
+      do {
+        let request = NoahInitiatePayinRequest(
+          fiatCurrency: "USD",
+          cryptoCurrency: "USDC_TEST",
+          network: NoahNetwork.ethereumSepolia,
+          destinationAddress: "0x0000000000000000000000000000000000000000"
+        )
+
+        let response = try await portal.ramps.noah.initiatePayin(request: request)
+
+        let data = response.data
+        logger.info("✅ [Noah Initiate Payin] Payin ID: \(data.payinId), bank: \(data.bankDetails.bankName ?? "n/a")")
+        showStatusView(message: "\(successStatus) Payin started: \(data.payinId)")
+      } catch {
+        logger.error("❌ [Noah Initiate Payin] Error: \(error.localizedDescription)")
+        showStatusView(message: "\(failureStatus) Payin failed: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  // MARK: - Noah Simulate Payin
+
+  @IBAction func noahSimulatePayin(_: Any) {
+    startLoading()
+
+    Task { @MainActor in
+      defer { stopLoading() }
+
+      guard let portal = portal else {
+        logger.error("❌ [Noah Simulate Payin] Portal not initialized")
+        showStatusView(message: "\(failureStatus) Portal not initialized")
+        return
+      }
+
+      do {
+        // Simulate requires a real Noah-issued payment method ID. Noah only
+        // mints one when a payin (bank-deposit workflow) is initiated, so kick
+        // one off first and reuse its bank details. A placeholder ID makes Noah
+        // respond with a 404 (ResourceNotFound, "read single fiat payment method").
+        let payinRequest = NoahInitiatePayinRequest(
+          fiatCurrency: "USD",
+          cryptoCurrency: "USDC_TEST",
+          network: NoahNetwork.ethereumSepolia,
+          destinationAddress: "0x0000000000000000000000000000000000000000"
+        )
+        let payinResponse = try await portal.ramps.noah.initiatePayin(request: payinRequest)
+        let paymentMethodId = payinResponse.data.bankDetails.paymentMethodId
+        logger.info("ℹ️ [Noah Simulate Payin] Using payment method ID: \(paymentMethodId)")
+
+        let request = NoahSimulatePayinRequest(
+          paymentMethodId: paymentMethodId,
+          fiatAmount: "100.00",
+          fiatCurrency: "USD"
+        )
+
+        let response = try await portal.ramps.noah.simulatePayin(request: request)
+
+        let data = response.data
+        logger.info("✅ [Noah Simulate Payin] Fiat deposit ID: \(data.fiatDepositId)")
+        showStatusView(message: "\(successStatus) Simulated deposit: \(data.fiatDepositId)")
+      } catch {
+        logger.error("❌ [Noah Simulate Payin] Error: \(error.localizedDescription)")
+        showStatusView(message: "\(failureStatus) Simulation failed: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  // MARK: - Noah Get Payment Methods
+
+  @IBAction func noahGetPaymentMethods(_: Any) {
+    startLoading()
+
+    Task { @MainActor in
+      defer { stopLoading() }
+
+      guard let portal = portal else {
+        logger.error("❌ [Noah Get Payment Methods] Portal not initialized")
+        showStatusView(message: "\(failureStatus) Portal not initialized")
+        return
+      }
+
+      do {
+        let response = try await portal.ramps.noah.getPaymentMethods()
+
+        let data = response.data
+        logger.info("✅ [Noah Get Payment Methods] Count: \(data.paymentMethods.count)")
+        for pm in data.paymentMethods {
+          logger.info("  • \(pm.paymentMethodCategory) — id: \(pm.id), country: \(pm.country)")
+        }
+        showStatusView(message: "\(successStatus) \(data.paymentMethods.count) payment methods")
+      } catch {
+        logger.error("❌ [Noah Get Payment Methods] Error: \(error.localizedDescription)")
+        showStatusView(message: "\(failureStatus) Payment methods failed: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  // MARK: - Noah Get Payout Countries
+
+  @IBAction func noahGetPayoutCountries(_: Any) {
+    startLoading()
+
+    Task { @MainActor in
+      defer { stopLoading() }
+
+      guard let portal = portal else {
+        logger.error("❌ [Noah Get Payout Countries] Portal not initialized")
+        showStatusView(message: "\(failureStatus) Portal not initialized")
+        return
+      }
+
+      do {
+        let response = try await portal.ramps.noah.getPayoutCountries()
+
+        let data = response.data
+        logger.info("✅ [Noah Get Payout Countries] \(data.countries.count) countries")
+        for (country, currencies) in data.countries {
+          logger.info("  • \(country): \(currencies.joined(separator: ", "))")
+        }
+        showStatusView(message: "\(successStatus) \(data.countries.count) countries supported")
+      } catch {
+        logger.error("❌ [Noah Get Payout Countries] Error: \(error.localizedDescription)")
+        showStatusView(message: "\(failureStatus) Countries failed: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  // MARK: - Noah Get Payout Channels
+
+  @IBAction func noahGetPayoutChannels(_: Any) {
+    startLoading()
+
+    Task { @MainActor in
+      defer { stopLoading() }
+
+      guard let portal = portal else {
+        logger.error("❌ [Noah Get Payout Channels] Portal not initialized")
+        showStatusView(message: "\(failureStatus) Portal not initialized")
+        return
+      }
+
+      do {
+        let request = NoahGetPayoutChannelsRequest(
+          cryptoCurrency: "USDC_TEST",
+          country: "US",
+          fiatCurrency: "USD",
+          fiatAmount: "0.01"
+        )
+
+        let response = try await portal.ramps.noah.getPayoutChannels(request: request)
+
+        let data = response.data
+        logger.info("✅ [Noah Get Payout Channels] \(data.items.count) channels")
+        for channel in data.items {
+          logger.info("  • \(channel.paymentMethodCategory)/\(channel.paymentMethodType) — id: \(channel.id), rate: \(channel.rate)")
+        }
+        showStatusView(message: "\(successStatus) \(data.items.count) channels available")
+      } catch {
+        logger.error("❌ [Noah Get Payout Channels] Error: \(error.localizedDescription)")
+        showStatusView(message: "\(failureStatus) Channels failed: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  // MARK: - Noah Get Payout Channel Form
+
+  @IBAction func noahGetPayoutChannelForm(_: Any) {
+    startLoading()
+
+    Task { @MainActor in
+      defer { stopLoading() }
+
+      guard let portal = portal else {
+        logger.error("❌ [Noah Get Payout Channel Form] Portal not initialized")
+        showStatusView(message: "\(failureStatus) Portal not initialized")
+        return
+      }
+
+      do {
+        // The form endpoint requires a real channel ID. Fetch the available
+        // payout channels first and use the first one returned, otherwise Noah
+        // responds with a 404 (ResourceNotFound) for unknown channel IDs.
+        let channelsRequest = NoahGetPayoutChannelsRequest(
+          cryptoCurrency: "USDC_TEST",
+          country: "US",
+          fiatCurrency: "USD",
+          fiatAmount: "0.01"
+        )
+        let channelsResponse = try await portal.ramps.noah.getPayoutChannels(request: channelsRequest)
+
+        guard let channelId = channelsResponse.data.items.first?.id else {
+          logger.error("❌ [Noah Get Payout Channel Form] No payout channels available")
+          showStatusView(message: "\(failureStatus) No payout channels available")
+          return
+        }
+
+        logger.info("ℹ️ [Noah Get Payout Channel Form] Using channel ID: \(channelId)")
+        let response = try await portal.ramps.noah.getPayoutChannelForm(channelId: channelId)
+
+        let data = response.data
+        logger.info("✅ [Noah Get Payout Channel Form] Schema present: \(data.formSchema != nil), content hash: \(data.formMetadata?.contentHash ?? "n/a")")
+        showStatusView(message: "\(successStatus) Channel form loaded")
+      } catch {
+        logger.error("❌ [Noah Get Payout Channel Form] Error: \(error.localizedDescription)")
+        showStatusView(message: "\(failureStatus) Form failed: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  // MARK: - Noah Sample Payout Channel + Form
+
+  /// Fetches the US/USDC_TEST/USD payout channels and returns a bank channel
+  /// together with a form payload that satisfies its dynamic schema.
+  ///
+  /// Noah validates the supplied `form` against the selected channel's
+  /// JSON-Schema. The US bank channels returned for USD require
+  /// `AccountHolderName`, `AccountHolderAddress`, `BankDetails`, and
+  /// `PaymentPurpose`. `AccountHolderName` is itself an object: an
+  /// `AccountHolderType` plus a conditional `Name` (a `FirstName`/`LastName`
+  /// object for individuals). We prefer a bank channel because its schema is
+  /// known; other channels (e.g. cards) expect a different shape.
+  private func noahSampleUsdPayoutChannelAndForm(
+    portal: PortalProtocol
+  ) async throws -> (channelId: String, form: [String: AnyCodable])? {
+    let channelsRequest = NoahGetPayoutChannelsRequest(
+      cryptoCurrency: "USDC_TEST",
+      country: "US",
+      fiatCurrency: "USD",
+      fiatAmount: "0.01"
+    )
+    let channelsResponse = try await portal.ramps.noah.getPayoutChannels(request: channelsRequest)
+
+    let bankChannel = channelsResponse.data.items.first { $0.paymentMethodCategory == "Bank" }
+    guard let channel = bankChannel ?? channelsResponse.data.items.first else {
+      return nil
+    }
+
+    var bankDetails: [String: Any] = [
+      "AccountNumber": "12345678",
+      "BankCode": "123456789"
+    ]
+    // BankAch channels additionally require an AccountType.
+    if channel.paymentMethodType == "BankAch" {
+      bankDetails["AccountType"] = "Checking"
+    }
+
+    let form: [String: AnyCodable] = [
+      "AccountHolderName": AnyCodable([
+        "AccountHolderType": "Individual",
+        "Name": [
+          "FirstName": "John",
+          "LastName": "Doe"
+        ]
+      ] as [String: Any]),
+      "AccountHolderAddress": AnyCodable([
+        "Address": "123 Main Street",
+        "City": "New York",
+        "State": "NY",
+        "PostalCode": "10001"
+      ]),
+      "BankDetails": AnyCodable(bankDetails),
+      "PaymentPurpose": AnyCodable("Transfer to own account")
+    ]
+
+    return (channel.id, form)
+  }
+
+  // MARK: - Noah Get Payout Quote
+
+  @IBAction func noahGetPayoutQuote(_: Any) {
+    startLoading()
+
+    Task { @MainActor in
+      defer { stopLoading() }
+
+      guard let portal = portal else {
+        logger.error("❌ [Noah Get Payout Quote] Portal not initialized")
+        showStatusView(message: "\(failureStatus) Portal not initialized")
+        return
+      }
+
+      do {
+        // The quote endpoint requires a real channel ID (Noah expects a 36-char
+        // UUID) and validates the supplied form against the channel's dynamic
+        // schema. Fetch a bank channel plus a matching sample form, otherwise
+        // Noah rejects the request with a 400 validation error.
+        guard let (channelId, form) = try await noahSampleUsdPayoutChannelAndForm(portal: portal) else {
+          logger.error("❌ [Noah Get Payout Quote] No payout channels available")
+          showStatusView(message: "\(failureStatus) No payout channels available")
+          return
+        }
+
+        logger.info("ℹ️ [Noah Get Payout Quote] Using channel ID: \(channelId)")
+
+        let request = NoahGetPayoutQuoteRequest(
+          channelId: channelId,
+          cryptoCurrency: "USDC_TEST",
+          fiatAmount: "0.01",
+          form: form,
+          fiatCurrency: "USD"
+        )
+
+        let response = try await portal.ramps.noah.getPayoutQuote(request: request)
+
+        let data = response.data
+        logger.info("✅ [Noah Get Payout Quote] Payout ID: \(data.payoutId), fee: \(data.totalFee), crypto est.: \(data.cryptoAmountEstimate)")
+        if let nextStep = data.nextStep {
+          logger.info("  → Next form step: \(nextStep.stepId) (\(nextStep.stepType.rawValue))")
+        }
+        showStatusView(message: "\(successStatus) Quote: \(data.payoutId)")
+      } catch {
+        logger.error("❌ [Noah Get Payout Quote] Error: \(error.localizedDescription)")
+        showStatusView(message: "\(failureStatus) Quote failed: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  // MARK: - Noah Initiate Payout
+
+  @IBAction func noahInitiatePayout(_: Any) {
+    startLoading()
+
+    Task { @MainActor in
+      defer { stopLoading() }
+
+      guard let portal = portal else {
+        logger.error("❌ [Noah Initiate Payout] Portal not initialized")
+        showStatusView(message: "\(failureStatus) Portal not initialized")
+        return
+      }
+
+      do {
+        // A payout must reference a real payoutId, which is issued by the quote
+        // endpoint. Fetch a bank channel + matching form, request a quote, then
+        // use the returned payoutId. Otherwise Noah responds with a 400
+        // ("Payout not found") for an unknown payout.
+        guard let (channelId, quoteForm) = try await noahSampleUsdPayoutChannelAndForm(portal: portal) else {
+          logger.error("❌ [Noah Initiate Payout] No payout channels available")
+          showStatusView(message: "\(failureStatus) No payout channels available")
+          return
+        }
+
+        let quoteRequest = NoahGetPayoutQuoteRequest(
+          channelId: channelId,
+          cryptoCurrency: "USDC_TEST",
+          fiatAmount: "0.01",
+          form: quoteForm,
+          fiatCurrency: "USD"
+        )
+        let quoteResponse = try await portal.ramps.noah.getPayoutQuote(request: quoteRequest)
+        let payoutId = quoteResponse.data.payoutId
+        logger.info("ℹ️ [Noah Initiate Payout] Using payout ID: \(payoutId)")
+
+        // Noah requires the trigger's nonce/sourceAddress/expiry to match the
+        // top-level request values, so compute them once and reuse them.
+        let sourceAddress = "0x1111111111111111111111111111111111111111"
+        let expiry = "2099-01-01T00:00:00Z"
+        let nonce = UUID().uuidString
+
+        let trigger = NoahSingleOnchainDepositSourceTriggerInput(
+          conditions: [
+            NoahSingleOnchainDepositSourceTriggerCondition(
+              amountConditions: [
+                NoahSingleOnchainDepositSourceTriggerAmountCondition(
+                  comparisonOperator: .gteq,
+                  value: "100"
+                )
+              ],
+              network: NoahNetwork.ethereumSepolia
+            )
+          ],
+          sourceAddress: sourceAddress,
+          expiry: expiry,
+          nonce: nonce
+        )
+
+        let request = NoahInitiatePayoutRequest(
+          payoutId: payoutId,
+          sourceAddress: sourceAddress,
+          expiry: expiry,
+          nonce: nonce,
+          network: NoahNetwork.ethereumSepolia,
+          trigger: .single(trigger)
+        )
+
+        let response = try await portal.ramps.noah.initiatePayout(request: request)
+
+        let data = response.data
+        logger.info("✅ [Noah Initiate Payout] Destination: \(data.destinationAddress ?? "n/a"), conditions: \(data.conditions?.count ?? 0)")
+        showStatusView(message: "\(successStatus) Payout initiated")
+      } catch {
+        logger.error("❌ [Noah Initiate Payout] Error: \(error.localizedDescription)")
+        showStatusView(message: "\(failureStatus) Payout failed: \(error.localizedDescription)")
+      }
+    }
+  }
+}

--- a/SPM Example/PortalSwift/MainViewController/ViewController.swift
+++ b/SPM Example/PortalSwift/MainViewController/ViewController.swift
@@ -931,7 +931,8 @@ class ViewController: UIViewController, UITextFieldDelegate {
         featureFlags: FeatureFlags(
           isMultiBackupEnabled: true,
           useEnclaveMPCApi: Settings.shared.useEnclaveMPC,
-          usePresignatures: Settings.shared.usePresignatures
+          usePresignatures: Settings.shared.usePresignatures,
+          usePreGeneratedWallet: Settings.shared.usePreGeneratedWallet
         ),
         apiHost: config.apiUrl,
         mpcHost: config.mpcUrl,

--- a/SPM Example/PortalSwift/MainViewController/ViewController.swift
+++ b/SPM Example/PortalSwift/MainViewController/ViewController.swift
@@ -2494,6 +2494,90 @@ extension ViewController {
 
 @available(iOS 16.0, *)
 extension ViewController {
+  /// High-level deposit using the explicit `yieldId` mode. The wallet address is auto-resolved.
+  @IBAction func handleYieldDeposit() {
+    guard let portal = portal else {
+      self.logger.info("Portal is not initialized")
+      return
+    }
+
+    Task { @MainActor in
+      self.logger.info("Starting high-level Yield deposit...")
+      do {
+        let params = YieldDepositParams(
+          target: .yieldId("ethereum-sepolia-link-aave-v3-lending"),
+          amount: "0.0000001"
+        )
+        let options = YieldSubmitOptions(onProgress: { event in
+          let hashSuffix = event.hash.map { " \(String($0.prefix(10)))..." } ?? ""
+          let message = "Deposit: \(event.step.rawValue) (\(event.index + 1)/\(event.total))\(hashSuffix)"
+          Task { @MainActor in
+            self.showStatusView(message: message)
+          }
+        })
+        let result = try await portal.yield.yieldxyz.deposit(params: params, options: options)
+        self.logger.info("Deposit complete: \(result.hashes) status: \(result.status.rawValue)")
+        self.showStatusView(message: "\(self.successStatus) Deposit complete. \(result.hashes.count) tx(s). Yield: \(result.yieldId)")
+      } catch {
+        self.logger.error("Yield deposit FAILED: \(error.localizedDescription)")
+        self.showStatusView(message: "\(self.failureStatus) Deposit FAILED: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  /// High-level withdraw using the `chain` + `token` mode (resolves the yieldId from Portal defaults).
+  @IBAction func handleYieldWithdraw() {
+    guard let portal = portal else {
+      self.logger.info("Portal is not initialized")
+      return
+    }
+
+    Task { @MainActor in
+      self.logger.info("Starting high-level Yield withdraw...")
+      do {
+        let params = YieldWithdrawParams(
+          target: .chainAndToken(chain: "eip155:11155111", token: "ETH"),
+          amount: "0.0000001"
+        )
+        let options = YieldSubmitOptions(onProgress: { event in
+          let hashSuffix = event.hash.map { " \(String($0.prefix(10)))..." } ?? ""
+          let message = "Withdraw: \(event.step.rawValue) (\(event.index + 1)/\(event.total))\(hashSuffix)"
+          Task { @MainActor in
+            self.showStatusView(message: message)
+          }
+        })
+        let result = try await portal.yield.yieldxyz.withdraw(params: params, options: options)
+        self.logger.info("Withdraw complete: \(result.hashes) status: \(result.status.rawValue)")
+        self.showStatusView(message: "\(self.successStatus) Withdraw complete. \(result.hashes.count) tx(s). Yield: \(result.yieldId)")
+      } catch {
+        self.logger.error("Yield withdraw FAILED: \(error.localizedDescription)")
+        self.showStatusView(message: "\(self.failureStatus) Withdraw FAILED: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  /// Fetches validators for a native-staking yield.
+  @IBAction func handleYieldGetValidators() {
+    guard let portal = portal else {
+      self.logger.info("Portal is not initialized")
+      return
+    }
+
+    Task { @MainActor in
+      let yieldId = "monad-testnet-mon-native-staking"
+      self.logger.info("Fetching validators for \(yieldId)...")
+      do {
+        let validators = try await portal.yield.getValidators(yieldId: yieldId)
+        self.logger.info("Found \(validators.count) validators for \(yieldId)")
+        self.logger.info("The validators: \(validators)")
+        self.showStatusView(message: "\(self.successStatus) \(validators.count) validators for \(yieldId)")
+      } catch {
+        self.logger.error("getValidators FAILED: \(error.localizedDescription)")
+        self.showStatusView(message: "\(self.failureStatus) getValidators FAILED: \(error.localizedDescription)")
+      }
+    }
+  }
+
   @IBAction func handleDiscoverYields() {
     guard let portal = portal else {
       self.logger.info("Portal is not initialized")

--- a/SPM Example/PortalSwift/MainViewController/ViewController.swift
+++ b/SPM Example/PortalSwift/MainViewController/ViewController.swift
@@ -144,7 +144,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
     static let toChainId = "eip155:143" // Monad Mainnet
     static let fromToken = "MON"
     static let toToken = "USDC"
-    static let fromAmount = "10"
+    static let fromAmount = "0.1"
   }
 
   // Set up the scroll view
@@ -3423,6 +3423,56 @@ extension ViewController {
       } catch {
         self.logger.error("Lifi routes FAILED: \(error.localizedDescription)")
         self.showStatusView(message: "\(self.failureStatus) Lifi routes: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  /// Demonstrates the high-level `portal.trading.lifi.tradeAsset` bridging method, which
+  /// encapsulates route discovery, sequential step execution (sign + confirm + poll status),
+  /// in a single call.
+  @IBAction func handleLifiTradeAsset() {
+    guard let portal = portal else {
+      self.logger.info("Portal is not initialized")
+      return
+    }
+
+    Task {
+      self.logger.info("=== LiFi Trade Asset (high-level) Example ===")
+      do {
+        let fromChainId = TradingConfig.fromChainId
+        guard let address = await portal.getAddress(fromChainId) else {
+          self.logger.error("Lifi tradeAsset FAILED: Could not get address for chain \(fromChainId)")
+          self.showStatusView(message: "\(self.failureStatus) Lifi tradeAsset: Address not found")
+          return
+        }
+
+        // LiFi /routes requires fromAmount in the token's smallest (base) units as an integer
+        // string (must pass "isBigNumberish" validation), NOT a human-readable decimal like "0.1".
+        // 0.1 MON (18 decimals) = 100000000000000000.
+        let amountInBaseUnits = "100000000000000000"
+
+        let params = LifiTradeAssetParams(
+          fromChain: TradingConfig.fromChainId,
+          toChain: TradingConfig.toChainId,
+          fromToken: TradingConfig.fromToken,
+          toToken: TradingConfig.toToken,
+          amount: amountInBaseUnits,
+          fromAddress: address,
+          onProgress: { [weak self] status, data in
+            self?.logger.info("[LiFi tradeAsset] \(status.rawValue) - step: \(data.stepIndex.map(String.init) ?? "-")/\(data.totalSteps.map(String.init) ?? "-"), txHash: \(data.txHash ?? "-")")
+          }
+        )
+
+        let result = try await portal.trading.lifi.tradeAsset(params: params)
+
+        self.logger.info("Lifi tradeAsset SUCCESS - executed \(result.hashes.count) step(s)")
+        for (index, hash) in result.hashes.enumerated() {
+          self.logger.info("  Step \(index + 1) tx: \(hash)")
+        }
+        self.showStatusView(message: "\(self.successStatus) Lifi tradeAsset: \(result.hashes.count) step(s) completed")
+      } catch {
+        self.logger.error("Lifi tradeAsset FAILED: \(error.localizedDescription)")
+        self.showStatusView(message: "\(self.failureStatus) Lifi tradeAsset: \(error.localizedDescription)")
       }
     }
   }

--- a/SPM Example/PortalSwift/Settings/Settings.swift
+++ b/SPM Example/PortalSwift/Settings/Settings.swift
@@ -58,6 +58,7 @@ class Settings: ObservableObject {
   var isAccountAbstracted: Bool = false
   var useEnclaveMPC: Bool = false
   var usePresignatures: Bool = false
+  var usePreGeneratedWallet: Bool = true
 }
 
 // MARK: - App Configuration

--- a/SPM Example/PortalSwift/Settings/SettingsView.swift
+++ b/SPM Example/PortalSwift/Settings/SettingsView.swift
@@ -81,6 +81,11 @@ struct SettingsView: View {
         set: { Settings.shared.usePresignatures = $0 }
       ))
 
+      Toggle("Use Pre-Generated Wallet", isOn: Binding(
+        get: { Settings.shared.usePreGeneratedWallet },
+        set: { Settings.shared.usePreGeneratedWallet = $0 }
+      ))
+
       Spacer()
     }
     .padding(.horizontal)

--- a/SPM Example/SPM Example.xcodeproj/project.pbxproj
+++ b/SPM Example/SPM Example.xcodeproj/project.pbxproj
@@ -282,6 +282,9 @@
 				F9BF35A02BF8115000BF2862 /* XCRemoteSwiftPackageReference "Web3" */,
 				2510AC502F50C7000021F8F3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				D8PU00072EF2000000000007 /* XCRemoteSwiftPackageReference "Pulse" */,
+				5E10AC010000000000000001 /* XCRemoteSwiftPackageReference "swift-nio" */,
+				5E10AC020000000000000002 /* XCRemoteSwiftPackageReference "swift-nio-http2" */,
+				5E10AC030000000000000003 /* XCRemoteSwiftPackageReference "swift-nio-extras" */,
 			);
 			productRefGroup = 607FACD11AFB9204008FA782 /* Products */;
 			projectDirPath = "";
@@ -758,6 +761,30 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 0.8.8;
+			};
+		};
+		5E10AC010000000000000001 /* XCRemoteSwiftPackageReference "swift-nio" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-nio.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.100.0;
+			};
+		};
+		5E10AC020000000000000002 /* XCRemoteSwiftPackageReference "swift-nio-http2" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-nio-http2.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.44.0;
+			};
+		};
+		5E10AC030000000000000003 /* XCRemoteSwiftPackageReference "swift-nio-extras" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-nio-extras.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.34.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/SPM Example/SPM Example.xcodeproj/project.pbxproj
+++ b/SPM Example/SPM Example.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		2510AC4B2F50C6DE0021F8F3 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2510AC4A2F50C6DE0021F8F3 /* GoogleService-Info.plist */; };
 		2510AC4C2F50C7000021F8F3 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 2510AC4D2F50C7000021F8F3 /* FirebaseAuth */; };
 		2510AC4E2F50C7000021F8F3 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 2510AC4F2F50C7000021F8F3 /* FirebaseCore */; };
-
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };

--- a/SPM Example/SPM Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SPM Example/SPM Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,402 @@
+{
+  "originHash" : "5ebf60df0077a2e0841f97dee89e2523a364c4f0d937132fc3f00be19a51335f",
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
+    {
+      "identity" : "anycodable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Flight-School/AnyCodable.git",
+      "state" : {
+        "revision" : "862808b2070cd908cb04f9aafe7de83d35f81b05",
+        "version" : "0.6.7"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "2781038865a80e2c425a1da12cc1327bcd56501f",
+        "version" : "1.7.6"
+      }
+    },
+    {
+      "identity" : "bigint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attaswift/BigInt.git",
+      "state" : {
+        "revision" : "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
+        "version" : "5.7.0"
+      }
+    },
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "e45a26384239e028ec87fbcc788f513b67e10d8f",
+        "version" : "1.9.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "state" : {
+        "revision" : "fdc352fabaf5916e7faa1f96ad02b1957e93e5a5",
+        "version" : "11.15.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "a2d0f1f1666de591eb1a811f40b1706f5c63a2ed",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "45ce435e9406d3c674dd249a042b932bee006f60",
+        "version" : "11.15.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googlesignin-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleSignIn-iOS.git",
+      "state" : {
+        "revision" : "65fb3f1aa6ffbfdc79c4e22178a55cd91561f5e9",
+        "version" : "8.0.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "gtmappauth",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GTMAppAuth.git",
+      "state" : {
+        "revision" : "5d7d66f647400952b1758b230e019b07c0b4b22a",
+        "version" : "4.1.1"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promisekit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mxcl/PromiseKit.git",
+      "state" : {
+        "revision" : "8a98e31a47854d3180882c8068cc4d9381bf382d",
+        "version" : "6.22.1"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "pulse",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Pulse",
+      "state" : {
+        "revision" : "a4e5bc2b0439552d4ff5fc9667c389be6ef5bd52",
+        "version" : "5.2.2"
+      }
+    },
+    {
+      "identity" : "secp256k1.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Boilertalk/secp256k1.swift.git",
+      "state" : {
+        "revision" : "cd187c632fb812fd93711a9f7e644adb7e5f97f0",
+        "version" : "0.1.7"
+      }
+    },
+    {
+      "identity" : "starscream",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/daltoniam/Starscream.git",
+      "state" : {
+        "revision" : "c6bfd1af48efcc9a9ad203665db12375ba6b145a",
+        "version" : "4.0.8"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "2971dd5d9f6e0515664b01044826bcea16e59fac",
+        "version" : "1.1.2"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "24ccdeeeed4dfaae7955fcac9dbf5489ed4f1a25",
+        "version" : "1.18.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "6f70fa9eab24c1fd982af18c281c4525d05e3095",
+        "version" : "4.2.0"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "76d7627bd88b47bf5a0f8497dd244885960dde0b",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "e932d3c4d8f77433c8f7093b5ebcbf91463948a0",
+        "version" : "2.95.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "3df009d563dc9f21a5c85b33d8c2e34d2e4f8c3b",
+        "version" : "1.32.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "b6571f3db40799df5a7fc0e92c399aa71c883edd",
+        "version" : "1.40.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "173cc69a058623525a58ae6710e2f5727c663793",
+        "version" : "2.36.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "60c3e187154421171721c1a38e800b390680fb5d",
+        "version" : "1.26.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "f6506eaa86ed2e01cb0ae14a75035b7fdbf0918f",
+        "version" : "1.38.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "89888196dd79c61c50bca9a103d8114f32e1e598",
+        "version" : "2.10.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "web3.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Boilertalk/Web3.swift",
+      "state" : {
+        "revision" : "b85187ddf230a10b04fa8574c44980f3369ddff5",
+        "version" : "0.8.8"
+      }
+    },
+    {
+      "identity" : "websocket-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/websocket-kit",
+      "state" : {
+        "revision" : "8666c92dbbb3c8eefc8008c9c8dcf50bfd302167",
+        "version" : "2.16.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/SPM Example/SPM Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SPM Example/SPM Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5ebf60df0077a2e0841f97dee89e2523a364c4f0d937132fc3f00be19a51335f",
+  "originHash" : "0fc84414ce9edee508b6a91e4e3f66509dcfd3339c9801d3bec59b2407d509c7",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -303,8 +303,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "e932d3c4d8f77433c8f7093b5ebcbf91463948a0",
-        "version" : "2.95.0"
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -312,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "3df009d563dc9f21a5c85b33d8c2e34d2e4f8c3b",
-        "version" : "1.32.1"
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
       }
     },
     {
@@ -321,8 +321,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "b6571f3db40799df5a7fc0e92c399aa71c883edd",
-        "version" : "1.40.0"
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
       }
     },
     {

--- a/SPM Example/SPM Example.xcodeproj/xcshareddata/xcschemes/SPM Example.xcscheme
+++ b/SPM Example/SPM Example.xcodeproj/xcshareddata/xcschemes/SPM Example.xcscheme
@@ -56,7 +56,6 @@
       buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableAddressSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Sources/PortalSwift/Core/Api/Delegations/DelegationCommonTypes.swift
+++ b/Sources/PortalSwift/Core/Api/Delegations/DelegationCommonTypes.swift
@@ -10,7 +10,7 @@ import Foundation
 // MARK: - ConstructedEipTransaction
 
 /// Represents a constructed EVM transaction returned by delegation endpoints.
-public struct ConstructedEipTransaction: Codable {
+public struct ConstructedEipTransaction: Codable, Equatable {
   public let from: String
   public let to: String
   public let data: String?

--- a/Sources/PortalSwift/Core/Api/Noah/NoahCommonTypes.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahCommonTypes.swift
@@ -1,0 +1,731 @@
+//
+//  NoahCommonTypes.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import AnyCodable
+import Foundation
+
+// MARK: - Customer type
+
+/// Noah customer type. Validated server-side by `isNoahCustomerType` in connect-api.
+public enum NoahCustomerType: String, Codable {
+  case individual = "Individual"
+  case business = "Business"
+}
+
+// MARK: - Payment method capability (request filter)
+
+/// Capability filter accepted by the `getPaymentMethods` request.
+/// Validated by `isNoahPaymentMethodCapability` in connect-api.
+public enum NoahPaymentMethodCapability: String, Codable {
+  case payoutFrom = "PayoutFrom"
+  case payinTo = "PayinTo"
+  case payoutTo = "PayoutTo"
+}
+
+// MARK: - Comparison operator (payout trigger)
+
+/// Comparison operator accepted by Noah's `AmountCondition`. The BFF currently
+/// forwards this string to Noah unchanged; Noah accepts `EQ`, `LTEQ`, or `GTEQ`.
+public enum NoahComparisonOperator: String, Codable {
+  case eq = "EQ"
+  case lteq = "LTEQ"
+  case gteq = "GTEQ"
+}
+
+// MARK: - Address
+
+/// Bank address shape returned by Noah. Mirrors connect-api's `NoahBankAddress`
+/// after the BFF's pascal-to-camel formatter
+/// (`Street`/`Street2`/`City`/`PostCode`/`State`/`Country`).
+public struct NoahBankAddress: Codable {
+  public let street: String?
+  public let street2: String?
+  public let city: String?
+  public let postCode: String?
+  public let state: String?
+  public let country: String?
+
+  public init(
+    street: String? = nil,
+    street2: String? = nil,
+    city: String? = nil,
+    postCode: String? = nil,
+    state: String? = nil,
+    country: String? = nil
+  ) {
+    self.street = street
+    self.street2 = street2
+    self.city = city
+    self.postCode = postCode
+    self.state = state
+    self.country = country
+  }
+}
+
+// MARK: - Fee details
+
+/// Fee breakdown returned with payin bank details. Mirrors connect-api's
+/// `NoahFeeDetails`.
+public struct NoahFeeDetails: Codable {
+  public let fiatCurrencyCode: String
+  public let totalFeePct: String
+  public let totalFeeBase: String
+  public let totalFeeMin: String
+
+  public init(
+    fiatCurrencyCode: String,
+    totalFeePct: String,
+    totalFeeBase: String,
+    totalFeeMin: String
+  ) {
+    self.fiatCurrencyCode = fiatCurrencyCode
+    self.totalFeePct = totalFeePct
+    self.totalFeeBase = totalFeeBase
+    self.totalFeeMin = totalFeeMin
+  }
+}
+
+// MARK: - Payin (bank details)
+
+/// Bank-side payment method related to a payin destination address.
+public struct NoahBankToAddressRelatedPaymentMethod: Codable {
+  public let paymentMethodId: String
+  /// Specific payment method type such as `"BankSepa"` or `"IdentifierPix"`.
+  public let paymentMethodType: String
+  public let fee: NoahFeeDetails
+  public let details: NoahBankToAddressRelatedPaymentMethodDetails?
+
+  public init(
+    paymentMethodId: String,
+    paymentMethodType: String,
+    fee: NoahFeeDetails,
+    details: NoahBankToAddressRelatedPaymentMethodDetails? = nil
+  ) {
+    self.paymentMethodId = paymentMethodId
+    self.paymentMethodType = paymentMethodType
+    self.fee = fee
+    self.details = details
+  }
+}
+
+public struct NoahBankToAddressRelatedPaymentMethodDetails: Codable {
+  public let accountNumber: String?
+  public let bankCode: String?
+
+  public init(accountNumber: String? = nil, bankCode: String? = nil) {
+    self.accountNumber = accountNumber
+    self.bankCode = bankCode
+  }
+}
+
+/// Bank details returned with a Noah payin (on-ramp deposit instructions).
+public struct NoahBankDetails: Codable {
+  public let paymentMethodId: String
+  /// Specific payment method type such as `"BankSepa"` or `"IdentifierPix"`.
+  public let paymentMethodType: String
+  public let accountNumber: String
+  public let cryptoCurrency: String
+  public let network: String
+  public let fee: NoahFeeDetails
+  public let accountHolderName: String?
+  public let bankCode: String?
+  public let bankName: String?
+  public let bankAddress: NoahBankAddress?
+  public let reference: String?
+  public let relatedPaymentMethods: [NoahBankToAddressRelatedPaymentMethod]?
+
+  public init(
+    paymentMethodId: String,
+    paymentMethodType: String,
+    accountNumber: String,
+    cryptoCurrency: String,
+    network: String,
+    fee: NoahFeeDetails,
+    accountHolderName: String? = nil,
+    bankCode: String? = nil,
+    bankName: String? = nil,
+    bankAddress: NoahBankAddress? = nil,
+    reference: String? = nil,
+    relatedPaymentMethods: [NoahBankToAddressRelatedPaymentMethod]? = nil
+  ) {
+    self.paymentMethodId = paymentMethodId
+    self.paymentMethodType = paymentMethodType
+    self.accountNumber = accountNumber
+    self.cryptoCurrency = cryptoCurrency
+    self.network = network
+    self.fee = fee
+    self.accountHolderName = accountHolderName
+    self.bankCode = bankCode
+    self.bankName = bankName
+    self.bankAddress = bankAddress
+    self.reference = reference
+    self.relatedPaymentMethods = relatedPaymentMethods
+  }
+}
+
+// MARK: - Payout channels
+
+/// Min/max payout limits for a Noah payout channel.
+public struct NoahChannelLimits: Codable {
+  public let minLimit: String
+  public let maxLimit: String?
+
+  public init(minLimit: String, maxLimit: String? = nil) {
+    self.minLimit = minLimit
+    self.maxLimit = maxLimit
+  }
+}
+
+/// Pre-calculated values (e.g. total fee) returned for a payout channel.
+public struct NoahChannelCalculated: Codable {
+  public let totalFee: String
+
+  public init(totalFee: String) {
+    self.totalFee = totalFee
+  }
+}
+
+/// A Noah payout channel describing a way to off-ramp into fiat.
+///
+/// Mirrors the shape emitted by connect-api's `Channel` (after the BFF's
+/// pascal-to-camel formatter). Many fields are optional because they're only
+/// populated for certain customer / channel / query combinations.
+public struct NoahChannel: Codable {
+  public let id: String
+  /// Broad grouping such as `"Bank"`, `"Card"`, or `"Identifier"`.
+  public let paymentMethodCategory: String
+  /// Specific payment method type such as `"BankSepa"` or `"IdentifierPix"`.
+  public let paymentMethodType: String
+  public let fiatCurrency: String
+  public let country: String
+  public let limits: NoahChannelLimits
+  public let rate: String
+  public let processingSeconds: Int
+  public let calculated: NoahChannelCalculated?
+  /// Recent payment methods, only populated if a customer id was supplied.
+  public let paymentMethods: [NoahChannelPaymentMethodDisplay]?
+  /// Settlement speed tier such as `"Standard"` or `"Priority"`.
+  public let processingTier: String?
+  /// Inline JSON-Schema for the channel's payout form. Use this instead of
+  /// `getPayoutChannelForm` whenever it's present to save a round-trip.
+  // TODO: revisit -- strongly type once backend schema is finalized.
+  public let formSchema: [String: AnyCodable]?
+  public let formMetadata: NoahFormMetadata?
+  public let issuer: String?
+
+  public init(
+    id: String,
+    paymentMethodCategory: String,
+    paymentMethodType: String,
+    fiatCurrency: String,
+    country: String,
+    limits: NoahChannelLimits,
+    rate: String,
+    processingSeconds: Int,
+    calculated: NoahChannelCalculated? = nil,
+    paymentMethods: [NoahChannelPaymentMethodDisplay]? = nil,
+    processingTier: String? = nil,
+    formSchema: [String: AnyCodable]? = nil,
+    formMetadata: NoahFormMetadata? = nil,
+    issuer: String? = nil
+  ) {
+    self.id = id
+    self.paymentMethodCategory = paymentMethodCategory
+    self.paymentMethodType = paymentMethodType
+    self.fiatCurrency = fiatCurrency
+    self.country = country
+    self.limits = limits
+    self.rate = rate
+    self.processingSeconds = processingSeconds
+    self.calculated = calculated
+    self.paymentMethods = paymentMethods
+    self.processingTier = processingTier
+    self.formSchema = formSchema
+    self.formMetadata = formMetadata
+    self.issuer = issuer
+  }
+}
+
+/// Display payload for a recent payment method attached to a channel.
+public struct NoahChannelPaymentMethodDisplay: Codable {
+  public let id: String
+  /// Specific payment method type such as `"BankSepa"` or `"IdentifierPix"`.
+  public let paymentMethodType: String
+  public let details: NoahPaymentMethodDisplayDetails
+  public let accountHolderDetails: NoahAccountHolderDetails?
+  public let issuerDetails: NoahIssuerDetails?
+
+  public init(
+    id: String,
+    paymentMethodType: String,
+    details: NoahPaymentMethodDisplayDetails,
+    accountHolderDetails: NoahAccountHolderDetails? = nil,
+    issuerDetails: NoahIssuerDetails? = nil
+  ) {
+    self.id = id
+    self.paymentMethodType = paymentMethodType
+    self.details = details
+    self.accountHolderDetails = accountHolderDetails
+    self.issuerDetails = issuerDetails
+  }
+}
+
+/// Metadata describing the schema content for a Noah form (channel-form or
+/// channel inline form).
+public struct NoahFormMetadata: Codable {
+  public let contentHash: String
+
+  public init(contentHash: String) {
+    self.contentHash = contentHash
+  }
+}
+
+// MARK: - Payment methods
+
+/// Per-method display details (bank/card/identifier shapes flattened by the BFF).
+public struct NoahPaymentMethodDisplayDetails: Codable {
+  public let type: String
+  public let accountNumber: String?
+  public let bankCode: String?
+  public let bankAddress: NoahBankAddress?
+  public let last4: String?
+  public let scheme: String?
+  public let identifierType: String?
+  public let identifier: String?
+
+  public init(
+    type: String,
+    accountNumber: String? = nil,
+    bankCode: String? = nil,
+    bankAddress: NoahBankAddress? = nil,
+    last4: String? = nil,
+    scheme: String? = nil,
+    identifierType: String? = nil,
+    identifier: String? = nil
+  ) {
+    self.type = type
+    self.accountNumber = accountNumber
+    self.bankCode = bankCode
+    self.bankAddress = bankAddress
+    self.last4 = last4
+    self.scheme = scheme
+    self.identifierType = identifierType
+    self.identifier = identifier
+  }
+}
+
+/// Per-payment-method capability flags (which Noah flows the method can be used in).
+public struct NoahPaymentMethodCapabilities: Codable {
+  public let payoutFrom: Bool
+  public let payinTo: Bool
+  public let payoutTo: Bool
+
+  public init(payoutFrom: Bool, payinTo: Bool, payoutTo: Bool) {
+    self.payoutFrom = payoutFrom
+    self.payinTo = payinTo
+    self.payoutTo = payoutTo
+  }
+}
+
+
+public struct NoahPersonName: Codable {
+  public let firstName: String
+  public let lastName: String
+  public let middleName: String?
+
+  public init(
+    firstName: String,
+    lastName: String,
+    middleName: String? = nil
+  ) {
+    self.firstName = firstName
+    self.lastName = lastName
+    self.middleName = middleName
+  }
+}
+
+/// Information about the holder of a Noah payment method.
+///
+/// Mirrors connect-api's `AccountHolderDetails`, which only carries the
+/// holder's structured `name`.
+public struct NoahAccountHolderDetails: Codable {
+  public let name: NoahPersonName?
+
+  public init(name: NoahPersonName? = nil) {
+    self.name = name
+  }
+}
+
+/// Information about the issuer (e.g. bank) of a Noah payment method.
+///
+/// Mirrors connect-api's `IssuerDetails`, which only carries an optional `name`.
+public struct NoahIssuerDetails: Codable {
+  public let name: String?
+
+  public init(name: String? = nil) {
+    self.name = name
+  }
+}
+
+/// A saved Noah payment method available to the current customer.
+///
+/// Field shape matches what connect-api's `getPaymentMethods` returns after
+/// pascal-to-camel formatting: `id`, `paymentMethodCategory`, `country`,
+/// `displayDetails`, and optional `customerId` / `capabilities`.
+public struct NoahPaymentMethod: Codable {
+  public let id: String
+  /// Broad grouping such as `"Bank"`, `"Card"`, or `"Identifier"`.
+  public let paymentMethodCategory: String
+  public let country: String
+  public let displayDetails: NoahPaymentMethodDisplayDetails
+  public let customerId: String?
+  public let capabilities: NoahPaymentMethodCapabilities?
+  public let accountHolderDetails: NoahAccountHolderDetails?
+  public let issuerDetails: NoahIssuerDetails?
+
+  public init(
+    id: String,
+    paymentMethodCategory: String,
+    country: String,
+    displayDetails: NoahPaymentMethodDisplayDetails,
+    customerId: String? = nil,
+    capabilities: NoahPaymentMethodCapabilities? = nil,
+    accountHolderDetails: NoahAccountHolderDetails? = nil,
+    issuerDetails: NoahIssuerDetails? = nil
+  ) {
+    self.id = id
+    self.paymentMethodCategory = paymentMethodCategory
+    self.country = country
+    self.displayDetails = displayDetails
+    self.customerId = customerId
+    self.capabilities = capabilities
+    self.accountHolderDetails = accountHolderDetails
+    self.issuerDetails = issuerDetails
+  }
+}
+
+// MARK: - Multi-step form
+
+/// Type of a Noah form step.
+public enum NoahFormNextStepType: String, Codable {
+  case ack = "Ack"
+  case dataEntry = "DataEntry"
+}
+
+/// Next step in a Noah multi-step form flow.
+///
+/// Per connect-api `FormNextStep`, `schema` is required when `nextStep` is
+/// present. We keep it optional in the SDK to be defensive against missing
+/// fields and avoid hard-decode failures.
+public struct NoahFormNextStep: Codable {
+  public let stepId: String
+  public let stepType: NoahFormNextStepType
+  // TODO: revisit -- strongly type once backend schema is finalized.
+  public let schema: [String: AnyCodable]?
+
+  public init(
+    stepId: String,
+    stepType: NoahFormNextStepType,
+    schema: [String: AnyCodable]? = nil
+  ) {
+    self.stepId = stepId
+    self.stepType = stepType
+    self.schema = schema
+  }
+}
+
+// MARK: - Payout conditions
+
+/// Comparison condition applied to a payout amount.
+///
+/// `comparisonOperator` is a string for forward-compatibility with new
+/// Noah-supported operators, but the canonical values are `EQ`, `LTEQ`, and
+/// `GTEQ` — use `NoahComparisonOperator` to construct them safely.
+public struct NoahAmountCondition: Codable {
+  public let comparisonOperator: String
+  public let value: String
+
+  public init(comparisonOperator: String, value: String) {
+    self.comparisonOperator = comparisonOperator
+    self.value = value
+  }
+
+  public init(comparisonOperator: NoahComparisonOperator, value: String) {
+    self.comparisonOperator = comparisonOperator.rawValue
+    self.value = value
+  }
+}
+
+/// Condition that must be met for the on-chain deposit to be picked up by Noah.
+///
+/// - Note: `destinationAddress` is typed as a flat `String` to match
+///   connect-api's `DepositSourceTriggerCondition.DestinationAddress: string`.
+///   Upstream Noah's OpenAPI describes this field as `{ Address: string }`, so
+///   if the BFF starts emitting a nested object this struct will fail to
+///   decode and we'll need to update both sides.
+public struct NoahDepositSourceTriggerCondition: Codable {
+  public let amountConditions: [NoahAmountCondition]
+  public let cryptoCurrency: String
+  public let network: String
+  public let destinationAddress: String
+
+  public init(
+    amountConditions: [NoahAmountCondition],
+    cryptoCurrency: String,
+    network: String,
+    destinationAddress: String
+  ) {
+    self.amountConditions = amountConditions
+    self.cryptoCurrency = cryptoCurrency
+    self.network = network
+    self.destinationAddress = destinationAddress
+  }
+}
+
+/// Per-condition entry used inside `NoahSingleOnchainDepositSourceTriggerInput`.
+/// JSON keys use PascalCase to match the Noah API wire format.
+public struct NoahSingleOnchainDepositSourceTriggerCondition: Codable {
+  public let amountConditions: [NoahSingleOnchainDepositSourceTriggerAmountCondition]
+  public let network: String
+
+  public init(
+    amountConditions: [NoahSingleOnchainDepositSourceTriggerAmountCondition],
+    network: String
+  ) {
+    self.amountConditions = amountConditions
+    self.network = network
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case amountConditions = "AmountConditions"
+    case network = "Network"
+  }
+}
+
+/// Amount condition entry used inside `NoahSingleOnchainDepositSourceTriggerInput`.
+/// JSON keys use PascalCase to match the Noah API wire format.
+public struct NoahSingleOnchainDepositSourceTriggerAmountCondition: Codable {
+  public let comparisonOperator: String
+  public let value: String
+
+  public init(comparisonOperator: String, value: String) {
+    self.comparisonOperator = comparisonOperator
+    self.value = value
+  }
+
+  public init(comparisonOperator: NoahComparisonOperator, value: String) {
+    self.comparisonOperator = comparisonOperator.rawValue
+    self.value = value
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case comparisonOperator = "ComparisonOperator"
+    case value = "Value"
+  }
+}
+
+/// Signed payout trigger describing a single on-chain deposit source.
+/// JSON keys use PascalCase to match the Noah API wire format.
+public struct NoahSingleOnchainDepositSourceTriggerInput: Codable {
+  public let type: String
+  public let conditions: [NoahSingleOnchainDepositSourceTriggerCondition]
+  public let sourceAddress: String
+  public let expiry: String
+  public let nonce: String
+
+  public init(
+    type: String = "SingleOnchainDepositSourceTriggerInput",
+    conditions: [NoahSingleOnchainDepositSourceTriggerCondition],
+    sourceAddress: String,
+    expiry: String,
+    nonce: String
+  ) {
+    self.type = type
+    self.conditions = conditions
+    self.sourceAddress = sourceAddress
+    self.expiry = expiry
+    self.nonce = nonce
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case type = "Type"
+    case conditions = "Conditions"
+    case sourceAddress = "SourceAddress"
+    case expiry = "Expiry"
+    case nonce = "Nonce"
+  }
+}
+
+/// Per-condition entry used inside permanent/quoted triggers. Unlike the single
+/// trigger, these conditions only constrain the network (no amount conditions).
+/// JSON keys use PascalCase to match the Noah API wire format.
+public struct NoahNetworkOnlyOnchainDepositSourceTriggerCondition: Codable {
+  public let network: String
+
+  public init(network: String) {
+    self.network = network
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case network = "Network"
+  }
+}
+
+/// Trigger that keeps a payout source active across multiple deposits (until
+/// expiry), rather than for a single matching amount.
+/// JSON keys use PascalCase to match the Noah API wire format.
+public struct NoahPermanentOnchainDepositSourceTriggerInput: Codable {
+  public let type: String
+  public let conditions: [NoahNetworkOnlyOnchainDepositSourceTriggerCondition]
+  public let sourceAddress: String
+  public let expiry: String
+  public let nonce: String
+  /// When `true`, the trigger matches deposits on any supported network.
+  public let networkAgnostic: Bool?
+
+  public init(
+    type: String = "PermanentOnchainDepositSourceTriggerInput",
+    conditions: [NoahNetworkOnlyOnchainDepositSourceTriggerCondition],
+    sourceAddress: String,
+    expiry: String,
+    nonce: String,
+    networkAgnostic: Bool? = nil
+  ) {
+    self.type = type
+    self.conditions = conditions
+    self.sourceAddress = sourceAddress
+    self.expiry = expiry
+    self.nonce = nonce
+    self.networkAgnostic = networkAgnostic
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case type = "Type"
+    case conditions = "Conditions"
+    case sourceAddress = "SourceAddress"
+    case expiry = "Expiry"
+    case nonce = "Nonce"
+    case networkAgnostic = "NetworkAgnostic"
+  }
+}
+
+/// Trigger backed by a signed quote (rate-locked payout). Requires the
+/// `SignedQuote` obtained from a `getPayoutQuote` call made with `quoted: true`.
+/// JSON keys use PascalCase to match the Noah API wire format.
+public struct NoahQuotedOnchainDepositSourceTriggerInput: Codable {
+  public let type: String
+  public let signedQuote: String
+  public let conditions: [NoahNetworkOnlyOnchainDepositSourceTriggerCondition]
+  public let sourceAddress: String
+  public let nonce: String
+  public let expiry: String?
+
+  public init(
+    type: String = "QuotedOnchainDepositSourceTriggerInput",
+    signedQuote: String,
+    conditions: [NoahNetworkOnlyOnchainDepositSourceTriggerCondition],
+    sourceAddress: String,
+    nonce: String,
+    expiry: String? = nil
+  ) {
+    self.type = type
+    self.signedQuote = signedQuote
+    self.conditions = conditions
+    self.sourceAddress = sourceAddress
+    self.nonce = nonce
+    self.expiry = expiry
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case type = "Type"
+    case signedQuote = "SignedQuote"
+    case conditions = "Conditions"
+    case sourceAddress = "SourceAddress"
+    case nonce = "Nonce"
+    case expiry = "Expiry"
+  }
+}
+
+/// The three Noah on-chain deposit source trigger variants accepted by
+/// `POST /payouts`. The wire shape is discriminated by the `Type` field, so this
+/// enum encodes the wrapped value transparently (no extra nesting).
+public enum NoahOnchainDepositSourceTrigger: Codable {
+  case single(NoahSingleOnchainDepositSourceTriggerInput)
+  case permanent(NoahPermanentOnchainDepositSourceTriggerInput)
+  case quoted(NoahQuotedOnchainDepositSourceTriggerInput)
+
+  private enum TypeKey: String, CodingKey {
+    case type = "Type"
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case let .single(value):
+      try container.encode(value)
+    case let .permanent(value):
+      try container.encode(value)
+    case let .quoted(value):
+      try container.encode(value)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: TypeKey.self)
+    let type = try container.decode(String.self, forKey: .type)
+    switch type {
+    case "SingleOnchainDepositSourceTriggerInput":
+      self = .single(try NoahSingleOnchainDepositSourceTriggerInput(from: decoder))
+    case "PermanentOnchainDepositSourceTriggerInput":
+      self = .permanent(try NoahPermanentOnchainDepositSourceTriggerInput(from: decoder))
+    case "QuotedOnchainDepositSourceTriggerInput":
+      self = .quoted(try NoahQuotedOnchainDepositSourceTriggerInput(from: decoder))
+    default:
+      throw DecodingError.dataCorruptedError(
+        forKey: TypeKey.type,
+        in: container,
+        debugDescription: "Unknown Noah trigger Type: \(type)"
+      )
+    }
+  }
+}
+
+// MARK: - Business fee
+
+/// Optional business (partner) fee applied to a Noah payout or payin.
+///
+/// JSON keys use PascalCase to match the Noah API wire format. The BFF forwards
+/// this object straight through to Noah, so the inner field names must stay
+/// PascalCase even though the surrounding request keys are camelCase.
+public struct NoahBusinessFee: Codable {
+  public let feeBase: String?
+  public let feePct: String?
+  public let fiatCurrency: String?
+
+  public init(
+    feeBase: String? = nil,
+    feePct: String? = nil,
+    fiatCurrency: String? = nil
+  ) {
+    self.feeBase = feeBase
+    self.feePct = feePct
+    self.fiatCurrency = fiatCurrency
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case feeBase = "FeeBase"
+    case feePct = "FeePct"
+    case fiatCurrency = "FiatCurrency"
+  }
+}
+
+// MARK: - Response envelope metadata
+
+/// Response envelope metadata returned by connect-api alongside `data`.
+///
+/// The BFF sends a freeform object here, so we expose it as `[String: AnyCodable]`.
+public typealias NoahResponseMetadata = [String: AnyCodable]

--- a/Sources/PortalSwift/Core/Api/Noah/NoahGetPaymentMethodsRequest.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahGetPaymentMethodsRequest.swift
@@ -1,0 +1,32 @@
+//
+//  NoahGetPaymentMethodsRequest.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+
+/// Query parameters for `GET /integrations/noah/payouts/payment-methods`.
+///
+/// All parameters are optional; omitting them lets connect-api fall back to
+/// its server-side defaults (`pageSize` defaults to whatever Noah uses).
+///
+/// - `pageSize`: clamped to the range `[1, 100]` by connect-api.
+/// - `pageToken`: cursor from a previous response's `data.pageToken`.
+/// - `capability`: filter the payment methods by what they can be used for.
+public struct NoahGetPaymentMethodsRequest: Codable {
+  public let pageSize: Int?
+  public let pageToken: String?
+  public let capability: NoahPaymentMethodCapability?
+
+  public init(
+    pageSize: Int? = nil,
+    pageToken: String? = nil,
+    capability: NoahPaymentMethodCapability? = nil
+  ) {
+    self.pageSize = pageSize
+    self.pageToken = pageToken
+    self.capability = capability
+  }
+}

--- a/Sources/PortalSwift/Core/Api/Noah/NoahGetPaymentMethodsResponse.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahGetPaymentMethodsResponse.swift
@@ -1,0 +1,30 @@
+//
+//  NoahGetPaymentMethodsResponse.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+
+/// Response from `GET /integrations/noah/payouts/payment-methods`.
+public struct NoahGetPaymentMethodsResponse: Codable {
+  public let data: NoahGetPaymentMethodsData
+  public let metadata: NoahResponseMetadata?
+
+  public init(data: NoahGetPaymentMethodsData, metadata: NoahResponseMetadata? = nil) {
+    self.data = data
+    self.metadata = metadata
+  }
+}
+
+/// The `data` payload of a Noah get-payment-methods response.
+public struct NoahGetPaymentMethodsData: Codable {
+  public let paymentMethods: [NoahPaymentMethod]
+  public let pageToken: String?
+
+  public init(paymentMethods: [NoahPaymentMethod], pageToken: String? = nil) {
+    self.paymentMethods = paymentMethods
+    self.pageToken = pageToken
+  }
+}

--- a/Sources/PortalSwift/Core/Api/Noah/NoahGetPayoutChannelFormResponse.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahGetPayoutChannelFormResponse.swift
@@ -1,0 +1,34 @@
+//
+//  NoahGetPayoutChannelFormResponse.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import AnyCodable
+import Foundation
+
+/// Response from `GET /integrations/noah/payouts/channels/{channelId}/form`.
+public struct NoahGetPayoutChannelFormResponse: Codable {
+  public let data: NoahGetPayoutChannelFormData
+  public let metadata: NoahResponseMetadata?
+
+  public init(data: NoahGetPayoutChannelFormData, metadata: NoahResponseMetadata? = nil) {
+    self.data = data
+    self.metadata = metadata
+  }
+}
+
+/// The `data` payload of a Noah get-payout-channel-form response.
+public struct NoahGetPayoutChannelFormData: Codable {
+  public let formSchema: [String: AnyCodable]? // TODO: revisit -- strongly type once backend schema is finalized
+  public let formMetadata: NoahFormMetadata?
+
+  public init(
+    formSchema: [String: AnyCodable]? = nil,
+    formMetadata: NoahFormMetadata? = nil
+  ) {
+    self.formSchema = formSchema
+    self.formMetadata = formMetadata
+  }
+}

--- a/Sources/PortalSwift/Core/Api/Noah/NoahGetPayoutChannelsRequest.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahGetPayoutChannelsRequest.swift
@@ -1,0 +1,42 @@
+//
+//  NoahGetPayoutChannelsRequest.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+
+/// Query parameters for `GET /integrations/noah/payouts/channels`.
+///
+/// Only `cryptoCurrency` is required; `country` and `fiatCurrency` are optional
+/// filters. `pageToken` is forwarded to Noah's pagination cursor — use the
+/// `pageToken` returned in the previous response to fetch the next page.
+public struct NoahGetPayoutChannelsRequest: Codable {
+  public let cryptoCurrency: String
+  public let country: String?
+  public let fiatCurrency: String?
+  public let fiatAmount: String?
+  public let paymentMethodId: String?
+  /// Page size between 1 and 100 (validated by the BFF).
+  public let pageSize: Int?
+  public let pageToken: String?
+
+  public init(
+    cryptoCurrency: String,
+    country: String? = nil,
+    fiatCurrency: String? = nil,
+    fiatAmount: String? = nil,
+    paymentMethodId: String? = nil,
+    pageSize: Int? = nil,
+    pageToken: String? = nil
+  ) {
+    self.cryptoCurrency = cryptoCurrency
+    self.country = country
+    self.fiatCurrency = fiatCurrency
+    self.fiatAmount = fiatAmount
+    self.paymentMethodId = paymentMethodId
+    self.pageSize = pageSize
+    self.pageToken = pageToken
+  }
+}

--- a/Sources/PortalSwift/Core/Api/Noah/NoahGetPayoutChannelsResponse.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahGetPayoutChannelsResponse.swift
@@ -1,0 +1,30 @@
+//
+//  NoahGetPayoutChannelsResponse.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+
+/// Response from `GET /integrations/noah/payouts/channels`.
+public struct NoahGetPayoutChannelsResponse: Codable {
+  public let data: NoahGetPayoutChannelsData
+  public let metadata: NoahResponseMetadata?
+
+  public init(data: NoahGetPayoutChannelsData, metadata: NoahResponseMetadata? = nil) {
+    self.data = data
+    self.metadata = metadata
+  }
+}
+
+/// The `data` payload of a Noah get-payout-channels response.
+public struct NoahGetPayoutChannelsData: Codable {
+  public let items: [NoahChannel]
+  public let pageToken: String?
+
+  public init(items: [NoahChannel], pageToken: String? = nil) {
+    self.items = items
+    self.pageToken = pageToken
+  }
+}

--- a/Sources/PortalSwift/Core/Api/Noah/NoahGetPayoutCountriesResponse.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahGetPayoutCountriesResponse.swift
@@ -1,0 +1,31 @@
+//
+//  NoahGetPayoutCountriesResponse.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+
+/// Response from `GET /integrations/noah/payouts/countries`.
+public struct NoahGetPayoutCountriesResponse: Codable {
+  public let data: NoahGetPayoutCountriesData
+  public let metadata: NoahResponseMetadata?
+
+  public init(data: NoahGetPayoutCountriesData, metadata: NoahResponseMetadata? = nil) {
+    self.data = data
+    self.metadata = metadata
+  }
+}
+
+/// The `data` payload of a Noah get-payout-countries response.
+///
+/// `countries` is keyed by country code and contains the list of fiat currency
+/// codes supported in that country.
+public struct NoahGetPayoutCountriesData: Codable {
+  public let countries: [String: [String]]
+
+  public init(countries: [String: [String]]) {
+    self.countries = countries
+  }
+}

--- a/Sources/PortalSwift/Core/Api/Noah/NoahGetPayoutQuoteRequest.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahGetPayoutQuoteRequest.swift
@@ -1,0 +1,81 @@
+//
+//  NoahGetPayoutQuoteRequest.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import AnyCodable
+import Foundation
+
+/// Request body for `POST /integrations/noah/payouts/quote`.
+///
+/// Exactly one of `fiatAmount` or `cryptoAmount` is set. Use the dedicated
+/// initializers so invalid states (both or neither) cannot be constructed.
+public struct NoahGetPayoutQuoteRequest: Codable {
+  public let channelId: String
+  public let cryptoCurrency: String
+  /// Fiat amount to receive. Mutually exclusive with `cryptoAmount`.
+  public let fiatAmount: String?
+  /// Crypto amount to sell. Mutually exclusive with `fiatAmount`.
+  public let cryptoAmount: String?
+  /// Request a signed, rate-locked quote. Required to later submit a
+  /// `QuotedOnchainDepositSourceTriggerInput` payout.
+  public let quoted: Bool?
+  public let form: [String: AnyCodable]? // TODO: revisit -- strongly type once backend schema is finalized
+  public let fiatCurrency: String?
+  public let paymentMethodId: String?
+  /// Existing form session to continue (reuses a prepared payout intent for
+  /// multi-step forms).
+  public let formSessionId: String?
+  /// Optional business (partner) fee. Forwarded to Noah as `BusinessFee`.
+  public let businessFee: NoahBusinessFee?
+
+  /// Creates a quote request specifying the fiat amount to receive.
+  public init(
+    channelId: String,
+    cryptoCurrency: String,
+    fiatAmount: String,
+    quoted: Bool? = nil,
+    form: [String: AnyCodable]? = nil,
+    fiatCurrency: String? = nil,
+    paymentMethodId: String? = nil,
+    formSessionId: String? = nil,
+    businessFee: NoahBusinessFee? = nil
+  ) {
+    self.channelId = channelId
+    self.cryptoCurrency = cryptoCurrency
+    self.fiatAmount = fiatAmount
+    self.cryptoAmount = nil
+    self.quoted = quoted
+    self.form = form
+    self.fiatCurrency = fiatCurrency
+    self.paymentMethodId = paymentMethodId
+    self.formSessionId = formSessionId
+    self.businessFee = businessFee
+  }
+
+  /// Creates a quote request specifying the crypto amount to sell.
+  public init(
+    channelId: String,
+    cryptoCurrency: String,
+    cryptoAmount: String,
+    quoted: Bool? = nil,
+    form: [String: AnyCodable]? = nil,
+    fiatCurrency: String? = nil,
+    paymentMethodId: String? = nil,
+    formSessionId: String? = nil,
+    businessFee: NoahBusinessFee? = nil
+  ) {
+    self.channelId = channelId
+    self.cryptoCurrency = cryptoCurrency
+    self.fiatAmount = nil
+    self.cryptoAmount = cryptoAmount
+    self.quoted = quoted
+    self.form = form
+    self.fiatCurrency = fiatCurrency
+    self.paymentMethodId = paymentMethodId
+    self.formSessionId = formSessionId
+    self.businessFee = businessFee
+  }
+}

--- a/Sources/PortalSwift/Core/Api/Noah/NoahGetPayoutQuoteResponse.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahGetPayoutQuoteResponse.swift
@@ -1,0 +1,93 @@
+//
+//  NoahGetPayoutQuoteResponse.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+
+/// Response from `POST /integrations/noah/payouts/quote`.
+public struct NoahGetPayoutQuoteResponse: Codable {
+  public let data: NoahGetPayoutQuoteData
+  public let metadata: NoahResponseMetadata?
+
+  public init(data: NoahGetPayoutQuoteData, metadata: NoahResponseMetadata? = nil) {
+    self.data = data
+    self.metadata = metadata
+  }
+}
+
+/// A single line item in a payout quote fee breakdown.
+public struct NoahTransactionBreakdownItem: Codable {
+  /// One of `"ChannelFee"`, `"BusinessFee"`, or `"Remaining"`.
+  public let type: String
+  public let amount: String
+
+  public init(type: String, amount: String) {
+    self.type = type
+    self.amount = amount
+  }
+}
+
+/// A signed payout quote that can be used to lock in a rate.
+public struct NoahSellQuote: Codable {
+  public let signedQuote: String
+  public let expiry: String
+
+  public init(signedQuote: String, expiry: String) {
+    self.signedQuote = signedQuote
+    self.expiry = expiry
+  }
+}
+
+/// The `data` payload of a Noah get-payout-quote response.
+public struct NoahGetPayoutQuoteData: Codable {
+  public let payoutId: String
+  public let totalFee: String
+  public let cryptoAmountEstimate: String
+  /// The crypto amount the client is authorized to send for this quote.
+  public let cryptoAuthorizedAmount: String
+  public let formSessionId: String
+  /// Disclosure: the crypto currency the quote was priced in, when returned by Noah.
+  public let cryptoCurrency: String?
+  /// Disclosure: the fiat currency the quote was priced in, when returned by Noah.
+  public let fiatCurrency: String?
+  /// Disclosure: the resolved fiat amount for the quote, when returned by Noah.
+  public let fiatAmount: String?
+  /// Exchange rate applied to the quote, when returned by Noah.
+  public let rate: String?
+  /// Fee breakdown line items, when returned by Noah.
+  public let breakdown: [NoahTransactionBreakdownItem]?
+  /// Signed quote details, present for quoted (rate-locked) payouts.
+  public let quote: NoahSellQuote?
+  public let nextStep: NoahFormNextStep?
+
+  public init(
+    payoutId: String,
+    totalFee: String,
+    cryptoAmountEstimate: String,
+    cryptoAuthorizedAmount: String,
+    formSessionId: String,
+    cryptoCurrency: String? = nil,
+    fiatCurrency: String? = nil,
+    fiatAmount: String? = nil,
+    rate: String? = nil,
+    breakdown: [NoahTransactionBreakdownItem]? = nil,
+    quote: NoahSellQuote? = nil,
+    nextStep: NoahFormNextStep? = nil
+  ) {
+    self.payoutId = payoutId
+    self.totalFee = totalFee
+    self.cryptoAmountEstimate = cryptoAmountEstimate
+    self.cryptoAuthorizedAmount = cryptoAuthorizedAmount
+    self.formSessionId = formSessionId
+    self.cryptoCurrency = cryptoCurrency
+    self.fiatCurrency = fiatCurrency
+    self.fiatAmount = fiatAmount
+    self.rate = rate
+    self.breakdown = breakdown
+    self.quote = quote
+    self.nextStep = nextStep
+  }
+}

--- a/Sources/PortalSwift/Core/Api/Noah/NoahInitiateKycRequest.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahInitiateKycRequest.swift
@@ -1,0 +1,41 @@
+//
+//  NoahInitiateKycRequest.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import AnyCodable
+import Foundation
+
+/// A fiat option offered to the customer during KYC.
+public struct NoahFiatOption: Codable {
+  public let fiatCurrencyCode: String
+
+  public init(fiatCurrencyCode: String) {
+    self.fiatCurrencyCode = fiatCurrencyCode
+  }
+}
+
+/// Request body for `POST /integrations/noah/customers/kyc`.
+public struct NoahInitiateKycRequest: Codable {
+  public let returnUrl: String
+  public let fiatOptions: [NoahFiatOption]?
+  public let customerType: NoahCustomerType?
+  public let metadata: [String: AnyCodable]? // TODO: revisit -- strongly type once backend schema is finalized
+  public let form: [String: AnyCodable]? // TODO: revisit -- strongly type once backend schema is finalized
+
+  public init(
+    returnUrl: String,
+    fiatOptions: [NoahFiatOption]? = nil,
+    customerType: NoahCustomerType? = nil,
+    metadata: [String: AnyCodable]? = nil,
+    form: [String: AnyCodable]? = nil
+  ) {
+    self.returnUrl = returnUrl
+    self.fiatOptions = fiatOptions
+    self.customerType = customerType
+    self.metadata = metadata
+    self.form = form
+  }
+}

--- a/Sources/PortalSwift/Core/Api/Noah/NoahInitiateKycResponse.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahInitiateKycResponse.swift
@@ -1,0 +1,33 @@
+//
+//  NoahInitiateKycResponse.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+
+/// Response from `POST /integrations/noah/customers/kyc`.
+///
+/// - Note: This endpoint is idempotent on the BFF. If a `NoahCustomer` record
+///   already exists for the client, the previously stored `hostedUrl` is
+///   returned regardless of KYC status (`Pending`, `Submitted`, `Approved`,
+///   `Declined`, etc.). Do not expect a fresh KYC URL for an existing customer.
+public struct NoahInitiateKycResponse: Codable {
+  public let data: NoahInitiateKycData
+  public let metadata: NoahResponseMetadata?
+
+  public init(data: NoahInitiateKycData, metadata: NoahResponseMetadata? = nil) {
+    self.data = data
+    self.metadata = metadata
+  }
+}
+
+/// The `data` payload of a Noah initiate-KYC response.
+public struct NoahInitiateKycData: Codable {
+  public let hostedUrl: String
+
+  public init(hostedUrl: String) {
+    self.hostedUrl = hostedUrl
+  }
+}

--- a/Sources/PortalSwift/Core/Api/Noah/NoahInitiatePayinRequest.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahInitiatePayinRequest.swift
@@ -1,0 +1,33 @@
+//
+//  NoahInitiatePayinRequest.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+
+/// Request body for `POST /integrations/noah/payins`.
+public struct NoahInitiatePayinRequest: Codable {
+  public let fiatCurrency: String
+  public let cryptoCurrency: String
+  public let network: String
+  public let destinationAddress: String
+  /// Optional per-payment-method business (partner) fees, keyed by payment
+  /// method type. Forwarded to Noah as `BusinessFees`.
+  public let businessFees: [String: NoahBusinessFee]?
+
+  public init(
+    fiatCurrency: String,
+    cryptoCurrency: String,
+    network: String,
+    destinationAddress: String,
+    businessFees: [String: NoahBusinessFee]? = nil
+  ) {
+    self.fiatCurrency = fiatCurrency
+    self.cryptoCurrency = cryptoCurrency
+    self.network = network
+    self.destinationAddress = destinationAddress
+    self.businessFees = businessFees
+  }
+}

--- a/Sources/PortalSwift/Core/Api/Noah/NoahInitiatePayinResponse.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahInitiatePayinResponse.swift
@@ -1,0 +1,30 @@
+//
+//  NoahInitiatePayinResponse.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+
+/// Response from `POST /integrations/noah/payins`.
+public struct NoahInitiatePayinResponse: Codable {
+  public let data: NoahInitiatePayinData
+  public let metadata: NoahResponseMetadata?
+
+  public init(data: NoahInitiatePayinData, metadata: NoahResponseMetadata? = nil) {
+    self.data = data
+    self.metadata = metadata
+  }
+}
+
+/// The `data` payload of a Noah initiate-payin response.
+public struct NoahInitiatePayinData: Codable {
+  public let payinId: String
+  public let bankDetails: NoahBankDetails
+
+  public init(payinId: String, bankDetails: NoahBankDetails) {
+    self.payinId = payinId
+    self.bankDetails = bankDetails
+  }
+}

--- a/Sources/PortalSwift/Core/Api/Noah/NoahInitiatePayoutRequest.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahInitiatePayoutRequest.swift
@@ -1,0 +1,41 @@
+//
+//  NoahInitiatePayoutRequest.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+
+/// Request body for `POST /integrations/noah/payouts`.
+public struct NoahInitiatePayoutRequest: Codable {
+  public let payoutId: String
+  public let sourceAddress: String
+  public let expiry: String
+  public let nonce: String
+  public let network: String
+  /// Optional explicit trigger. Accepts the Single, Permanent, or Quoted
+  /// variant. When omitted, the BFF synthesises a Single trigger from the
+  /// quote and the supplied `sourceAddress` / `expiry` / `nonce`.
+  public let trigger: NoahOnchainDepositSourceTrigger?
+  /// Optional business (partner) fee. Forwarded to Noah as `BusinessFee`.
+  public let businessFee: NoahBusinessFee?
+
+  public init(
+    payoutId: String,
+    sourceAddress: String,
+    expiry: String,
+    nonce: String,
+    network: String,
+    trigger: NoahOnchainDepositSourceTrigger? = nil,
+    businessFee: NoahBusinessFee? = nil
+  ) {
+    self.payoutId = payoutId
+    self.sourceAddress = sourceAddress
+    self.expiry = expiry
+    self.nonce = nonce
+    self.network = network
+    self.trigger = trigger
+    self.businessFee = businessFee
+  }
+}

--- a/Sources/PortalSwift/Core/Api/Noah/NoahInitiatePayoutResponse.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahInitiatePayoutResponse.swift
@@ -1,0 +1,50 @@
+//
+//  NoahInitiatePayoutResponse.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+
+/// Response from `POST /integrations/noah/payouts`.
+///
+/// - Note: The BFF requires either a `trigger` on the request or a saved
+///   payment method on the quote (via `paymentMethodId`). When `trigger` is
+///   absent and the saved method is `SingleOnchainDepositSource`, the BFF
+///   synthesises a default trigger with the supplied `expiry` / `nonce` /
+///   `sourceAddress`.
+public struct NoahInitiatePayoutResponse: Codable {
+  public let data: NoahInitiatePayoutData
+  public let metadata: NoahResponseMetadata?
+
+  public init(data: NoahInitiatePayoutData, metadata: NoahResponseMetadata? = nil) {
+    self.data = data
+    self.metadata = metadata
+  }
+}
+
+/// The `data` payload of a Noah initiate-payout response.
+///
+/// - `destinationAddress` is optional because the BFF derives it from
+///   `conditions[0].destinationAddress` and falls back to `null` when the
+///   shape is missing or malformed.
+/// - `conditions` is optional because the upstream Noah workflow response
+///   types it as optional; an empty workflow has no conditions.
+public struct NoahInitiatePayoutData: Codable {
+  public let destinationAddress: String?
+  public let conditions: [NoahDepositSourceTriggerCondition]?
+  /// Identifier of the Noah rule created for permanent/quoted triggers, when
+  /// returned.
+  public let ruleId: String?
+
+  public init(
+    destinationAddress: String? = nil,
+    conditions: [NoahDepositSourceTriggerCondition]? = nil,
+    ruleId: String? = nil
+  ) {
+    self.destinationAddress = destinationAddress
+    self.conditions = conditions
+    self.ruleId = ruleId
+  }
+}

--- a/Sources/PortalSwift/Core/Api/Noah/NoahNetwork.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahNetwork.swift
@@ -1,0 +1,45 @@
+//
+//  NoahNetwork.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+
+/// Convenience constants for the CAIP-2 chain IDs that connect-api accepts in
+/// Noah `network` parameters.
+///
+/// Only chains present in connect-api's `CAIP2_TO_NOAH_NETWORK` map are included.
+/// Passing any other value will be rejected with
+/// `Unsupported network for Noah integration`.
+///
+/// The BFF validates these via the `[namespace]:[reference]` regex and then
+/// translates them into Noah's internal network strings (e.g.
+/// `"eip155:1"` -> `"Ethereum"`). Passing a non-CAIP-2 value (e.g. `"ethereum"`)
+/// will be rejected with `Network must be a "[namespace]:[reference]"`.
+public enum NoahNetwork {
+  /// Ethereum mainnet — `eip155:1` -> Noah `"Ethereum"`.
+  public static let ethereum = "eip155:1"
+  /// Ethereum Sepolia testnet — `eip155:11155111` -> Noah `"EthereumTestSepolia"`.
+  /// Use with sandbox-only test assets such as `USDC_TEST`.
+  public static let ethereumSepolia = "eip155:11155111"
+  /// Base mainnet — `eip155:8453` -> Noah `"Base"`.
+  public static let base = "eip155:8453"
+  /// Base Sepolia testnet — `eip155:84532` -> Noah `"BaseTestSepolia"`.
+  public static let baseSepolia = "eip155:84532"
+  /// Polygon PoS mainnet — `eip155:137` -> Noah `"PolygonPos"`.
+  public static let polygon = "eip155:137"
+  /// Polygon Amoy testnet — `eip155:80002` -> Noah `"PolygonTestAmoy"`.
+  public static let polygonAmoy = "eip155:80002"
+  /// Gnosis mainnet — `eip155:100` -> Noah `"Gnosis"`.
+  public static let gnosis = "eip155:100"
+  /// Gnosis Chiado testnet — `eip155:10200` -> Noah `"GnosisTestChiado"`.
+  public static let gnosisChiado = "eip155:10200"
+  /// Solana mainnet — `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` -> Noah `"Solana"`.
+  /// Equivalent to `solana:mainnet` on the BFF.
+  public static let solana = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+  /// Solana devnet — `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` -> Noah `"SolanaDevnet"`.
+  /// Equivalent to `solana:devnet` on the BFF.
+  public static let solanaDevnet = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
+}

--- a/Sources/PortalSwift/Core/Api/Noah/NoahSimulatePayinRequest.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahSimulatePayinRequest.swift
@@ -1,0 +1,25 @@
+//
+//  NoahSimulatePayinRequest.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+
+/// Request body for `POST /integrations/noah/payins/simulate`.
+public struct NoahSimulatePayinRequest: Codable {
+  public let paymentMethodId: String
+  public let fiatAmount: String
+  public let fiatCurrency: String
+
+  public init(
+    paymentMethodId: String,
+    fiatAmount: String,
+    fiatCurrency: String
+  ) {
+    self.paymentMethodId = paymentMethodId
+    self.fiatAmount = fiatAmount
+    self.fiatCurrency = fiatCurrency
+  }
+}

--- a/Sources/PortalSwift/Core/Api/Noah/NoahSimulatePayinResponse.swift
+++ b/Sources/PortalSwift/Core/Api/Noah/NoahSimulatePayinResponse.swift
@@ -1,0 +1,34 @@
+//
+//  NoahSimulatePayinResponse.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+
+/// Response from `POST /integrations/noah/payins/simulate`.
+///
+/// - Important: This endpoint is **sandbox-only**. The BFF returns
+///   `Forbidden` in production environments.
+public struct NoahSimulatePayinResponse: Codable {
+  public let data: NoahSimulatePayinData
+  public let metadata: NoahResponseMetadata?
+
+  public init(data: NoahSimulatePayinData, metadata: NoahResponseMetadata? = nil) {
+    self.data = data
+    self.metadata = metadata
+  }
+}
+
+/// The `data` payload of a Noah simulate-payin response.
+public struct NoahSimulatePayinData: Codable {
+  public let fiatDepositId: String
+  /// Reference for the simulated deposit, when returned by Noah.
+  public let reference: String?
+
+  public init(fiatDepositId: String, reference: String? = nil) {
+    self.fiatDepositId = fiatDepositId
+    self.reference = reference
+  }
+}

--- a/Sources/PortalSwift/Core/Api/PortalApi.swift
+++ b/Sources/PortalSwift/Core/Api/PortalApi.swift
@@ -29,6 +29,7 @@ public protocol PortalApiProtocol: AnyObject {
   func getTransactions(_ chainId: String, limit: Int?, offset: Int?, order: TransactionOrder?) async throws -> [FetchedTransaction]
   func identify(_ traits: [String: AnyCodable]) async throws -> MetricsResponse
   func prepareEject(_ walletId: String, _ backupMethod: BackupMethods) async throws -> String
+  func generatePreGeneratedShares(metadataStr: String) async throws -> GenerateApiResponse
   func refreshClient() async throws
   func updateShareStatus(_ type: PortalSharePairType, status: SharePairUpdateStatus, sharePairIds: [String]) async throws
   func storeClientCipherText(_ backupSharePairId: String, cipherText: String) async throws -> Bool
@@ -92,6 +93,7 @@ public class PortalApi: PortalApiProtocol {
   private let _clientStorage = ThreadSafeClientWrapper()
   private var apiKey: String
   private var baseUrl: String
+  private let enclaveMPCHost: String
   private let decoder = JSONDecoder()
   private var httpRequests: HttpRequester
   private let logger = PortalLogger.shared
@@ -173,12 +175,14 @@ public class PortalApi: PortalApiProtocol {
   public init(
     apiKey: String,
     apiHost: String = "api.portalhq.io",
+    enclaveMPCHost: String = "mpc-client.portalhq.io",
     provider: PortalProviderProtocol? = nil,
     featureFlags: FeatureFlags? = nil,
     requests: PortalRequestsProtocol? = nil
   ) {
     self.apiKey = apiKey
     self.baseUrl = apiHost.starts(with: "localhost") ? "http://\(apiHost)" : "https://\(apiHost)"
+    self.enclaveMPCHost = enclaveMPCHost
     self.featureFlags = featureFlags
     self.provider = provider
     self.requests = requests ?? PortalRequests()
@@ -495,6 +499,21 @@ public class PortalApi: PortalApiProtocol {
     }
 
     throw URLError(.badURL)
+  }
+
+  public func generatePreGeneratedShares(metadataStr: String) async throws -> GenerateApiResponse {
+    guard let url = URL(string: "https://\(enclaveMPCHost)/v1/generate") else {
+      self.logger.error("PortalApi.generatePreGeneratedShares() - Unable to build request URL.")
+      throw URLError(.badURL)
+    }
+
+    do {
+      let payload = GenerateApiRequest(usePreGenerated: true, metadataStr: metadataStr)
+      return try await self.post(url, withBearerToken: self.apiKey, andPayload: payload, mappingInResponse: GenerateApiResponse.self)
+    } catch {
+      self.logger.error("PortalApi.generatePreGeneratedShares() - Unable to generate pre-generated shares: \(error.localizedDescription)")
+      throw error
+    }
   }
 
   public func updateShareStatus(

--- a/Sources/PortalSwift/Core/Api/PortalApi.swift
+++ b/Sources/PortalSwift/Core/Api/PortalApi.swift
@@ -19,30 +19,30 @@ public protocol PortalApiProtocol: AnyObject {
   var evmAccountType: PortalEvmAccountTypeApiProtocol { get }
   var noah: PortalNoahApiProtocol { get }
 
-  func eject() async throws -> String
+  func eject(traceId: String?) async throws -> String
   func fund(chainId: String, params: FundParams) async throws -> FundResponse
-  func getClient() async throws -> ClientResponse
-  func getClientCipherText(_ backupSharePairId: String) async throws -> String
+  func getClient(traceId: String?) async throws -> ClientResponse
+  func getClientCipherText(_ backupSharePairId: String, traceId: String?) async throws -> String
   func getQuote(_ swapsApiKey: String, withArgs: QuoteArgs, forChainId: String?) async throws -> Quote
   func getNftAssets(_ chainId: String) async throws -> [NftAsset]
   func getSharePairs(_ type: PortalSharePairType, walletId: String) async throws -> [FetchedSharePair]
   func getSources(_ swapsApiKey: String, forChainId: String) async throws -> [String: String]
   func getTransactions(_ chainId: String, limit: Int?, offset: Int?, order: TransactionOrder?) async throws -> [FetchedTransaction]
   func identify(_ traits: [String: AnyCodable]) async throws -> MetricsResponse
-  func prepareEject(_ walletId: String, _ backupMethod: BackupMethods) async throws -> String
-  func generatePreGeneratedShares(metadataStr: String) async throws -> GenerateApiResponse
-  func refreshClient() async throws
-  func updateShareStatus(_ type: PortalSharePairType, status: SharePairUpdateStatus, sharePairIds: [String]) async throws
-  func storeClientCipherText(_ backupSharePairId: String, cipherText: String) async throws -> Bool
+  func prepareEject(_ walletId: String, _ backupMethod: BackupMethods, traceId: String?) async throws -> String
+  func generatePreGeneratedShares(metadataStr: String, traceId: String?) async throws -> GenerateApiResponse
+  func refreshClient(traceId: String?) async throws
+  func updateShareStatus(_ type: PortalSharePairType, status: SharePairUpdateStatus, sharePairIds: [String], traceId: String?) async throws
+  func storeClientCipherText(_ backupSharePairId: String, cipherText: String, traceId: String?) async throws -> Bool
   func track(_ event: String, withProperties: [String: AnyCodable]) async throws -> MetricsResponse
   func evaluateTransaction(chainId: String, transaction: EvaluateTransactionParam, operationType: EvaluateTransactionOperationType?) async throws -> BlockaidValidateTrxRes
-  func buildEip155Transaction(chainId: String, params: BuildTransactionParam) async throws -> BuildEip115TransactionResponse
-  func buildSolanaTransaction(chainId: String, params: BuildTransactionParam) async throws -> BuildSolanaTransactionResponse
-  func buildBitcoinP2wpkhTransaction(chainId: String, params: BuildTransactionParam) async throws -> BuildBitcoinP2wpkhTransactionResponse
-  func broadcastBitcoinP2wpkhTransaction(chainId: String, params: BroadcastParam) async throws -> BroadcastBitcoinP2wpkhTransactionResponse
+  func buildEip155Transaction(chainId: String, params: BuildTransactionParam, traceId: String?) async throws -> BuildEip115TransactionResponse
+  func buildSolanaTransaction(chainId: String, params: BuildTransactionParam, traceId: String?) async throws -> BuildSolanaTransactionResponse
+  func buildBitcoinP2wpkhTransaction(chainId: String, params: BuildTransactionParam, traceId: String?) async throws -> BuildBitcoinP2wpkhTransactionResponse
+  func broadcastBitcoinP2wpkhTransaction(chainId: String, params: BroadcastParam, traceId: String?) async throws -> BroadcastBitcoinP2wpkhTransactionResponse
   func getAssets(_ chainId: String) async throws -> AssetsResponse
   func getTransactionDetails(chain: String, signature: String) async throws -> GetTransactionDetailsResponse
-  func getWalletCapabilities() async throws -> WalletCapabilitiesResponse
+  func getWalletCapabilities(traceId: String?) async throws -> WalletCapabilitiesResponse
 
   // deprecated functions
   @available(*, deprecated, message: "This function has been moved to 'Portal'. Please use 'Portal.getBalances()' instead.") // this func need to be private thats why we deprecate it to move it to private later
@@ -69,6 +69,66 @@ public protocol PortalApiProtocol: AnyObject {
   func getBackupShareMetadata(completion: @escaping (Result<[FetchedSharePair]>) -> Void) throws
   @available(*, deprecated, renamed: "getSharePairs", message: "Please use the async/await implementation of getSharePairs().")
   func getSigningShareMetadata(completion: @escaping (Result<[FetchedSharePair]>) -> Void) throws
+}
+
+/// Backward-compatible convenience overloads.
+///
+/// Several API requirements carry an optional `traceId` so high-level operations
+/// (e.g. `sendAsset`, MPC generate/backup/recover) can share a single
+/// `X-Portal-Trace-Id` across their requests. These overloads preserve the original
+/// call shapes (without `traceId`) so existing callers continue to compile unchanged.
+public extension PortalApiProtocol {
+  func eject() async throws -> String {
+    try await eject(traceId: nil)
+  }
+
+  func getClient() async throws -> ClientResponse {
+    try await getClient(traceId: nil)
+  }
+
+  func getClientCipherText(_ backupSharePairId: String) async throws -> String {
+    try await getClientCipherText(backupSharePairId, traceId: nil)
+  }
+
+  func prepareEject(_ walletId: String, _ backupMethod: BackupMethods) async throws -> String {
+    try await prepareEject(walletId, backupMethod, traceId: nil)
+  }
+
+  func generatePreGeneratedShares(metadataStr: String) async throws -> GenerateApiResponse {
+    try await generatePreGeneratedShares(metadataStr: metadataStr, traceId: nil)
+  }
+
+  func refreshClient() async throws {
+    try await refreshClient(traceId: nil)
+  }
+
+  func updateShareStatus(_ type: PortalSharePairType, status: SharePairUpdateStatus, sharePairIds: [String]) async throws {
+    try await updateShareStatus(type, status: status, sharePairIds: sharePairIds, traceId: nil)
+  }
+
+  func storeClientCipherText(_ backupSharePairId: String, cipherText: String) async throws -> Bool {
+    try await storeClientCipherText(backupSharePairId, cipherText: cipherText, traceId: nil)
+  }
+
+  func getWalletCapabilities() async throws -> WalletCapabilitiesResponse {
+    try await getWalletCapabilities(traceId: nil)
+  }
+
+  func buildEip155Transaction(chainId: String, params: BuildTransactionParam) async throws -> BuildEip115TransactionResponse {
+    try await buildEip155Transaction(chainId: chainId, params: params, traceId: nil)
+  }
+
+  func buildSolanaTransaction(chainId: String, params: BuildTransactionParam) async throws -> BuildSolanaTransactionResponse {
+    try await buildSolanaTransaction(chainId: chainId, params: params, traceId: nil)
+  }
+
+  func buildBitcoinP2wpkhTransaction(chainId: String, params: BuildTransactionParam) async throws -> BuildBitcoinP2wpkhTransactionResponse {
+    try await buildBitcoinP2wpkhTransaction(chainId: chainId, params: params, traceId: nil)
+  }
+
+  func broadcastBitcoinP2wpkhTransaction(chainId: String, params: BroadcastParam) async throws -> BroadcastBitcoinP2wpkhTransactionResponse {
+    try await broadcastBitcoinP2wpkhTransaction(chainId: chainId, params: params, traceId: nil)
+  }
 }
 
 /// The ThreadSafeClientWrapper is just a thread-safe actor to consume the ClientResponse class, we need to refactor that later.
@@ -201,7 +261,8 @@ public class PortalApi: PortalApiProtocol {
    * Public functions
    *******************************************/
 
-  public func eject() async throws -> String {
+  public func eject(traceId: String? = nil) async throws -> String {
+    let traceId = traceId ?? generateTraceId()
     if let url = URL(string: "\(baseUrl)/api/v3/clients/me/eject") {
       do {
         let body: [String: String] = [
@@ -209,7 +270,7 @@ public class PortalApi: PortalApiProtocol {
           "clientPlatformVersion": SDK_VERSION
         ]
 
-        let ejectData = try await post(url, withBearerToken: self.apiKey, andPayload: body, mappingInResponse: Data.self)
+        let ejectData = try await post(url, withBearerToken: self.apiKey, andPayload: body, traceId: traceId, mappingInResponse: Data.self)
         guard let ejectResponse = String(data: ejectData, encoding: .utf8) else {
           throw PortalApiError.unableToReadStringResponse
         }
@@ -227,9 +288,10 @@ public class PortalApi: PortalApiProtocol {
 
   @available(*, deprecated, message: "This function has been moved to 'Portal'. Please use 'Portal.getBalances()' instead.") // this func need to be private thats why we deprecate it to move it to private later
   public func getBalances(_ chainId: String) async throws -> [FetchedBalance] {
+    let traceId = generateTraceId()
     if let url = URL(string: "\(baseUrl)/api/v3/clients/me/balances?chainId=\(chainId)") {
       do {
-        let balancesResponse = try await get(url, withBearerToken: self.apiKey, mappingInResponse: [FetchedBalance].self)
+        let balancesResponse = try await get(url, withBearerToken: self.apiKey, traceId: traceId, mappingInResponse: [FetchedBalance].self)
 
         return balancesResponse
       } catch {
@@ -243,11 +305,14 @@ public class PortalApi: PortalApiProtocol {
   }
 
   /// Retrieve the client by API key.
+  /// - Parameters:
+  ///   - traceId: Optional trace ID forwarded as the `X-Portal-Trace-Id` header.
   /// - Returns: ClientResponse
-  public func getClient() async throws -> ClientResponse {
+  public func getClient(traceId: String? = nil) async throws -> ClientResponse {
+    let traceId = traceId ?? generateTraceId()
     if let url = URL(string: "\(baseUrl)/api/v3/clients/me") {
       do {
-        let clientResponse = try await get(url, withBearerToken: self.apiKey, mappingInResponse: ClientResponse.self)
+        let clientResponse = try await get(url, withBearerToken: self.apiKey, traceId: traceId, mappingInResponse: ClientResponse.self)
 
         return clientResponse
       } catch {
@@ -259,9 +324,10 @@ public class PortalApi: PortalApiProtocol {
   }
 
   public func getAssets(_ chainId: String) async throws -> AssetsResponse {
+    let traceId = generateTraceId()
     if let url = URL(string: "\(baseUrl)/api/v3/clients/me/chains/\(chainId)/assets") {
       do {
-        let assets = try await get(url, withBearerToken: self.apiKey, mappingInResponse: AssetsResponse.self)
+        let assets = try await get(url, withBearerToken: self.apiKey, traceId: traceId, mappingInResponse: AssetsResponse.self)
 
         return assets
       } catch {
@@ -274,10 +340,11 @@ public class PortalApi: PortalApiProtocol {
     throw URLError(.badURL)
   }
 
-  public func getClientCipherText(_ backupSharePairId: String) async throws -> String {
+  public func getClientCipherText(_ backupSharePairId: String, traceId: String? = nil) async throws -> String {
+    let traceId = traceId ?? generateTraceId()
     if let url = URL(string: "\(baseUrl)/api/v3/clients/me/backup-share-pairs/\(backupSharePairId)/cipher-text") {
       do {
-        let response = try await get(url, withBearerToken: self.apiKey, mappingInResponse: ClientCipherTextResponse.self)
+        let response = try await get(url, withBearerToken: self.apiKey, traceId: traceId, mappingInResponse: ClientCipherTextResponse.self)
 
         return response.cipherText
       } catch {
@@ -289,9 +356,10 @@ public class PortalApi: PortalApiProtocol {
   }
 
   public func getSources(_ swapsApiKey: String, forChainId: String) async throws -> [String: String] {
+    let traceId = generateTraceId()
     if let url = URL(string: "\(baseUrl)/api/v3/swaps/sources") {
       let payload = ["apiKey": swapsApiKey, "chainId": forChainId]
-      let response = try await post(url, withBearerToken: self.apiKey, andPayload: payload, mappingInResponse: [String: String].self)
+      let response = try await post(url, withBearerToken: self.apiKey, andPayload: payload, traceId: traceId, mappingInResponse: [String: String].self)
 
       return response
     }
@@ -300,6 +368,7 @@ public class PortalApi: PortalApiProtocol {
   }
 
   public func getQuote(_ swapsApiKey: String, withArgs: QuoteArgs, forChainId: String? = nil) async throws -> Quote {
+    let traceId = generateTraceId()
     let chainId = forChainId != nil ? forChainId : "eip155:\(self.chainId ?? 1)"
 
     if let url = URL(string: "\(baseUrl)/api/v3/swaps/quote") {
@@ -311,7 +380,7 @@ public class PortalApi: PortalApiProtocol {
       body["apiKey"] = AnyCodable(swapsApiKey)
       body["chainId"] = AnyCodable(chainId)
 
-      let response = try await post(url, withBearerToken: self.apiKey, andPayload: body, mappingInResponse: Quote.self)
+      let response = try await post(url, withBearerToken: self.apiKey, andPayload: body, traceId: traceId, mappingInResponse: Quote.self)
 
       return response
     }
@@ -320,9 +389,10 @@ public class PortalApi: PortalApiProtocol {
   }
 
   public func getNftAssets(_ chainId: String) async throws -> [NftAsset] {
+    let traceId = generateTraceId()
     if let url = URL(string: "\(baseUrl)/api/v3/clients/me/chains/\(chainId)/assets/nfts") {
       do {
-        let nfts = try await get(url, withBearerToken: self.apiKey, mappingInResponse: [NftAsset].self)
+        let nfts = try await get(url, withBearerToken: self.apiKey, traceId: traceId, mappingInResponse: [NftAsset].self)
 
         return nfts
       } catch {
@@ -336,9 +406,10 @@ public class PortalApi: PortalApiProtocol {
   }
 
   public func getSharePairs(_ type: PortalSharePairType, walletId: String) async throws -> [FetchedSharePair] {
+    let traceId = generateTraceId()
     if let url = URL(string: "\(baseUrl)/api/v3/clients/me/wallets/\(walletId)/\(type)-share-pairs") {
       do {
-        let sharePairs = try await get(url, withBearerToken: self.apiKey, mappingInResponse: [FetchedSharePair].self)
+        let sharePairs = try await get(url, withBearerToken: self.apiKey, traceId: traceId, mappingInResponse: [FetchedSharePair].self)
 
         return sharePairs
       } catch {
@@ -376,9 +447,10 @@ public class PortalApi: PortalApiProtocol {
       requestUrlString += "&" + queryParams.joined(separator: "&")
     }
 
+    let traceId = generateTraceId()
     if let url = URL(string: requestUrlString) {
       do {
-        let transactions = try await get(url, withBearerToken: self.apiKey, mappingInResponse: [FetchedTransaction].self)
+        let transactions = try await get(url, withBearerToken: self.apiKey, traceId: traceId, mappingInResponse: [FetchedTransaction].self)
 
         return transactions
       } catch {
@@ -400,8 +472,9 @@ public class PortalApi: PortalApiProtocol {
       throw URLError(.badURL)
     }
 
+    let traceId = generateTraceId()
     do {
-      return try await get(url, withBearerToken: self.apiKey, mappingInResponse: GetTransactionDetailsResponse.self)
+      return try await get(url, withBearerToken: self.apiKey, traceId: traceId, mappingInResponse: GetTransactionDetailsResponse.self)
     } catch {
       self.logger.error("PortalApi.getTransactionDetails() - Error: \(error.localizedDescription)")
       throw error
@@ -409,8 +482,9 @@ public class PortalApi: PortalApiProtocol {
   }
 
   public func identify(_ traits: [String: AnyCodable] = [:]) async throws -> MetricsResponse {
+    let traceId = generateTraceId()
     if let url = URL(string: "\(baseUrl)/api/v1/analytics/identify") {
-      let response = try await post(url, withBearerToken: self.apiKey, andPayload: ["traits": traits], mappingInResponse: MetricsResponse.self)
+      let response = try await post(url, withBearerToken: self.apiKey, andPayload: ["traits": traits], traceId: traceId, mappingInResponse: MetricsResponse.self)
 
       return response
     }
@@ -418,9 +492,10 @@ public class PortalApi: PortalApiProtocol {
     throw URLError(.badURL)
   }
 
-  public func prepareEject(_ walletId: String, _ backupMethod: BackupMethods) async throws -> String {
+  public func prepareEject(_ walletId: String, _ backupMethod: BackupMethods, traceId: String? = nil) async throws -> String {
+    let traceId = traceId ?? generateTraceId()
     if let url = URL(string: "\(baseUrl)/api/v3/clients/me/wallets/\(walletId)/prepare-eject") {
-      let prepareEjectResponse = try await post(url, withBearerToken: self.apiKey, andPayload: ["backupMethod": backupMethod.rawValue], mappingInResponse: PrepareEjectResponse.self)
+      let prepareEjectResponse = try await post(url, withBearerToken: self.apiKey, andPayload: ["backupMethod": backupMethod.rawValue], traceId: traceId, mappingInResponse: PrepareEjectResponse.self)
 
       return prepareEjectResponse.share
     }
@@ -428,9 +503,9 @@ public class PortalApi: PortalApiProtocol {
     throw URLError(.badURL)
   }
 
-  public func refreshClient() async throws {
+  public func refreshClient(traceId: String? = nil) async throws {
     do {
-      try await _clientStorage.set(client: self.getClient())
+      try await _clientStorage.set(client: self.getClient(traceId: traceId))
 
       return
     } catch {
@@ -457,13 +532,14 @@ public class PortalApi: PortalApiProtocol {
     guard let chainId = chainId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
       throw PortalApiError.unableToEncodeData
     }
+    let traceId = generateTraceId()
     if let url = URL(string: "\(baseUrl)/api/v3/clients/me/evaluate-transaction?chainId=\(chainId)") {
       do {
         var payload = transaction.toDictionary()
         if let operationType {
           payload["operationType"] = operationType.rawValue
         }
-        let response = try await post(url, withBearerToken: self.apiKey, andPayload: payload, mappingInResponse: BlockaidValidateTrxRes.self)
+        let response = try await post(url, withBearerToken: self.apiKey, andPayload: payload, traceId: traceId, mappingInResponse: BlockaidValidateTrxRes.self)
 
         return response
       } catch {
@@ -476,13 +552,14 @@ public class PortalApi: PortalApiProtocol {
     }
   }
 
-  public func storeClientCipherText(_ backupSharePairId: String, cipherText: String) async throws -> Bool {
+  public func storeClientCipherText(_ backupSharePairId: String, cipherText: String, traceId: String? = nil) async throws -> Bool {
+    let traceId = traceId ?? generateTraceId()
     if let url = URL(string: "\(baseUrl)/api/v3/clients/me/backup-share-pairs/\(backupSharePairId)") {
       do {
         let payload = AnyCodable([
           "clientCipherText": cipherText
         ])
-        try await patch(url, withBearerToken: self.apiKey, andPayload: payload, mappingInResponse: Data.self)
+        try await patch(url, withBearerToken: self.apiKey, andPayload: payload, traceId: traceId, mappingInResponse: Data.self)
 
         return true
       } catch {
@@ -496,12 +573,13 @@ public class PortalApi: PortalApiProtocol {
   }
 
   public func track(_ event: String, withProperties: [String: AnyCodable]) async throws -> MetricsResponse {
+    let traceId = generateTraceId()
     if let url = URL(string: "\(baseUrl)/api/v1/analytics/track") {
       let payload = MetricsTrackRequest(
         event: event,
         properties: withProperties
       )
-      let response = try await post(url, withBearerToken: self.apiKey, andPayload: payload, mappingInResponse: MetricsResponse.self)
+      let response = try await post(url, withBearerToken: self.apiKey, andPayload: payload, traceId: traceId, mappingInResponse: MetricsResponse.self)
 
       return response
     }
@@ -509,7 +587,8 @@ public class PortalApi: PortalApiProtocol {
     throw URLError(.badURL)
   }
 
-  public func generatePreGeneratedShares(metadataStr: String) async throws -> GenerateApiResponse {
+  public func generatePreGeneratedShares(metadataStr: String, traceId: String? = nil) async throws -> GenerateApiResponse {
+    let traceId = traceId ?? generateTraceId()
     guard let url = URL(string: "https://\(enclaveMPCHost)/v1/generate") else {
       self.logger.error("PortalApi.generatePreGeneratedShares() - Unable to build request URL.")
       throw URLError(.badURL)
@@ -517,7 +596,7 @@ public class PortalApi: PortalApiProtocol {
 
     do {
       let payload = GenerateApiRequest(usePreGenerated: true, metadataStr: metadataStr)
-      return try await self.post(url, withBearerToken: self.apiKey, andPayload: payload, mappingInResponse: GenerateApiResponse.self)
+      return try await self.post(url, withBearerToken: self.apiKey, andPayload: payload, traceId: traceId, mappingInResponse: GenerateApiResponse.self)
     } catch {
       self.logger.error("PortalApi.generatePreGeneratedShares() - Unable to generate pre-generated shares: \(error.localizedDescription)")
       throw error
@@ -527,8 +606,10 @@ public class PortalApi: PortalApiProtocol {
   public func updateShareStatus(
     _ type: PortalSharePairType,
     status: SharePairUpdateStatus,
-    sharePairIds: [String]
+    sharePairIds: [String],
+    traceId: String? = nil
   ) async throws {
+    let traceId = traceId ?? generateTraceId()
     if let url = URL(string: "\(baseUrl)/api/v3/clients/me/\(type.rawValue)-share-pairs/") {
       do {
         let payload = ShareStatusUpdateRequest(
@@ -537,7 +618,7 @@ public class PortalApi: PortalApiProtocol {
           status: status
         )
 
-        try await self.patch(url, withBearerToken: self.apiKey, andPayload: payload, mappingInResponse: Data.self)
+        try await self.patch(url, withBearerToken: self.apiKey, andPayload: payload, traceId: traceId, mappingInResponse: Data.self)
 
         return
       } catch {
@@ -551,9 +632,10 @@ public class PortalApi: PortalApiProtocol {
   }
 
   public func fund(chainId: String, params: FundParams) async throws -> FundResponse {
+    let traceId = generateTraceId()
     if let url = URL(string: "\(baseUrl)/api/v3/clients/me/fund") {
       let payload = FundRequestBody(amount: params.amount, chainId: chainId, token: params.token)
-      let response = try await post(url, withBearerToken: self.apiKey, andPayload: payload, mappingInResponse: FundResponse.self)
+      let response = try await post(url, withBearerToken: self.apiKey, andPayload: payload, traceId: traceId, mappingInResponse: FundResponse.self)
 
       return response
     }
@@ -561,13 +643,13 @@ public class PortalApi: PortalApiProtocol {
     throw URLError(.badURL)
   }
 
-  public func broadcastBitcoinP2wpkhTransaction(chainId: String, params: BroadcastParam) async throws -> BroadcastBitcoinP2wpkhTransactionResponse {
+  public func broadcastBitcoinP2wpkhTransaction(chainId: String, params: BroadcastParam, traceId: String?) async throws -> BroadcastBitcoinP2wpkhTransactionResponse {
     guard chainId.starts(with: "bip122:") else {
       throw PortalApiError.invalidChainId(message: "Invalid chainId: \(chainId). ChainId must start with 'bip122:'")
     }
 
     if let url = URL(string: "\(baseUrl)/api/v3/clients/me/chains/\(chainId)/assets/send/broadcast-transaction") {
-      let response = try await post(url, withBearerToken: self.apiKey, andPayload: params, mappingInResponse: BroadcastBitcoinP2wpkhTransactionResponse.self)
+      let response = try await post(url, withBearerToken: self.apiKey, andPayload: params, traceId: traceId, mappingInResponse: BroadcastBitcoinP2wpkhTransactionResponse.self)
 
       return response
     }
@@ -575,13 +657,13 @@ public class PortalApi: PortalApiProtocol {
     throw URLError(.badURL)
   }
 
-  public func buildBitcoinP2wpkhTransaction(chainId: String, params: BuildTransactionParam) async throws -> BuildBitcoinP2wpkhTransactionResponse {
+  public func buildBitcoinP2wpkhTransaction(chainId: String, params: BuildTransactionParam, traceId: String?) async throws -> BuildBitcoinP2wpkhTransactionResponse {
     guard chainId.starts(with: "bip122:") else {
       throw PortalApiError.invalidChainId(message: "Invalid chainId: \(chainId). ChainId must start with 'bip122:'")
     }
 
     if let url = getBuildTransactionUrl(chainId: chainId) {
-      let response = try await post(url, withBearerToken: self.apiKey, andPayload: params.toDictionary(), mappingInResponse: BuildBitcoinP2wpkhTransactionResponse.self)
+      let response = try await post(url, withBearerToken: self.apiKey, andPayload: params.toDictionary(), traceId: traceId, mappingInResponse: BuildBitcoinP2wpkhTransactionResponse.self)
 
       return response
     }
@@ -589,13 +671,13 @@ public class PortalApi: PortalApiProtocol {
     throw URLError(.badURL)
   }
 
-  public func buildEip155Transaction(chainId: String, params: BuildTransactionParam) async throws -> BuildEip115TransactionResponse {
+  public func buildEip155Transaction(chainId: String, params: BuildTransactionParam, traceId: String?) async throws -> BuildEip115TransactionResponse {
     guard chainId.starts(with: "eip155:") else {
       throw PortalApiError.invalidChainId(message: "Invalid chainId: \(chainId). ChainId must start with 'eip155:'")
     }
 
     if let url = getBuildTransactionUrl(chainId: chainId) {
-      let response = try await post(url, withBearerToken: self.apiKey, andPayload: params.toDictionary(), mappingInResponse: BuildEip115TransactionResponse.self)
+      let response = try await post(url, withBearerToken: self.apiKey, andPayload: params.toDictionary(), traceId: traceId, mappingInResponse: BuildEip115TransactionResponse.self)
 
       return response
     }
@@ -603,13 +685,13 @@ public class PortalApi: PortalApiProtocol {
     throw URLError(.badURL)
   }
 
-  public func buildSolanaTransaction(chainId: String, params: BuildTransactionParam) async throws -> BuildSolanaTransactionResponse {
+  public func buildSolanaTransaction(chainId: String, params: BuildTransactionParam, traceId: String?) async throws -> BuildSolanaTransactionResponse {
     guard chainId.starts(with: "solana:") else {
       throw PortalApiError.invalidChainId(message: "Invalid chainId: \(chainId). ChainId must start with 'solana:'")
     }
 
     if let url = getBuildTransactionUrl(chainId: chainId) {
-      let response = try await post(url, withBearerToken: self.apiKey, andPayload: params.toDictionary(), mappingInResponse: BuildSolanaTransactionResponse.self)
+      let response = try await post(url, withBearerToken: self.apiKey, andPayload: params.toDictionary(), traceId: traceId, mappingInResponse: BuildSolanaTransactionResponse.self)
 
       return response
     }
@@ -617,9 +699,10 @@ public class PortalApi: PortalApiProtocol {
     throw URLError(.badURL)
   }
 
-  public func getWalletCapabilities() async throws -> WalletCapabilitiesResponse {
+  public func getWalletCapabilities(traceId: String? = nil) async throws -> WalletCapabilitiesResponse {
+    let traceId = traceId ?? generateTraceId()
     if let url = URL(string: "\(baseUrl)/api/v3/clients/me/wallet_getCapabilities") {
-      let response = try await get(url, withBearerToken: self.apiKey, mappingInResponse: WalletCapabilitiesResponse.self)
+      let response = try await get(url, withBearerToken: self.apiKey, traceId: traceId, mappingInResponse: WalletCapabilitiesResponse.self)
 
       return response
     }
@@ -636,28 +719,28 @@ public class PortalApi: PortalApiProtocol {
   }
 
   @discardableResult
-  private func get<ResponseType>(_ url: URL, withBearerToken: String? = nil,
+  private func get<ResponseType>(_ url: URL, withBearerToken: String? = nil, traceId: String? = nil,
                                  mappingInResponse: ResponseType.Type) async throws -> ResponseType where ResponseType: Decodable
   {
-    let portalRequest = PortalAPIRequest(url: url, bearerToken: withBearerToken)
+    let portalRequest = PortalAPIRequest(url: url, bearerToken: withBearerToken, traceId: traceId)
     return try await self.requests.execute(request: portalRequest, mappingInResponse: mappingInResponse.self)
   }
 
   @discardableResult
-  private func patch<ResponseType>(_ url: URL, withBearerToken: String? = nil, andPayload: Codable, mappingInResponse: ResponseType.Type) async throws -> ResponseType where ResponseType: Decodable {
-    let portalRequest = PortalAPIRequest(url: url, method: .patch, payload: andPayload, bearerToken: withBearerToken)
+  private func patch<ResponseType>(_ url: URL, withBearerToken: String? = nil, andPayload: Codable, traceId: String? = nil, mappingInResponse: ResponseType.Type) async throws -> ResponseType where ResponseType: Decodable {
+    let portalRequest = PortalAPIRequest(url: url, method: .patch, payload: andPayload, bearerToken: withBearerToken, traceId: traceId)
     return try await self.requests.execute(request: portalRequest, mappingInResponse: mappingInResponse.self)
   }
 
   @discardableResult
-  private func put<ResponseType>(_ url: URL, withBearerToken: String? = nil, andPayload: Codable, mappingInResponse: ResponseType.Type) async throws -> ResponseType where ResponseType: Decodable {
-    let portalRequest = PortalAPIRequest(url: url, method: .put, payload: andPayload, bearerToken: withBearerToken)
+  private func put<ResponseType>(_ url: URL, withBearerToken: String? = nil, andPayload: Codable, traceId: String? = nil, mappingInResponse: ResponseType.Type) async throws -> ResponseType where ResponseType: Decodable {
+    let portalRequest = PortalAPIRequest(url: url, method: .put, payload: andPayload, bearerToken: withBearerToken, traceId: traceId)
     return try await self.requests.execute(request: portalRequest, mappingInResponse: mappingInResponse.self)
   }
 
   @discardableResult
-  private func post<ResponseType>(_ url: URL, withBearerToken: String? = nil, andPayload: Codable? = nil, mappingInResponse: ResponseType.Type) async throws -> ResponseType where ResponseType: Decodable {
-    let portalRequest = PortalAPIRequest(url: url, method: .post, payload: andPayload, bearerToken: withBearerToken)
+  private func post<ResponseType>(_ url: URL, withBearerToken: String? = nil, andPayload: Codable? = nil, traceId: String? = nil, mappingInResponse: ResponseType.Type) async throws -> ResponseType where ResponseType: Decodable {
+    let portalRequest = PortalAPIRequest(url: url, method: .post, payload: andPayload, bearerToken: withBearerToken, traceId: traceId)
     return try await self.requests.execute(request: portalRequest, mappingInResponse: mappingInResponse.self)
   }
 
@@ -680,10 +763,11 @@ public class PortalApi: PortalApiProtocol {
     guard let chainId = withChainId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
       throw PortalApiError.unableToEncodeData
     }
+    let traceId = generateTraceId()
     if let url = URL(string: "\(baseUrl)/api/v3/clients/me/simulate-transaction?chainId=\(chainId)") {
       do {
         let transformedTransaction = AnyCodable(transaction)
-        let simulatedTransaction = try await post(url, withBearerToken: self.apiKey, andPayload: transformedTransaction, mappingInResponse: SimulatedTransaction.self)
+        let simulatedTransaction = try await post(url, withBearerToken: self.apiKey, andPayload: transformedTransaction, traceId: traceId, mappingInResponse: SimulatedTransaction.self)
 
         return simulatedTransaction
       } catch {
@@ -855,7 +939,8 @@ public class PortalApi: PortalApiProtocol {
       path: "/api/v2/clients/me/wallet/stored-client-backup-share",
       body: body,
       headers: [
-        "Authorization": "Bearer \(self.apiKey)"
+        "Authorization": "Bearer \(self.apiKey)",
+        PORTAL_TRACE_ID_HEADER: generateTraceId()
       ],
       requestType: HttpRequestType.CustomRequest
     ) { (result: Result<String>) in

--- a/Sources/PortalSwift/Core/Api/PortalApi.swift
+++ b/Sources/PortalSwift/Core/Api/PortalApi.swift
@@ -17,6 +17,7 @@ public protocol PortalApiProtocol: AnyObject {
   var blockaid: PortalBlockaidApiProtocol { get }
   var delegations: PortalDelegationsApiProtocol { get }
   var evmAccountType: PortalEvmAccountTypeApiProtocol { get }
+  var noah: PortalNoahApiProtocol { get }
 
   func eject() async throws -> String
   func fund(chainId: String, params: FundParams) async throws -> FundResponse
@@ -160,6 +161,13 @@ public class PortalApi: PortalApiProtocol {
 
   /// Access to EVM Account Type API functionality.
   public lazy var evmAccountType: PortalEvmAccountTypeApiProtocol = PortalEvmAccountTypeApi(
+    apiKey: self.apiKey,
+    apiHost: self.baseUrl.replacingOccurrences(of: "https://", with: "").replacingOccurrences(of: "http://", with: ""),
+    requests: self.requests
+  )
+
+  /// Access to Noah ramps integration functionality.
+  public lazy var noah: PortalNoahApiProtocol = PortalNoahApi(
     apiKey: self.apiKey,
     apiHost: self.baseUrl.replacingOccurrences(of: "https://", with: "").replacingOccurrences(of: "http://", with: ""),
     requests: self.requests

--- a/Sources/PortalSwift/Core/Api/PortalDelegationsApi.swift
+++ b/Sources/PortalSwift/Core/Api/PortalDelegationsApi.swift
@@ -103,8 +103,9 @@ public class PortalDelegationsApi: PortalDelegationsApiProtocol {
       throw URLError(.badURL)
     }
     do {
+      let traceId = generateTraceId()
       let body = ApproveDelegationBody(delegateAddress: request.delegateAddress, amount: request.amount)
-      return try await post(url, withBearerToken: apiKey, andPayload: body, mappingInResponse: ApproveDelegationResponse.self)
+      return try await post(url, withBearerToken: apiKey, andPayload: body, traceId: traceId, mappingInResponse: ApproveDelegationResponse.self)
     } catch {
       logger.error("PortalDelegationsApi.approve() - Error: \(error.localizedDescription)")
       throw error
@@ -132,8 +133,9 @@ public class PortalDelegationsApi: PortalDelegationsApiProtocol {
       throw URLError(.badURL)
     }
     do {
+      let traceId = generateTraceId()
       let body = RevokeDelegationBody(delegateAddress: request.delegateAddress)
-      return try await post(url, withBearerToken: apiKey, andPayload: body, mappingInResponse: RevokeDelegationResponse.self)
+      return try await post(url, withBearerToken: apiKey, andPayload: body, traceId: traceId, mappingInResponse: RevokeDelegationResponse.self)
     } catch {
       logger.error("PortalDelegationsApi.revoke() - Error: \(error.localizedDescription)")
       throw error
@@ -160,7 +162,8 @@ public class PortalDelegationsApi: PortalDelegationsApiProtocol {
       throw URLError(.badURL)
     }
     do {
-      return try await get(url, withBearerToken: apiKey, mappingInResponse: DelegationStatusResponse.self)
+      let traceId = generateTraceId()
+      return try await get(url, withBearerToken: apiKey, traceId: traceId, mappingInResponse: DelegationStatusResponse.self)
     } catch {
       logger.error("PortalDelegationsApi.getStatus() - Error: \(error.localizedDescription)")
       throw error
@@ -190,8 +193,9 @@ public class PortalDelegationsApi: PortalDelegationsApiProtocol {
       throw URLError(.badURL)
     }
     do {
+      let traceId = generateTraceId()
       let body = TransferFromBody(fromAddress: request.fromAddress, toAddress: request.toAddress, amount: request.amount)
-      return try await post(url, withBearerToken: apiKey, andPayload: body, mappingInResponse: TransferFromResponse.self)
+      return try await post(url, withBearerToken: apiKey, andPayload: body, traceId: traceId, mappingInResponse: TransferFromResponse.self)
     } catch {
       logger.error("PortalDelegationsApi.transferFrom() - Error: \(error.localizedDescription)")
       throw error
@@ -216,9 +220,10 @@ public class PortalDelegationsApi: PortalDelegationsApiProtocol {
     _ url: URL,
     withBearerToken: String? = nil,
     andPayload: Codable? = nil,
+    traceId: String? = nil,
     mappingInResponse: ResponseType.Type
   ) async throws -> ResponseType where ResponseType: Decodable {
-    let portalRequest = PortalAPIRequest(url: url, method: .post, payload: andPayload, bearerToken: withBearerToken)
+    let portalRequest = PortalAPIRequest(url: url, method: .post, payload: andPayload, bearerToken: withBearerToken, traceId: traceId)
     return try await requests.execute(request: portalRequest, mappingInResponse: mappingInResponse.self)
   }
 
@@ -227,15 +232,17 @@ public class PortalDelegationsApi: PortalDelegationsApiProtocol {
   /// - Parameters:
   ///   - url: The target URL for the request
   ///   - withBearerToken: Optional bearer token for authentication
+  ///   - traceId: Optional trace ID forwarded as the `X-Portal-Trace-Id` header
   ///   - mappingInResponse: The response type to decode the response into
   /// - Returns: Decoded response of the specified type
   /// - Throws: Network or decoding errors if the request fails
   private func get<ResponseType>(
     _ url: URL,
     withBearerToken: String? = nil,
+    traceId: String? = nil,
     mappingInResponse: ResponseType.Type
   ) async throws -> ResponseType where ResponseType: Decodable {
-    let portalRequest = PortalAPIRequest(url: url, bearerToken: withBearerToken)
+    let portalRequest = PortalAPIRequest(url: url, bearerToken: withBearerToken, traceId: traceId)
     return try await requests.execute(request: portalRequest, mappingInResponse: mappingInResponse.self)
   }
 

--- a/Sources/PortalSwift/Core/Api/PortalEvmAccountTypeApi.swift
+++ b/Sources/PortalSwift/Core/Api/PortalEvmAccountTypeApi.swift
@@ -12,22 +12,44 @@ public protocol PortalEvmAccountTypeApiProtocol: AnyObject {
   /// Retrieves the account type for the client's wallet on the given chain.
   /// - Parameter chainId: CAIP-2 chain ID (e.g., "eip155:11155111")
   /// - Returns: Response containing account type status and metadata
-  func getStatus(chainId: String) async throws -> EvmAccountTypeResponse
+  func getStatus(chainId: String, traceId: String?) async throws -> EvmAccountTypeResponse
 
   /// Builds the authorization list hash for EIP-7702 upgrade.
   /// - Parameters:
   ///   - chainId: CAIP-2 chain ID
   ///   - subsidize: When `true`, the API submits the transaction on-chain and returns the hash in `data.transactionHash`.
+  ///   - traceId: Optional trace ID forwarded as the `X-Portal-Trace-Id` header.
   /// - Returns: Response containing the hash to sign
-  func buildAuthorizationList(chainId: String, subsidize: Bool?) async throws -> BuildAuthorizationListResponse
+  func buildAuthorizationList(chainId: String, subsidize: Bool?, traceId: String?) async throws -> BuildAuthorizationListResponse
 
   /// Builds the authorization transaction from the signature.
   /// - Parameters:
   ///   - chainId: CAIP-2 chain ID
   ///   - signature: The raw signature (without 0x prefix) from signing the authorization list hash
   ///   - subsidize: When `true`, the API submits the transaction on-chain and returns the hash in `data.transactionHash`.
+  ///   - traceId: Optional trace ID forwarded as the `X-Portal-Trace-Id` header.
   /// - Returns: Response containing the EIP-7702 transaction and, when subsidized, the on-chain transaction hash.
-  func buildAuthorizationTransaction(chainId: String, signature: String, subsidize: Bool?) async throws -> BuildAuthorizationTransactionResponse
+  func buildAuthorizationTransaction(chainId: String, signature: String, subsidize: Bool?, traceId: String?) async throws -> BuildAuthorizationTransactionResponse
+}
+
+/// Backward-compatible convenience overloads.
+///
+/// The requirements carry an optional `traceId` so `EvmAccountType.upgradeTo7702` can share a
+/// single `X-Portal-Trace-Id` across its requests. These overloads preserve the original call
+/// shapes (without `traceId`) so existing callers of `PortalEvmAccountTypeApiProtocol` continue
+/// to compile unchanged.
+public extension PortalEvmAccountTypeApiProtocol {
+  func getStatus(chainId: String) async throws -> EvmAccountTypeResponse {
+    try await getStatus(chainId: chainId, traceId: nil)
+  }
+
+  func buildAuthorizationList(chainId: String, subsidize: Bool? = nil) async throws -> BuildAuthorizationListResponse {
+    try await buildAuthorizationList(chainId: chainId, subsidize: subsidize, traceId: nil)
+  }
+
+  func buildAuthorizationTransaction(chainId: String, signature: String, subsidize: Bool? = nil) async throws -> BuildAuthorizationTransactionResponse {
+    try await buildAuthorizationTransaction(chainId: chainId, signature: signature, subsidize: subsidize, traceId: nil)
+  }
 }
 
 /// API class for EVM Account Type integration functionality.
@@ -63,7 +85,8 @@ public class PortalEvmAccountTypeApi: PortalEvmAccountTypeApiProtocol {
   /// - Parameter chainId: CAIP-2 chain ID (e.g., "eip155:11155111")
   /// - Returns: Response containing data.status ("SMART_CONTRACT", "EIP_155_EOA", "EIP_7702_EOA") and metadata (chainId, eoaAddress, smartContractAddress)
   /// - Throws: `URLError` if the URL cannot be constructed, or network/decoding errors if the request fails.
-  public func getStatus(chainId: String) async throws -> EvmAccountTypeResponse {
+  public func getStatus(chainId: String, traceId: String? = nil) async throws -> EvmAccountTypeResponse {
+    let traceId = traceId ?? generateTraceId()
     guard let encodedChain = chainId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
           let url = URL(string: "\(baseUrl)/api/v3/clients/me/chains/\(encodedChain)/wallet/account-type")
     else {
@@ -71,7 +94,7 @@ public class PortalEvmAccountTypeApi: PortalEvmAccountTypeApiProtocol {
       throw URLError(.badURL)
     }
     do {
-      return try await get(url, withBearerToken: apiKey, mappingInResponse: EvmAccountTypeResponse.self)
+      return try await get(url, withBearerToken: apiKey, traceId: traceId, mappingInResponse: EvmAccountTypeResponse.self)
     } catch {
       logger.error("PortalEvmAccountTypeApi.getStatus() - Error: \(error.localizedDescription)")
       throw error
@@ -85,7 +108,8 @@ public class PortalEvmAccountTypeApi: PortalEvmAccountTypeApiProtocol {
   ///   - subsidize: When `true`, the API submits the transaction on-chain and returns the transaction hash in `data.transactionHash`. Defaults to `nil`.
   /// - Returns: Response containing data.hash (hex string with 0x prefix)
   /// - Throws: `URLError` if the URL cannot be constructed, or network/decoding errors if the request fails.
-  public func buildAuthorizationList(chainId: String, subsidize: Bool? = nil) async throws -> BuildAuthorizationListResponse {
+  public func buildAuthorizationList(chainId: String, subsidize: Bool? = nil, traceId: String? = nil) async throws -> BuildAuthorizationListResponse {
+    let traceId = traceId ?? generateTraceId()
     guard let encodedChain = chainId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
           let url = URL(string: "\(baseUrl)/api/v3/clients/me/chains/\(encodedChain)/wallet/build-authorization-list")
     else {
@@ -94,7 +118,7 @@ public class PortalEvmAccountTypeApi: PortalEvmAccountTypeApiProtocol {
     }
     do {
       let body = BuildAuthorizationListRequest(subsidize: subsidize)
-      return try await post(url, withBearerToken: apiKey, andPayload: body, mappingInResponse: BuildAuthorizationListResponse.self)
+      return try await post(url, withBearerToken: apiKey, andPayload: body, traceId: traceId, mappingInResponse: BuildAuthorizationListResponse.self)
     } catch {
       logger.error("PortalEvmAccountTypeApi.buildAuthorizationList() - Error: \(error.localizedDescription)")
       throw error
@@ -109,7 +133,8 @@ public class PortalEvmAccountTypeApi: PortalEvmAccountTypeApiProtocol {
   ///   - subsidize: When `true`, the API submits the transaction on-chain and returns the transaction hash in `data.transactionHash`. Defaults to `nil`.
   /// - Returns: Response containing `data.transaction` (the EIP-7702 transaction) and, when subsidized, `data.transactionHash` (the on-chain transaction hash).
   /// - Throws: `URLError` if the URL cannot be constructed, or network/decoding errors if the request fails.
-  public func buildAuthorizationTransaction(chainId: String, signature: String, subsidize: Bool? = nil) async throws -> BuildAuthorizationTransactionResponse {
+  public func buildAuthorizationTransaction(chainId: String, signature: String, subsidize: Bool? = nil, traceId: String? = nil) async throws -> BuildAuthorizationTransactionResponse {
+    let traceId = traceId ?? generateTraceId()
     guard let encodedChain = chainId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
           let url = URL(string: "\(baseUrl)/api/v3/clients/me/chains/\(encodedChain)/wallet/build-authorization-transaction")
     else {
@@ -118,7 +143,7 @@ public class PortalEvmAccountTypeApi: PortalEvmAccountTypeApiProtocol {
     }
     do {
       let body = BuildAuthorizationTransactionRequest(signature: signature, subsidize: subsidize)
-      return try await post(url, withBearerToken: apiKey, andPayload: body, mappingInResponse: BuildAuthorizationTransactionResponse.self)
+      return try await post(url, withBearerToken: apiKey, andPayload: body, traceId: traceId, mappingInResponse: BuildAuthorizationTransactionResponse.self)
     } catch {
       logger.error("PortalEvmAccountTypeApi.buildAuthorizationTransaction() - Error: \(error.localizedDescription)")
       throw error
@@ -132,18 +157,20 @@ public class PortalEvmAccountTypeApi: PortalEvmAccountTypeApiProtocol {
     _ url: URL,
     withBearerToken: String? = nil,
     andPayload: Codable? = nil,
+    traceId: String? = nil,
     mappingInResponse: ResponseType.Type
   ) async throws -> ResponseType where ResponseType: Decodable {
-    let portalRequest = PortalAPIRequest(url: url, method: .post, payload: andPayload, bearerToken: withBearerToken)
+    let portalRequest = PortalAPIRequest(url: url, method: .post, payload: andPayload, bearerToken: withBearerToken, traceId: traceId)
     return try await requests.execute(request: portalRequest, mappingInResponse: mappingInResponse.self)
   }
 
   private func get<ResponseType>(
     _ url: URL,
     withBearerToken: String? = nil,
+    traceId: String? = nil,
     mappingInResponse: ResponseType.Type
   ) async throws -> ResponseType where ResponseType: Decodable {
-    let portalRequest = PortalAPIRequest(url: url, bearerToken: withBearerToken)
+    let portalRequest = PortalAPIRequest(url: url, bearerToken: withBearerToken, traceId: traceId)
     return try await requests.execute(request: portalRequest, mappingInResponse: mappingInResponse.self)
   }
 }

--- a/Sources/PortalSwift/Core/Api/PortalNoahApi.swift
+++ b/Sources/PortalSwift/Core/Api/PortalNoahApi.swift
@@ -1,0 +1,269 @@
+//
+//  PortalNoahApi.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+
+/// Protocol describing the Noah on/off-ramp API surface.
+public protocol PortalNoahApiProtocol: AnyObject {
+  func initiateKyc(request: NoahInitiateKycRequest) async throws -> NoahInitiateKycResponse
+  func initiatePayin(request: NoahInitiatePayinRequest) async throws -> NoahInitiatePayinResponse
+  func simulatePayin(request: NoahSimulatePayinRequest) async throws -> NoahSimulatePayinResponse
+  func getPaymentMethods(request: NoahGetPaymentMethodsRequest) async throws -> NoahGetPaymentMethodsResponse
+  func getPayoutCountries() async throws -> NoahGetPayoutCountriesResponse
+  func getPayoutChannels(request: NoahGetPayoutChannelsRequest) async throws -> NoahGetPayoutChannelsResponse
+  func getPayoutChannelForm(channelId: String) async throws -> NoahGetPayoutChannelFormResponse
+  func getPayoutQuote(request: NoahGetPayoutQuoteRequest) async throws -> NoahGetPayoutQuoteResponse
+  func initiatePayout(request: NoahInitiatePayoutRequest) async throws -> NoahInitiatePayoutResponse
+}
+
+public extension PortalNoahApiProtocol {
+  /// Convenience overload for `getPaymentMethods` using default request values.
+  func getPaymentMethods() async throws -> NoahGetPaymentMethodsResponse {
+    try await getPaymentMethods(request: NoahGetPaymentMethodsRequest())
+  }
+}
+
+/// API class for the Noah on/off-ramp integration.
+///
+/// Mirrors the React Native `PortalNoahApi` HTTP surface. All endpoints sit
+/// under `/api/v3/clients/me/integrations/noah/*` and require the client API
+/// key as a bearer token.
+public class PortalNoahApi: PortalNoahApiProtocol {
+  private let apiKey: String
+  private let baseUrl: String
+  private let requests: PortalRequestsProtocol
+  private let logger = PortalLogger.shared
+
+  private static let basePath = "/api/v3/clients/me/integrations/noah"
+
+  /// Create an instance of `PortalNoahApi`.
+  /// - Parameters:
+  ///   - apiKey: The Portal Client API key.
+  ///   - apiHost: The Portal API hostname.
+  ///   - requests: An instance of `PortalRequestsProtocol` used to perform HTTP requests.
+  public init(
+    apiKey: String,
+    apiHost: String = "api.portalhq.io",
+    requests: PortalRequestsProtocol? = nil
+  ) {
+    self.apiKey = apiKey
+    self.baseUrl = apiHost.starts(with: "localhost") ? "http://\(apiHost)" : "https://\(apiHost)"
+    self.requests = requests ?? PortalRequests()
+  }
+
+  /*******************************************
+   * Public functions
+   *******************************************/
+
+  /// Start a Noah KYC flow for the current client.
+  public func initiateKyc(request: NoahInitiateKycRequest) async throws -> NoahInitiateKycResponse {
+    guard let url = URL(string: "\(baseUrl)\(Self.basePath)/customers/kyc") else {
+      logger.error("PortalNoahApi.initiateKyc() - Unable to build request URL.")
+      throw URLError(.badURL)
+    }
+
+    do {
+      return try await post(url, withBearerToken: apiKey, andPayload: request, mappingInResponse: NoahInitiateKycResponse.self)
+    } catch {
+      logger.error("PortalNoahApi.initiateKyc() - Error: \(error.localizedDescription)")
+      throw error
+    }
+  }
+
+  /// Initiate a Noah payin (on-ramp) and receive bank deposit instructions.
+  public func initiatePayin(request: NoahInitiatePayinRequest) async throws -> NoahInitiatePayinResponse {
+    guard let url = URL(string: "\(baseUrl)\(Self.basePath)/payins") else {
+      logger.error("PortalNoahApi.initiatePayin() - Unable to build request URL.")
+      throw URLError(.badURL)
+    }
+
+    do {
+      return try await post(url, withBearerToken: apiKey, andPayload: request, mappingInResponse: NoahInitiatePayinResponse.self)
+    } catch {
+      logger.error("PortalNoahApi.initiatePayin() - Error: \(error.localizedDescription)")
+      throw error
+    }
+  }
+
+  /// Simulate a Noah payin (sandbox-only fiat deposit).
+  public func simulatePayin(request: NoahSimulatePayinRequest) async throws -> NoahSimulatePayinResponse {
+    guard let url = URL(string: "\(baseUrl)\(Self.basePath)/payins/simulate") else {
+      logger.error("PortalNoahApi.simulatePayin() - Unable to build request URL.")
+      throw URLError(.badURL)
+    }
+
+    do {
+      return try await post(url, withBearerToken: apiKey, andPayload: request, mappingInResponse: NoahSimulatePayinResponse.self)
+    } catch {
+      logger.error("PortalNoahApi.simulatePayin() - Error: \(error.localizedDescription)")
+      throw error
+    }
+  }
+
+  /// List stored Noah payment methods for the current client.
+  public func getPaymentMethods(request: NoahGetPaymentMethodsRequest) async throws -> NoahGetPaymentMethodsResponse {
+    guard let url = makeUrl(
+      path: "\(Self.basePath)/payouts/payment-methods",
+      queryItems: [
+        queryItem("pageSize", request.pageSize),
+        queryItem("pageToken", request.pageToken),
+        queryItem("capability", request.capability?.rawValue),
+      ]
+    ) else {
+      logger.error("PortalNoahApi.getPaymentMethods() - Unable to build request URL.")
+      throw URLError(.badURL)
+    }
+
+    do {
+      return try await get(url, withBearerToken: apiKey, mappingInResponse: NoahGetPaymentMethodsResponse.self)
+    } catch {
+      logger.error("PortalNoahApi.getPaymentMethods() - Error: \(error.localizedDescription)")
+      throw error
+    }
+  }
+
+  /// List the countries and fiat currencies supported for Noah payouts.
+  public func getPayoutCountries() async throws -> NoahGetPayoutCountriesResponse {
+    guard let url = URL(string: "\(baseUrl)\(Self.basePath)/payouts/countries") else {
+      logger.error("PortalNoahApi.getPayoutCountries() - Unable to build request URL.")
+      throw URLError(.badURL)
+    }
+
+    do {
+      return try await get(url, withBearerToken: apiKey, mappingInResponse: NoahGetPayoutCountriesResponse.self)
+    } catch {
+      logger.error("PortalNoahApi.getPayoutCountries() - Error: \(error.localizedDescription)")
+      throw error
+    }
+  }
+
+  /// List Noah payout channels matching the supplied filters.
+  public func getPayoutChannels(request: NoahGetPayoutChannelsRequest) async throws -> NoahGetPayoutChannelsResponse {
+    guard let url = makeUrl(
+      path: "\(Self.basePath)/payouts/channels",
+      queryItems: [
+        queryItem("cryptoCurrency", request.cryptoCurrency),
+        queryItem("country", request.country),
+        queryItem("fiatCurrency", request.fiatCurrency),
+        queryItem("fiatAmount", request.fiatAmount),
+        queryItem("paymentMethodId", request.paymentMethodId),
+        queryItem("pageSize", request.pageSize),
+        queryItem("pageToken", request.pageToken),
+      ]
+    ) else {
+      logger.error("PortalNoahApi.getPayoutChannels() - Unable to build request URL.")
+      throw URLError(.badURL)
+    }
+
+    do {
+      return try await get(url, withBearerToken: apiKey, mappingInResponse: NoahGetPayoutChannelsResponse.self)
+    } catch {
+      logger.error("PortalNoahApi.getPayoutChannels() - Error: \(error.localizedDescription)")
+      throw error
+    }
+  }
+
+  /// Fetch the dynamic form schema for the given Noah payout channel.
+  public func getPayoutChannelForm(channelId: String) async throws -> NoahGetPayoutChannelFormResponse {
+    // Encode as a single path segment. Both `.urlPathAllowed` and
+    // `URL.appendingPathComponent` leave `/` unescaped, which would alter the
+    // request path (path injection). Strip `/` from the allowed set so it is
+    // percent-encoded.
+    var allowed = CharacterSet.urlPathAllowed
+    allowed.remove(charactersIn: "/")
+    guard let encodedChannelId = channelId.addingPercentEncoding(withAllowedCharacters: allowed) else {
+      logger.error("PortalNoahApi.getPayoutChannelForm() - Unable to percent-encode channelId.")
+      throw PortalApiError.unableToEncodeData
+    }
+
+    guard let url = URL(string: "\(baseUrl)\(Self.basePath)/payouts/channels/\(encodedChannelId)/form") else {
+      logger.error("PortalNoahApi.getPayoutChannelForm() - Unable to build request URL.")
+      throw URLError(.badURL)
+    }
+
+    do {
+      return try await get(url, withBearerToken: apiKey, mappingInResponse: NoahGetPayoutChannelFormResponse.self)
+    } catch {
+      logger.error("PortalNoahApi.getPayoutChannelForm() - Error: \(error.localizedDescription)")
+      throw error
+    }
+  }
+
+  /// Request a Noah payout quote for the given channel and form responses.
+  public func getPayoutQuote(request: NoahGetPayoutQuoteRequest) async throws -> NoahGetPayoutQuoteResponse {
+    guard let url = URL(string: "\(baseUrl)\(Self.basePath)/payouts/quote") else {
+      logger.error("PortalNoahApi.getPayoutQuote() - Unable to build request URL.")
+      throw URLError(.badURL)
+    }
+
+    do {
+      return try await post(url, withBearerToken: apiKey, andPayload: request, mappingInResponse: NoahGetPayoutQuoteResponse.self)
+    } catch {
+      logger.error("PortalNoahApi.getPayoutQuote() - Error: \(error.localizedDescription)")
+      throw error
+    }
+  }
+
+  /// Initiate a Noah payout from a previously quoted payout.
+  public func initiatePayout(request: NoahInitiatePayoutRequest) async throws -> NoahInitiatePayoutResponse {
+    guard let url = URL(string: "\(baseUrl)\(Self.basePath)/payouts") else {
+      logger.error("PortalNoahApi.initiatePayout() - Unable to build request URL.")
+      throw URLError(.badURL)
+    }
+
+    do {
+      return try await post(url, withBearerToken: apiKey, andPayload: request, mappingInResponse: NoahInitiatePayoutResponse.self)
+    } catch {
+      logger.error("PortalNoahApi.initiatePayout() - Error: \(error.localizedDescription)")
+      throw error
+    }
+  }
+
+  /*******************************************
+   * Private functions
+   *******************************************/
+
+  /// Builds a URL with correctly escaped query values via `URLComponents`.
+  /// Prefer this over manual string joining + `.urlQueryAllowed`, which leaves
+  /// reserved separators like `&` and `=` unescaped.
+  private func makeUrl(path: String, queryItems: [URLQueryItem?] = []) -> URL? {
+    guard var components = URLComponents(string: "\(baseUrl)\(path)") else {
+      return nil
+    }
+    let items = queryItems.compactMap { $0 }
+    if !items.isEmpty {
+      components.queryItems = items
+    }
+    return components.url
+  }
+
+  private func queryItem(_ name: String, _ value: Any?) -> URLQueryItem? {
+    guard let value else { return nil }
+    return URLQueryItem(name: name, value: "\(value)")
+  }
+
+  @discardableResult
+  private func get<ResponseType>(
+    _ url: URL,
+    withBearerToken: String? = nil,
+    mappingInResponse: ResponseType.Type
+  ) async throws -> ResponseType where ResponseType: Decodable {
+    let portalRequest = PortalAPIRequest(url: url, bearerToken: withBearerToken)
+    return try await requests.execute(request: portalRequest, mappingInResponse: mappingInResponse.self)
+  }
+
+  @discardableResult
+  private func post<ResponseType>(
+    _ url: URL,
+    withBearerToken: String? = nil,
+    andPayload: Codable? = nil,
+    mappingInResponse: ResponseType.Type
+  ) async throws -> ResponseType where ResponseType: Decodable {
+    let portalRequest = PortalAPIRequest(url: url, method: .post, payload: andPayload, bearerToken: withBearerToken)
+    return try await requests.execute(request: portalRequest, mappingInResponse: mappingInResponse.self)
+  }
+}

--- a/Sources/PortalSwift/Core/Api/PortalYieldXyzApi.swift
+++ b/Sources/PortalSwift/Core/Api/PortalYieldXyzApi.swift
@@ -17,6 +17,8 @@ public protocol PortalYieldXyzApiProtocol: AnyObject {
   func getHistoricalYieldActions(request: YieldXyzGetHistoricalActionsRequest) async throws -> YieldXyzGetHistoricalActionsResponse
   func getYieldTransaction(transactionId: String) async throws -> YieldXyzGetTransactionResponse
   func submitTransactionHash(request: YieldXyzTrackTransactionRequest) async throws -> YieldXyzTrackTransactionResponse
+  func getYieldDefaults(includeOpportunities: Bool?) async throws -> YieldXyzGetDefaultsResponse
+  func getYieldValidators(yieldId: String) async throws -> YieldXyzGetValidatorsResponse
 }
 
 /// API class specifically for Yield.xyz integration functionality.
@@ -258,6 +260,52 @@ public class PortalYieldXyzApi: PortalYieldXyzApiProtocol {
           userInfo: [NSLocalizedDescriptionKey: "API returned 400 Bad Request when submitting transaction hash."]
         )
       }
+      throw error
+    }
+  }
+
+  /// Retrieves Portal's curated default yield opportunities, keyed by `"{caip2}:{TOKEN}"`.
+  /// - Parameter includeOpportunities: When `true`, the backend enriches each entry with the live opportunity.
+  /// - Returns: A `YieldXyzGetDefaultsResponse` whose `data` maps chain+token keys to default yields.
+  /// - Throws: An error if the operation fails.
+  public func getYieldDefaults(includeOpportunities: Bool? = nil) async throws -> YieldXyzGetDefaultsResponse {
+    var queryParams: [String] = []
+    addParam("includeOpportunities", includeOpportunities, to: &queryParams)
+
+    let queryString = queryParams.isEmpty ? "" : "?\(queryParams.joined(separator: "&"))"
+
+    guard let url = URL(string: "\(baseUrl)/api/v3/clients/me/integrations/yield-xyz/yields/defaults\(queryString)") else {
+      logger.error("PortalYieldXyzApi.getYieldDefaults() - Unable to build request URL.")
+      throw URLError(.badURL)
+    }
+
+    do {
+      return try await get(url, withBearerToken: apiKey, mappingInResponse: YieldXyzGetDefaultsResponse.self)
+    } catch {
+      logger.error("PortalYieldXyzApi.getYieldDefaults() - Error: \(error.localizedDescription)")
+      throw error
+    }
+  }
+
+  /// Retrieves available validators for a native-staking yield.
+  /// - Parameter yieldId: The yield identifier.
+  /// - Returns: A `YieldXyzGetValidatorsResponse` containing validators.
+  /// - Throws: An error if the operation fails.
+  public func getYieldValidators(yieldId: String) async throws -> YieldXyzGetValidatorsResponse {
+    // Encode as a single path segment (exclude `/` which `.urlPathAllowed` still permits).
+    var pathSegmentAllowed = CharacterSet.urlPathAllowed
+    pathSegmentAllowed.remove(charactersIn: "/")
+    let encodedYieldId = yieldId.addingPercentEncoding(withAllowedCharacters: pathSegmentAllowed) ?? yieldId
+
+    guard let url = URL(string: "\(baseUrl)/api/v3/clients/me/integrations/yield-xyz/yields/\(encodedYieldId)/validators") else {
+      logger.error("PortalYieldXyzApi.getYieldValidators() - Unable to build request URL.")
+      throw URLError(.badURL)
+    }
+
+    do {
+      return try await get(url, withBearerToken: apiKey, mappingInResponse: YieldXyzGetValidatorsResponse.self)
+    } catch {
+      logger.error("PortalYieldXyzApi.getYieldValidators() - Error: \(error.localizedDescription)")
       throw error
     }
   }

--- a/Sources/PortalSwift/Core/Api/lifi/LifiTradeAsset.swift
+++ b/Sources/PortalSwift/Core/Api/lifi/LifiTradeAsset.swift
@@ -1,0 +1,235 @@
+//
+//  LifiTradeAsset.swift
+//  PortalSwift
+//
+//  Created by Portal Labs, Inc.
+//  Copyright © 2025 Portal Labs, Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Closure invoked with progress updates while `tradeAsset` executes.
+public typealias LifiProgressHandler = (_ status: LifiTradeAssetProgressStatus, _ data: LifiTradeAssetProgressData) -> Void
+
+/// Closure that signs and submits an EVM transaction, returning the transaction hash.
+public typealias LifiSignAndSendTransaction = (_ transaction: ETHTransactionParam, _ chainId: String) async throws -> String
+
+/// The outcome of waiting for an on-chain transaction confirmation.
+public enum LifiConfirmationResult: Equatable {
+  /// The transaction was mined and reported a success status.
+  case confirmed
+  /// The transaction was mined but reverted (receipt status != 0x1).
+  case reverted
+  /// Confirmation could not be determined within the allotted attempts (still pending or the node
+  /// was unreachable). This is distinct from a definitive on-chain revert.
+  case timedOut
+}
+
+/// Closure that waits for an on-chain transaction confirmation.
+/// Throws `CancellationError` if the surrounding task is cancelled so polling can stop promptly.
+public typealias LifiWaitForConfirmation = (_ txHash: String, _ chainId: String) async throws -> LifiConfirmationResult
+
+/// Parameters for the high-level `tradeAsset` bridging method.
+
+// MARK: - LifiTradeAssetParams
+
+public struct LifiTradeAssetParams {
+  /// The sending chain. Can be the chain id or chain key (e.g. "8453").
+  public let fromChain: String
+  /// The receiving chain. Can be the chain id or chain key (e.g. "137").
+  public let toChain: String
+  /// The token that should be transferred. Can be the address or the symbol.
+  public let fromToken: String
+  /// The token that should be transferred to. Can be the address or the symbol.
+  public let toToken: String
+  /// The amount to send, expressed in the token’s base units as an integer string (e.g. wei for 18-decimal tokens).
+  public let amount: String
+  /// The sending wallet address.
+  public let fromAddress: String?
+  /// The receiving wallet address. If none is provided, the fromAddress will be used.
+  public let toAddress: String?
+  /// The index of the route to execute from the routes response (defaults to 0).
+  public let routeIndex: Int?
+  /// Optional callback that receives progress updates as the trade executes.
+  public let onProgress: LifiProgressHandler?
+
+  public init(
+    fromChain: String,
+    toChain: String,
+    fromToken: String,
+    toToken: String,
+    amount: String,
+    fromAddress: String? = nil,
+    toAddress: String? = nil,
+    routeIndex: Int? = nil,
+    onProgress: LifiProgressHandler? = nil
+  ) {
+    self.fromChain = fromChain
+    self.toChain = toChain
+    self.fromToken = fromToken
+    self.toToken = toToken
+    self.amount = amount
+    self.fromAddress = fromAddress
+    self.toAddress = toAddress
+    self.routeIndex = routeIndex
+    self.onProgress = onProgress
+  }
+}
+
+/// The result of a successful `tradeAsset` execution.
+
+// MARK: - LifiTradeAssetResult
+
+public struct LifiTradeAssetResult {
+  /// One transaction hash per executed step, in execution order.
+  public let hashes: [String]
+  /// The enriched steps (with populated transactionRequest) that were executed.
+  public let steps: [LifiStep]
+  /// The route that was selected and executed.
+  public let route: LifiRoute
+
+  public init(hashes: [String], steps: [LifiStep], route: LifiRoute) {
+    self.hashes = hashes
+    self.steps = steps
+    self.route = route
+  }
+}
+
+/// Progress status values emitted by `tradeAsset` via the `onProgress` callback.
+
+// MARK: - LifiTradeAssetProgressStatus
+
+public enum LifiTradeAssetProgressStatus: String {
+  /// Emitted before requesting routes.
+  case fetchingRoutes = "fetching_routes"
+  /// Emitted once a route has been selected.
+  case routeSelected = "route_selected"
+  /// Emitted before requesting the transaction details for a step.
+  case preparingStep = "preparing_step"
+  /// Emitted before signing and submitting a step's transaction.
+  case signing
+  /// Emitted after a step's transaction hash has been returned.
+  case submitted
+  /// Emitted before waiting for on-chain confirmation.
+  case confirming
+  /// Emitted while polling the LiFi status for a step.
+  case lifiPending = "lifi_pending"
+  /// Emitted once a step has reached a terminal LiFi status.
+  case stepDone = "step_done"
+  /// Emitted once all steps have completed.
+  case complete
+  /// Emitted when the trade fails.
+  case failed
+}
+
+/// Contextual data passed alongside a progress status.
+
+// MARK: - LifiTradeAssetProgressData
+
+public struct LifiTradeAssetProgressData {
+  public var routeIndex: Int?
+  public var stepIndex: Int?
+  public var totalSteps: Int?
+  public var route: LifiRoute?
+  public var step: LifiStep?
+  public var txHash: String?
+  public var lifiStatus: LifiStatusRawResponse?
+  public var errorMessage: String?
+
+  public init(
+    routeIndex: Int? = nil,
+    stepIndex: Int? = nil,
+    totalSteps: Int? = nil,
+    route: LifiRoute? = nil,
+    step: LifiStep? = nil,
+    txHash: String? = nil,
+    lifiStatus: LifiStatusRawResponse? = nil,
+    errorMessage: String? = nil
+  ) {
+    self.routeIndex = routeIndex
+    self.stepIndex = stepIndex
+    self.totalSteps = totalSteps
+    self.route = route
+    self.step = step
+    self.txHash = txHash
+    self.lifiStatus = lifiStatus
+    self.errorMessage = errorMessage
+  }
+}
+
+/// Options controlling the LiFi status polling behavior.
+
+// MARK: - LifiPollStatusOptions
+
+public struct LifiPollStatusOptions {
+  /// The interval between status polls, in milliseconds (default: 10000; minimum enforced: 100).
+  public let everyMs: Int
+  /// An initial delay before the first poll, in milliseconds (default: 0).
+  public let initialDelayMs: Int
+  /// The overall timeout for polling, in milliseconds (default: 600000).
+  public let timeoutMs: Int
+
+  public init(everyMs: Int = 10_000, initialDelayMs: Int = 0, timeoutMs: Int = 600_000) {
+    self.everyMs = everyMs
+    self.initialDelayMs = initialDelayMs
+    self.timeoutMs = timeoutMs
+  }
+}
+
+/// Errors that can be thrown by the high-level `tradeAsset` / `pollStatus` methods.
+
+// MARK: - LifiTradeAssetError
+
+public enum LifiTradeAssetError: Error, LocalizedError, Equatable {
+  /// A signing closure was not provided when constructing the Lifi instance.
+  case missingSigner
+  /// A confirmation closure was not provided when constructing the Lifi instance.
+  case missingConfirmation
+  /// No routes were returned for the requested trade.
+  case noRoutesFound
+  /// The provided route index is out of bounds.
+  case routeIndexOutOfBounds
+  /// The selected route contains no steps.
+  case routeHasNoSteps
+  /// The step did not contain a transaction request to sign.
+  case missingTransactionRequest
+  /// The step's transaction request was malformed — missing required fields, the wrong shape, or
+  /// containing an invalid value (e.g. a negative or non-integer amount).
+  case invalidTransactionRequest
+  /// The transaction was mined but reverted on-chain for the given transaction hash.
+  case transactionConfirmationFailed(String)
+  /// On-chain confirmation could not be determined before timing out (transaction may still be
+  /// pending, or the node was unreachable). Distinct from a definitive revert.
+  case transactionConfirmationTimedOut(String)
+  /// The LiFi transfer reached a FAILED terminal state.
+  case lifiTransferFailed(String)
+  /// Polling exceeded the configured timeout.
+  case pollTimeout
+
+  public var errorDescription: String? {
+    switch self {
+    case .missingSigner:
+      return "Lifi.tradeAsset requires a signAndSendTransaction closure (injected by Portal)."
+    case .missingConfirmation:
+      return "Lifi.tradeAsset requires a waitForConfirmation closure (injected by Portal)."
+    case .noRoutesFound:
+      return "No routes were returned for the requested trade."
+    case .routeIndexOutOfBounds:
+      return "The provided routeIndex is out of bounds."
+    case .routeHasNoSteps:
+      return "The selected route contains no steps."
+    case .missingTransactionRequest:
+      return "The route step did not contain a transaction request to sign."
+    case .invalidTransactionRequest:
+      return "The route step's transaction request was malformed (missing required fields, wrong shape, or an invalid value)."
+    case let .transactionConfirmationFailed(txHash):
+      return "Transaction reverted on-chain: \(txHash)."
+    case let .transactionConfirmationTimedOut(txHash):
+      return "Timed out waiting for on-chain confirmation of transaction: \(txHash). It may still be pending."
+    case let .lifiTransferFailed(detail):
+      return "LiFi transfer FAILED: \(detail)."
+    case .pollTimeout:
+      return "Timed out while polling LiFi status."
+    }
+  }
+}

--- a/Sources/PortalSwift/Core/Api/yieldxyz/YieldXyzCodable.swift
+++ b/Sources/PortalSwift/Core/Api/yieldxyz/YieldXyzCodable.swift
@@ -1,0 +1,26 @@
+//
+//  YieldXyzCodable.swift
+//  PortalSwift
+//
+//  Created by Portal Labs
+//
+
+import Foundation
+
+/// A `String`-backed, Codable enum that decodes unrecognized values to a designated `unknownValue`
+/// instead of throwing.
+///
+/// Yield.xyz (StakeKit) is an external provider that periodically adds new action/transaction and
+/// opportunity types. Without this, a single unrecognized value would fail decoding of the entire
+/// response (e.g. an `enter`/`exit`/`discover` payload), breaking otherwise-usable operations.
+public protocol YieldXyzUnknownTolerantEnum: RawRepresentable, Codable where RawValue == String {
+  /// The case returned when the decoded raw value is not recognized.
+  static var unknownValue: Self { get }
+}
+
+public extension YieldXyzUnknownTolerantEnum {
+  init(from decoder: Decoder) throws {
+    let rawValue = try decoder.singleValueContainer().decode(String.self)
+    self = Self(rawValue: rawValue) ?? Self.unknownValue
+  }
+}

--- a/Sources/PortalSwift/Core/Api/yieldxyz/YieldXyzEnterRequest.swift
+++ b/Sources/PortalSwift/Core/Api/yieldxyz/YieldXyzEnterRequest.swift
@@ -71,6 +71,27 @@ public struct YieldXyzEnterArguments: Codable {
     self.executionMode = executionMode
     self.ledgerWalletApiCompatible = ledgerWalletApiCompatible
   }
+
+  /// Returns a copy with `amount` replaced. Prefer this over reconstructing all fields manually.
+  public func withAmount(_ amount: String) -> YieldXyzEnterArguments {
+    YieldXyzEnterArguments(
+      amount: amount,
+      validatorAddress: validatorAddress,
+      validatorAddresses: validatorAddresses,
+      providerId: providerId,
+      duration: duration,
+      inputToken: inputToken,
+      subnetId: subnetId,
+      tronResource: tronResource,
+      feeConfigurationId: feeConfigurationId,
+      cosmosPubKey: cosmosPubKey,
+      tezosPubKey: tezosPubKey,
+      cAddressBech: cAddressBech,
+      pAddressBech: pAddressBech,
+      executionMode: executionMode,
+      ledgerWalletApiCompatible: ledgerWalletApiCompatible
+    )
+  }
 }
 
 /// Tron resource types

--- a/Sources/PortalSwift/Core/Api/yieldxyz/YieldXyzEnterYieldResponse.swift
+++ b/Sources/PortalSwift/Core/Api/yieldxyz/YieldXyzEnterYieldResponse.swift
@@ -77,14 +77,16 @@ public struct YieldXyzEnterRawResponse: Codable {
 }
 
 /// Yield action intent types
-public enum YieldXyzActionIntent: String, Codable {
+public enum YieldXyzActionIntent: String, YieldXyzUnknownTolerantEnum {
   case enter
   case manage
   case exit
+  case unknown
+  public static var unknownValue: YieldXyzActionIntent { .unknown }
 }
 
 /// Yield action types
-public enum YieldXyzActionType: String, Codable {
+public enum YieldXyzActionType: String, YieldXyzUnknownTolerantEnum {
   case STAKE
   case UNSTAKE
   case CLAIM_REWARDS
@@ -103,17 +105,21 @@ public enum YieldXyzActionType: String, Codable {
   case MIGRATE
   case VERIFY_WITHDRAW_CREDENTIALS
   case DELEGATE
+  case unknown
+  public static var unknownValue: YieldXyzActionType { .unknown }
 }
 
 /// Yield action execution patterns
-public enum YieldXyzActionExecutionPattern: String, Codable {
+public enum YieldXyzActionExecutionPattern: String, YieldXyzUnknownTolerantEnum {
   case synchronous
   case asynchronous
   case batch
+  case unknown
+  public static var unknownValue: YieldXyzActionExecutionPattern { .unknown }
 }
 
 /// Yield action status
-public enum YieldXyzActionStatus: String, Codable {
+public enum YieldXyzActionStatus: String, YieldXyzUnknownTolerantEnum {
   case CANCELED
   case CREATED
   case WAITING_FOR_NEXT
@@ -121,6 +127,8 @@ public enum YieldXyzActionStatus: String, Codable {
   case FAILED
   case SUCCESS
   case STALE
+  case unknown
+  public static var unknownValue: YieldXyzActionStatus { .unknown }
 }
 
 /// Yield action transaction
@@ -186,7 +194,7 @@ public struct YieldXyzActionTransaction: Codable {
 }
 
 /// Yield action transaction status
-public enum YieldXyzActionTransactionStatus: String, Codable {
+public enum YieldXyzActionTransactionStatus: String, YieldXyzUnknownTolerantEnum {
   case NOT_FOUND
   case CREATED
   case BLOCKED
@@ -197,10 +205,12 @@ public enum YieldXyzActionTransactionStatus: String, Codable {
   case CONFIRMED
   case FAILED
   case SKIPPED
+  case unknown
+  public static var unknownValue: YieldXyzActionTransactionStatus { .unknown }
 }
 
 /// Yield action transaction type
-public enum YieldXyzActionTransactionType: String, Codable {
+public enum YieldXyzActionTransactionType: String, YieldXyzUnknownTolerantEnum {
   case SWAP
   case DEPOSIT
   case APPROVAL
@@ -251,4 +261,6 @@ public enum YieldXyzActionTransactionType: String, Codable {
   case INFSTONES_PROVISION
   case INFSTONES_EXIT_REQUEST
   case INFSTONES_CLAIM_REQUEST
+  case unknown
+  public static var unknownValue: YieldXyzActionTransactionType { .unknown }
 }

--- a/Sources/PortalSwift/Core/Api/yieldxyz/YieldXyzGetDefaultsResponse.swift
+++ b/Sources/PortalSwift/Core/Api/yieldxyz/YieldXyzGetDefaultsResponse.swift
@@ -1,0 +1,35 @@
+//
+//  YieldXyzGetDefaultsResponse.swift
+//  PortalSwift
+//
+//  Created by Portal Labs
+//
+
+import Foundation
+
+/// Response from the Portal yield defaults endpoint.
+///
+/// The payload maps a `"{caip2}:{TOKEN}"` key (e.g. `"eip155:1:USDC"`) to the default yield
+/// configured for that chain + token. Unlike most Yield.xyz endpoints, this payload is NOT
+/// wrapped in `rawResponse`; the map lives directly under `data`.
+public struct YieldXyzGetDefaultsResponse: Codable {
+  public let data: [String: YieldXyzDefaultYieldEntry]?
+  public let error: String?
+
+  public init(data: [String: YieldXyzDefaultYieldEntry]? = nil, error: String? = nil) {
+    self.data = data
+    self.error = error
+  }
+}
+
+/// A single default-yield entry for a `"{caip2}:{TOKEN}"` key.
+public struct YieldXyzDefaultYieldEntry: Codable {
+  public let yieldId: String?
+  /// Populated only when the defaults request is made with `includeOpportunities = true`.
+  public let opportunity: YieldXyzOpportunity?
+
+  public init(yieldId: String? = nil, opportunity: YieldXyzOpportunity? = nil) {
+    self.yieldId = yieldId
+    self.opportunity = opportunity
+  }
+}

--- a/Sources/PortalSwift/Core/Api/yieldxyz/YieldXyzGetValidatorsResponse.swift
+++ b/Sources/PortalSwift/Core/Api/yieldxyz/YieldXyzGetValidatorsResponse.swift
@@ -1,0 +1,183 @@
+//
+//  YieldXyzGetValidatorsResponse.swift
+//  PortalSwift
+//
+//  Created by Portal Labs
+//
+
+import Foundation
+
+/// Response containing validators for a native-staking yield.
+public struct YieldXyzGetValidatorsResponse: Codable {
+  public let data: YieldXyzGetValidatorsData?
+  public let error: String?
+
+  public init(data: YieldXyzGetValidatorsData? = nil, error: String? = nil) {
+    self.data = data
+    self.error = error
+  }
+}
+
+public struct YieldXyzGetValidatorsData: Codable {
+  /// Some backends place validators directly on `data`; most nest them in `rawResponse`.
+  public let validators: [YieldXyzValidator]?
+  public let rawResponse: YieldXyzGetValidatorsRawResponse?
+
+  public init(validators: [YieldXyzValidator]? = nil, rawResponse: YieldXyzGetValidatorsRawResponse? = nil) {
+    self.validators = validators
+    self.rawResponse = rawResponse
+  }
+}
+
+public struct YieldXyzGetValidatorsRawResponse: Codable {
+  public let items: [YieldXyzValidator]?
+  public let validators: [YieldXyzValidator]?
+  public let limit: Int?
+  public let offset: Int?
+  public let total: Int?
+
+  public init(
+    items: [YieldXyzValidator]? = nil,
+    validators: [YieldXyzValidator]? = nil,
+    limit: Int? = nil,
+    offset: Int? = nil,
+    total: Int? = nil
+  ) {
+    self.items = items
+    self.validators = validators
+    self.limit = limit
+    self.offset = offset
+    self.total = total
+  }
+}
+
+/// A validator for a native-staking yield (e.g. Monad, Ethereum 2.0).
+public struct YieldXyzValidator: Codable {
+  public let address: String
+  public let name: String?
+  public let logoURI: String?
+  public let website: String?
+  public let rewardRate: YieldXyzRewardRate?
+  public let provider: YieldXyzProvider?
+  public let commission: Double?
+  public let tvlUsd: String?
+  public let tvl: String?
+  public let tvlRaw: String?
+  public let votingPower: Double?
+  public let preferred: Bool?
+  public let minimumStake: String?
+  public let remainingPossibleStake: String?
+  public let remainingSlots: Int?
+  public let nominatorCount: Int?
+  public let status: String?
+  public let providerId: String?
+  public let pricePerShare: String?
+  public let subnetId: Int?
+  public let subnetName: String?
+  public let marketCap: String?
+  public let tokenSymbol: String?
+
+  public init(
+    address: String,
+    name: String? = nil,
+    logoURI: String? = nil,
+    website: String? = nil,
+    rewardRate: YieldXyzRewardRate? = nil,
+    provider: YieldXyzProvider? = nil,
+    commission: Double? = nil,
+    tvlUsd: String? = nil,
+    tvl: String? = nil,
+    tvlRaw: String? = nil,
+    votingPower: Double? = nil,
+    preferred: Bool? = nil,
+    minimumStake: String? = nil,
+    remainingPossibleStake: String? = nil,
+    remainingSlots: Int? = nil,
+    nominatorCount: Int? = nil,
+    status: String? = nil,
+    providerId: String? = nil,
+    pricePerShare: String? = nil,
+    subnetId: Int? = nil,
+    subnetName: String? = nil,
+    marketCap: String? = nil,
+    tokenSymbol: String? = nil
+  ) {
+    self.address = address
+    self.name = name
+    self.logoURI = logoURI
+    self.website = website
+    self.rewardRate = rewardRate
+    self.provider = provider
+    self.commission = commission
+    self.tvlUsd = tvlUsd
+    self.tvl = tvl
+    self.tvlRaw = tvlRaw
+    self.votingPower = votingPower
+    self.preferred = preferred
+    self.minimumStake = minimumStake
+    self.remainingPossibleStake = remainingPossibleStake
+    self.remainingSlots = remainingSlots
+    self.nominatorCount = nominatorCount
+    self.status = status
+    self.providerId = providerId
+    self.pricePerShare = pricePerShare
+    self.subnetId = subnetId
+    self.subnetName = subnetName
+    self.marketCap = marketCap
+    self.tokenSymbol = tokenSymbol
+  }
+}
+
+/// A yield/validator provider.
+public struct YieldXyzProvider: Codable {
+  public let name: String?
+  public let uniqueId: String?
+  public let website: String?
+  public let rank: Int?
+  public let preferred: Bool?
+  public let revshare: YieldXyzRevshare?
+
+  public init(
+    name: String? = nil,
+    uniqueId: String? = nil,
+    website: String? = nil,
+    rank: Int? = nil,
+    preferred: Bool? = nil,
+    revshare: YieldXyzRevshare? = nil
+  ) {
+    self.name = name
+    self.uniqueId = uniqueId
+    self.website = website
+    self.rank = rank
+    self.preferred = preferred
+    self.revshare = revshare
+  }
+}
+
+/// Revenue-share configuration tiers for a provider.
+public struct YieldXyzRevshare: Codable {
+  public let trial: YieldXyzRevshareTier?
+  public let standard: YieldXyzRevshareTier?
+  public let pro: YieldXyzRevshareTier?
+
+  public init(
+    trial: YieldXyzRevshareTier? = nil,
+    standard: YieldXyzRevshareTier? = nil,
+    pro: YieldXyzRevshareTier? = nil
+  ) {
+    self.trial = trial
+    self.standard = standard
+    self.pro = pro
+  }
+}
+
+/// A single revenue-share tier.
+public struct YieldXyzRevshareTier: Codable {
+  public let minRevShare: Double?
+  public let maxRevShare: Double?
+
+  public init(minRevShare: Double? = nil, maxRevShare: Double? = nil) {
+    self.minRevShare = minRevShare
+    self.maxRevShare = maxRevShare
+  }
+}

--- a/Sources/PortalSwift/Core/Api/yieldxyz/YieldXyzGetYieldsRequest.swift
+++ b/Sources/PortalSwift/Core/Api/yieldxyz/YieldXyzGetYieldsRequest.swift
@@ -60,11 +60,13 @@ public enum YieldXyzGetYieldsSort: String, Codable {
 }
 
 /// Yield mechanics types
-public enum YieldXyzMechanicsType: String, Codable {
+public enum YieldXyzMechanicsType: String, YieldXyzUnknownTolerantEnum {
   case staking
   case restaking
   case lending
   case vault
   case fixed_yield
   case real_world_asset
+  case unknown
+  public static var unknownValue: YieldXyzMechanicsType { .unknown }
 }

--- a/Sources/PortalSwift/Core/Api/yieldxyz/YieldXyzGetYieldsResponse.swift
+++ b/Sources/PortalSwift/Core/Api/yieldxyz/YieldXyzGetYieldsResponse.swift
@@ -165,6 +165,7 @@ public enum YieldXyzSource: String, Codable {
   case restaking
   case protocol_incentive
   case points
+  case lending
   case lending_interest
   case mev
   case real_world_asset_yield

--- a/Sources/PortalSwift/Core/Api/yieldxyz/YieldXyzGetYieldsResponse.swift
+++ b/Sources/PortalSwift/Core/Api/yieldxyz/YieldXyzGetYieldsResponse.swift
@@ -131,9 +131,11 @@ public struct YieldXyzRewardRate: Codable {
 }
 
 /// Rate type enum
-public enum YieldXyzRateType: String, Codable {
+public enum YieldXyzRateType: String, YieldXyzUnknownTolerantEnum {
   case APR
   case APY
+  case unknown
+  public static var unknownValue: YieldXyzRateType { .unknown }
 }
 
 /// Reward rate component
@@ -160,7 +162,7 @@ public struct YieldXyzRewardRateComponent: Codable {
 }
 
 /// Yield source enum
-public enum YieldXyzSource: String, Codable {
+public enum YieldXyzSource: String, YieldXyzUnknownTolerantEnum {
   case staking
   case restaking
   case protocol_incentive
@@ -170,6 +172,8 @@ public enum YieldXyzSource: String, Codable {
   case mev
   case real_world_asset_yield
   case validator_commission
+  case unknown
+  public static var unknownValue: YieldXyzSource { .unknown }
 }
 
 /// Statistics for a yield opportunity
@@ -286,7 +290,7 @@ public struct YieldXyzMechanics: Codable {
 }
 
 /// Reward schedule enum
-public enum YieldXyzRewardSchedule: String, Codable {
+public enum YieldXyzRewardSchedule: String, YieldXyzUnknownTolerantEnum {
   case block
   case hour
   case day
@@ -295,12 +299,16 @@ public enum YieldXyzRewardSchedule: String, Codable {
   case era
   case epoch
   case campaign
+  case unknown
+  public static var unknownValue: YieldXyzRewardSchedule { .unknown }
 }
 
 /// Reward claiming enum
-public enum YieldXyzRewardClaiming: String, Codable {
+public enum YieldXyzRewardClaiming: String, YieldXyzUnknownTolerantEnum {
   case auto
   case manual
+  case unknown
+  public static var unknownValue: YieldXyzRewardClaiming { .unknown }
 }
 
 /// Lockup period information
@@ -432,7 +440,7 @@ public struct YieldXyzArgumentField: Codable {
 }
 
 /// Argument field name enum
-public enum YieldXyzArgumentFieldName: String, Codable {
+public enum YieldXyzArgumentFieldName: String, YieldXyzUnknownTolerantEnum {
   case amount
   case validatorAddress
   case validatorAddresses
@@ -449,15 +457,19 @@ public enum YieldXyzArgumentFieldName: String, Codable {
   case pAddressBech
   case executionMode
   case ledgerWalletApiCompatible
+  case unknown
+  public static var unknownValue: YieldXyzArgumentFieldName { .unknown }
 }
 
 /// Argument field type enum
-public enum YieldXyzArgumentFieldType: String, Codable {
+public enum YieldXyzArgumentFieldType: String, YieldXyzUnknownTolerantEnum {
   case string
   case number
   case address
   case `enum`
   case boolean
+  case unknown
+  public static var unknownValue: YieldXyzArgumentFieldType { .unknown }
 }
 
 /// Possible fee taking mechanisms

--- a/Sources/PortalSwift/Core/Mpc/Mobile/MpcMobileProtocol.swift
+++ b/Sources/PortalSwift/Core/Mpc/Mobile/MpcMobileProtocol.swift
@@ -19,6 +19,7 @@ public struct MpcMetadata: Codable {
   var isRaw: Bool? = nil
   var signatureApprovalMemo: String? = nil
   var sponsorGas: Bool? = nil
+  var reqId: String? = nil
 }
 
 extension MpcMetadata {

--- a/Sources/PortalSwift/Core/Mpc/PortalMpc.swift
+++ b/Sources/PortalSwift/Core/Mpc/PortalMpc.swift
@@ -392,47 +392,25 @@ public class PortalMpc: PortalMpcProtocol {
     try await walletModificationOperationGuard.acquire(for: "generate")
 
     do {
-      // Generate both backup shares in parallel
-      let generateResponse = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<PortalMpcGenerateResponse, Error>) in
-        Task { [self] in
-          do {
-            withProgressCallback?(MpcStatus(status: .generatingShare, done: false))
-
-            var generateResponse: PortalMpcGenerateResponse = [:]
-
-            async let ed25519Generate = try self.getSigningShare(.ED25519)
-            async let secp256k1Generate = try self.getSigningShare(.SECP256K1)
-
-            let (ed25519MpcShare, secp256k1MpcShare) = try await (ed25519Generate, secp256k1Generate)
-
-            withProgressCallback?(MpcStatus(status: .parsingShare, done: false))
-
-            // Parse ED25519 Share
-            let ed25519ShareData = try self.encoder.encode(ed25519MpcShare)
-            guard let ed25519ShareString = String(data: ed25519ShareData, encoding: .utf8) else {
-              throw MpcError.unexpectedErrorOnGenerate("Unable to stringify ED25519 share.")
-            }
-            generateResponse["ED25519"] = PortalMpcGeneratedShare(
-              id: ed25519MpcShare.signingSharePairId ?? "",
-              share: ed25519ShareString
-            )
-
-            // Parse SECP256K1 Share
-            let secp256k1ShareData = try self.encoder.encode(secp256k1MpcShare)
-            guard let secp256k1ShareString = String(data: secp256k1ShareData, encoding: .utf8) else {
-              throw MpcError.unexpectedErrorOnGenerate("Unable to stringify ED25519 share.")
-            }
-            generateResponse["SECP256K1"] = PortalMpcGeneratedShare(
-              id: secp256k1MpcShare.signingSharePairId ?? "",
-              share: secp256k1ShareString
-            )
-
-            continuation.resume(returning: generateResponse)
-          } catch {
-            continuation.resume(throwing: error)
-            return
+      let generateResponse: PortalMpcGenerateResponse
+      if self.featureFlags?.usePreGeneratedWallet == true {
+        // Try the pre-generated wallet HTTP path, falling back to the binary DKG flow ONLY on a
+        // server-side (5xx) failure, which is transient and safe to retry. Every other failure —
+        // 4xx client errors (e.g. the enclave "wallet already exists" precheck), auth failures,
+        // network/URL errors, and share decode/validation failures — is surfaced immediately,
+        // since a binary retry would not resolve them and would only add a full DKG round of latency.
+        do {
+          generateResponse = try await self.generateSigningSharesViaApi(withProgressCallback: withProgressCallback)
+        } catch {
+          guard PortalMpc.isRetryableServerError(error) else {
+            self.logger.error("[PortalMpc] Pre-generated wallet generation failed with a non-retryable error; not falling back to the binary: \(error.localizedDescription)")
+            throw error
           }
+          self.logger.error("[PortalMpc] Pre-generated wallet generation failed with a server (5xx) error, falling back to the binary: \(error.localizedDescription)")
+          generateResponse = try await self.generateSigningSharesViaBinary(withProgressCallback: withProgressCallback)
         }
+      } else {
+        generateResponse = try await self.generateSigningSharesViaBinary(withProgressCallback: withProgressCallback)
       }
 
       withProgressCallback?(MpcStatus(status: .storingShare, done: false))
@@ -458,6 +436,133 @@ public class PortalMpc: PortalMpcProtocol {
       await walletModificationOperationGuard.release()
       throw error
     }
+  }
+
+  /// Generates both signing shares using the MPC binary (the default, on-device DKG flow).
+  private func generateSigningSharesViaBinary(withProgressCallback: ((MpcStatus) -> Void)? = nil) async throws -> PortalMpcGenerateResponse {
+    // Generate both signing shares in parallel
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<PortalMpcGenerateResponse, Error>) in
+      Task { [self] in
+        do {
+          self.logger.info("Generating wallet: generating signing shares using the binary MPC flow.")
+          withProgressCallback?(MpcStatus(status: .generatingShare, done: false))
+
+          var generateResponse: PortalMpcGenerateResponse = [:]
+
+          async let ed25519Generate = try self.getSigningShare(.ED25519)
+          async let secp256k1Generate = try self.getSigningShare(.SECP256K1)
+
+          let (ed25519MpcShare, secp256k1MpcShare) = try await (ed25519Generate, secp256k1Generate)
+
+          withProgressCallback?(MpcStatus(status: .parsingShare, done: false))
+
+          // Parse ED25519 Share
+          let ed25519ShareData = try self.encoder.encode(ed25519MpcShare)
+          guard let ed25519ShareString = String(data: ed25519ShareData, encoding: .utf8) else {
+            throw MpcError.unexpectedErrorOnGenerate("Unable to stringify ED25519 share.")
+          }
+          generateResponse["ED25519"] = PortalMpcGeneratedShare(
+            id: ed25519MpcShare.signingSharePairId ?? "",
+            share: ed25519ShareString
+          )
+
+          // Parse SECP256K1 Share
+          let secp256k1ShareData = try self.encoder.encode(secp256k1MpcShare)
+          guard let secp256k1ShareString = String(data: secp256k1ShareData, encoding: .utf8) else {
+            throw MpcError.unexpectedErrorOnGenerate("Unable to stringify SECP256K1 share.")
+          }
+          generateResponse["SECP256K1"] = PortalMpcGeneratedShare(
+            id: secp256k1MpcShare.signingSharePairId ?? "",
+            share: secp256k1ShareString
+          )
+
+          continuation.resume(returning: generateResponse)
+        } catch {
+          continuation.resume(throwing: error)
+          return
+        }
+      }
+    }
+  }
+
+  /// Generates both signing shares via the Enclave MPC API `POST /v1/generate` endpoint, opting
+  /// into the pre-generated wallet pool. The API returns both curves in a single call.
+  private func generateSigningSharesViaApi(withProgressCallback: ((MpcStatus) -> Void)? = nil) async throws -> PortalMpcGenerateResponse {
+    self.logger.info("Generating wallet: generating signing shares using the API MPC Enclave flow.")
+    withProgressCallback?(MpcStatus(status: .generatingShare, done: false))
+
+    guard let api = self.api else {
+      throw MpcError.unexpectedErrorOnGenerate("Portal API is unavailable for pre-generated wallet generation.")
+    }
+
+    // Send the same metadata we send to the binary. The per-curve `curve` is irrelevant here
+    // because the API generates both curves in a single request.
+    let metadataString = try self.mpcMetadata.jsonString()
+
+    let apiResponse = try await api.generatePreGeneratedShares(metadataStr: metadataString)
+
+    withProgressCallback?(MpcStatus(status: .parsingShare, done: false))
+
+    var generateResponse: PortalMpcGenerateResponse = [:]
+    generateResponse["ED25519"] = try self.makeGeneratedShare(from: apiResponse.ed25519, forCurve: .ED25519)
+    generateResponse["SECP256K1"] = try self.makeGeneratedShare(from: apiResponse.secp256k1, forCurve: .SECP256K1)
+
+    return generateResponse
+  }
+
+  /// Transforms an API curve share (base64-encoded `MpcShare`) into the same stored format the
+  /// binary path produces (a JSON-stringified `MpcShare`).
+  private func makeGeneratedShare(from curveShare: GenerateApiCurveShare, forCurve: PortalCurve) throws -> PortalMpcGeneratedShare {
+    guard let shareData = PortalMpc.decodeStandardBase64(curveShare.share) else {
+      throw MpcError.unableToDecodeShare
+    }
+
+    let mpcShare = try self.decoder.decode(MpcShare.self, from: shareData)
+
+    guard let signingSharePairId = mpcShare.signingSharePairId, !signingSharePairId.isEmpty else {
+      throw MpcError.unexpectedErrorOnGenerate("Missing signingSharePairId for \(forCurve.rawValue) pre-generated share.")
+    }
+
+    // Re-encode to a JSON string to match exactly what the binary path stores.
+    let reEncodedData = try self.encoder.encode(mpcShare)
+    guard let shareString = String(data: reEncodedData, encoding: .utf8) else {
+      throw MpcError.unexpectedErrorOnGenerate("Unable to stringify \(forCurve.rawValue) share.")
+    }
+
+    // Use the decoded `signingSharePairId` (not the response envelope `id`) so the stored
+    // share id matches exactly what the binary path produces. Downstream `updateShareStatus`
+    // is keyed off this id, so the two paths must stay identical.
+    return PortalMpcGeneratedShare(id: signingSharePairId, share: shareString)
+  }
+
+  /// Reports whether an error from the pre-generated wallet API is a server-side (5xx) failure —
+  /// the only case where we fall back to the on-device binary DKG flow, since a 5xx is transient
+  /// and safe to retry. Every other failure (4xx client errors such as "wallet already exists",
+  /// auth failures, network/URL errors, and share decode/validation failures) is surfaced
+  /// immediately, because a binary retry would not resolve it and would only add DKG latency.
+  static func isRetryableServerError(_ error: Error) -> Bool {
+    guard let requestError = error as? PortalRequestsError else {
+      return false
+    }
+
+    switch requestError {
+    case .internalServerError:
+      return true
+    default:
+      return false
+    }
+  }
+
+  /// Decodes a standard-alphabet base64 string into `Data`. The Enclave MPC API returns shares as
+  /// base64 `RawStdEncoding` (no `=` padding), while `Data(base64Encoded:)` requires correct
+  /// padding, so we re-add it. The standard (not URL-safe) alphabet is used intentionally.
+  static func decodeStandardBase64(_ value: String) -> Data? {
+    var base64 = value
+    let remainder = base64.count % 4
+    if remainder > 0 {
+      base64.append(String(repeating: "=", count: 4 - remainder))
+    }
+    return Data(base64Encoded: base64)
   }
 
   public func recover(

--- a/Sources/PortalSwift/Core/Mpc/PortalMpc.swift
+++ b/Sources/PortalSwift/Core/Mpc/PortalMpc.swift
@@ -145,6 +145,9 @@ public class PortalMpc: PortalMpcProtocol {
 
     try await walletModificationOperationGuard.acquire(for: "backup")
 
+    // A single trace ID is shared across MPC reqId and follow-up API calls for this operation.
+    let traceId = generateTraceId()
+
     do {
       // Obtain the signing share.
       let shares = try await keychain?.getShares() ?? [:]
@@ -167,7 +170,7 @@ public class PortalMpc: PortalMpcProtocol {
           // Run both backups in parallel
           if let ed25519SigningShare = shares[PortalCurve.ED25519.rawValue] {
             do {
-              async let mpcShare = try getBackupShare(.ED25519, withMethod: method, andSigningShare: ed25519SigningShare.share)
+              async let mpcShare = try getBackupShare(.ED25519, withMethod: method, andSigningShare: ed25519SigningShare.share, reqId: traceId)
 
               usingProgressCallback?(MpcStatus(status: .parsingShare, done: false))
               let shareData = try await encoder.encode(mpcShare)
@@ -186,7 +189,7 @@ public class PortalMpc: PortalMpcProtocol {
           }
           if let secp256k1SigningShare = shares[PortalCurve.SECP256K1.rawValue]?.share {
             do {
-              async let mpcShare = try getBackupShare(.SECP256K1, withMethod: method, andSigningShare: secp256k1SigningShare)
+              async let mpcShare = try getBackupShare(.SECP256K1, withMethod: method, andSigningShare: secp256k1SigningShare, reqId: traceId)
 
               usingProgressCallback?(MpcStatus(status: .parsingShare, done: false))
               let shareData = try await encoder.encode(mpcShare)
@@ -226,7 +229,7 @@ public class PortalMpc: PortalMpcProtocol {
       let shareIds = generateResponse.values.map { share in
         share.id
       }
-      try await self.api?.updateShareStatus(.backup, status: .STORED_CLIENT_BACKUP_SHARE_KEY, sharePairIds: shareIds)
+      try await self.api?.updateShareStatus(.backup, status: .STORED_CLIENT_BACKUP_SHARE_KEY, sharePairIds: shareIds, traceId: traceId)
 
       guard let client = try await api?.client else {
         throw MpcError.clientInformationUnavailable
@@ -234,7 +237,7 @@ public class PortalMpc: PortalMpcProtocol {
 
       if client.environment?.backupWithPortalEnabled ?? false {
         for share in generateResponse.values {
-          let successful = try await api?.storeClientCipherText(share.id, cipherText: encryptResult.cipherText) ?? false
+          let successful = try await api?.storeClientCipherText(share.id, cipherText: encryptResult.cipherText, traceId: traceId) ?? false
 
           if !successful {
             self.logger.error("[PortalMpc] Unable to store client cipherText.")
@@ -244,7 +247,7 @@ public class PortalMpc: PortalMpcProtocol {
       }
 
       // Refresh the client
-      try await self.api?.refreshClient()
+      try await self.api?.refreshClient(traceId: traceId)
       try await self.keychain?.loadMetadata()
 
       await walletModificationOperationGuard.release()
@@ -253,7 +256,7 @@ public class PortalMpc: PortalMpcProtocol {
       usingProgressCallback?(MpcStatus(status: .done, done: true))
 
       // Return the Backup response
-      return PortalMpcBackupResponse(cipherText: encryptResult.cipherText, shareIds: shareIds)
+      return PortalMpcBackupResponse(cipherText: encryptResult.cipherText, shareIds: shareIds, traceId: traceId)
     } catch {
       await walletModificationOperationGuard.release()
       throw error
@@ -269,6 +272,9 @@ public class PortalMpc: PortalMpcProtocol {
     if self.version != "v6" {
       throw MpcError.backupNoLongerSupported("[PortalMpc] Eject is no longer supported for this version of MPC. Please use `version = \"v6\"`.")
     }
+
+    // A single trace ID is shared across follow-up API calls for this operation.
+    let traceId = generateTraceId()
 
     var cipherText = withCipherText
     var organizationShare = andOrganizationBackupShare
@@ -318,12 +324,12 @@ public class PortalMpc: PortalMpcProtocol {
 
     let backupWithPortal = client.environment?.backupWithPortalEnabled ?? false
     if backupWithPortal {
-      cipherText = try await self.api?.getClientCipherText(backupSharePairId)
-      organizationShare = try await self.api?.prepareEject(SECP256K1WalletId, method)
+      cipherText = try await self.api?.getClientCipherText(backupSharePairId, traceId: traceId)
+      organizationShare = try await self.api?.prepareEject(SECP256K1WalletId, method, traceId: traceId)
 
       // Conditionally prepare eject for Solana wallets
       if let Ed25519WalletId {
-        organizationShareEd25519 = try? await self.api?.prepareEject(Ed25519WalletId, method)
+        organizationShareEd25519 = try? await self.api?.prepareEject(Ed25519WalletId, method, traceId: traceId)
       }
     }
 
@@ -375,7 +381,7 @@ public class PortalMpc: PortalMpcProtocol {
       privateKeys[.solana] = ejectResult.privateKey
     }
 
-    _ = try await self.api?.eject()
+    _ = try await self.api?.eject(traceId: traceId)
 
     guard privateKeys[.eip155] != nil else {
       throw MpcError.unexpectedErrorOnEject("Unable to find private key for Ethereum wallet.")
@@ -391,6 +397,9 @@ public class PortalMpc: PortalMpcProtocol {
 
     try await walletModificationOperationGuard.acquire(for: "generate")
 
+    // A single trace ID is shared across MPC reqId and follow-up API calls for this operation.
+    let traceId = generateTraceId()
+
     do {
       let generateResponse: PortalMpcGenerateResponse
       if self.featureFlags?.usePreGeneratedWallet == true {
@@ -400,17 +409,17 @@ public class PortalMpc: PortalMpcProtocol {
         // network/URL errors, and share decode/validation failures — is surfaced immediately,
         // since a binary retry would not resolve them and would only add a full DKG round of latency.
         do {
-          generateResponse = try await self.generateSigningSharesViaApi(withProgressCallback: withProgressCallback)
+          generateResponse = try await self.generateSigningSharesViaApi(withProgressCallback: withProgressCallback, reqId: traceId)
         } catch {
           guard PortalMpc.isRetryableServerError(error) else {
             self.logger.error("[PortalMpc] Pre-generated wallet generation failed with a non-retryable error; not falling back to the binary: \(error.localizedDescription)")
             throw error
           }
           self.logger.error("[PortalMpc] Pre-generated wallet generation failed with a server (5xx) error, falling back to the binary: \(error.localizedDescription)")
-          generateResponse = try await self.generateSigningSharesViaBinary(withProgressCallback: withProgressCallback)
+          generateResponse = try await self.generateSigningSharesViaBinary(withProgressCallback: withProgressCallback, reqId: traceId)
         }
       } else {
-        generateResponse = try await self.generateSigningSharesViaBinary(withProgressCallback: withProgressCallback)
+        generateResponse = try await self.generateSigningSharesViaBinary(withProgressCallback: withProgressCallback, reqId: traceId)
       }
 
       withProgressCallback?(MpcStatus(status: .storingShare, done: false))
@@ -420,10 +429,10 @@ public class PortalMpc: PortalMpcProtocol {
       let shareIds: [String] = generateResponse.values.map { share in
         share.id
       }
-      try await self.api?.updateShareStatus(.signing, status: .STORED_CLIENT, sharePairIds: shareIds)
+      try await self.api?.updateShareStatus(.signing, status: .STORED_CLIENT, sharePairIds: shareIds, traceId: traceId)
 
       // Reset the metadata in the Keychain
-      try await self.api?.refreshClient()
+      try await self.api?.refreshClient(traceId: traceId)
       try await self.keychain?.loadMetadata()
 
       let addresses = try await keychain?.getAddresses() ?? [:]
@@ -439,7 +448,7 @@ public class PortalMpc: PortalMpcProtocol {
   }
 
   /// Generates both signing shares using the MPC binary (the default, on-device DKG flow).
-  private func generateSigningSharesViaBinary(withProgressCallback: ((MpcStatus) -> Void)? = nil) async throws -> PortalMpcGenerateResponse {
+  private func generateSigningSharesViaBinary(withProgressCallback: ((MpcStatus) -> Void)? = nil, reqId: String?) async throws -> PortalMpcGenerateResponse {
     // Generate both signing shares in parallel
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<PortalMpcGenerateResponse, Error>) in
       Task { [self] in
@@ -449,8 +458,8 @@ public class PortalMpc: PortalMpcProtocol {
 
           var generateResponse: PortalMpcGenerateResponse = [:]
 
-          async let ed25519Generate = try self.getSigningShare(.ED25519)
-          async let secp256k1Generate = try self.getSigningShare(.SECP256K1)
+          async let ed25519Generate = try self.getSigningShare(.ED25519, reqId: reqId)
+          async let secp256k1Generate = try self.getSigningShare(.SECP256K1, reqId: reqId)
 
           let (ed25519MpcShare, secp256k1MpcShare) = try await (ed25519Generate, secp256k1Generate)
 
@@ -487,7 +496,7 @@ public class PortalMpc: PortalMpcProtocol {
 
   /// Generates both signing shares via the Enclave MPC API `POST /v1/generate` endpoint, opting
   /// into the pre-generated wallet pool. The API returns both curves in a single call.
-  private func generateSigningSharesViaApi(withProgressCallback: ((MpcStatus) -> Void)? = nil) async throws -> PortalMpcGenerateResponse {
+  private func generateSigningSharesViaApi(withProgressCallback: ((MpcStatus) -> Void)? = nil, reqId: String?) async throws -> PortalMpcGenerateResponse {
     self.logger.info("Generating wallet: generating signing shares using the API MPC Enclave flow.")
     withProgressCallback?(MpcStatus(status: .generatingShare, done: false))
 
@@ -497,9 +506,11 @@ public class PortalMpc: PortalMpcProtocol {
 
     // Send the same metadata we send to the binary. The per-curve `curve` is irrelevant here
     // because the API generates both curves in a single request.
-    let metadataString = try self.mpcMetadata.jsonString()
+    var metadata = self.mpcMetadata
+    metadata.reqId = reqId
+    let metadataString = try metadata.jsonString()
 
-    let apiResponse = try await api.generatePreGeneratedShares(metadataStr: metadataString)
+    let apiResponse = try await api.generatePreGeneratedShares(metadataStr: metadataString, traceId: reqId)
 
     withProgressCallback?(MpcStatus(status: .parsingShare, done: false))
 
@@ -576,6 +587,9 @@ public class PortalMpc: PortalMpcProtocol {
 
     try await walletModificationOperationGuard.acquire(for: "recover")
 
+    // A single trace ID is shared across MPC reqId and follow-up API calls for this operation.
+    let traceId = generateTraceId()
+
     do {
       guard let client = try await api?.client else {
         throw MpcError.clientInformationUnavailable
@@ -599,7 +613,7 @@ public class PortalMpc: PortalMpcProtocol {
           throw MpcError.noValidBackupFound
         }
 
-        cipherText = try await self.api?.getClientCipherText(backupSharePairId)
+        cipherText = try await self.api?.getClientCipherText(backupSharePairId, traceId: traceId)
       }
 
       guard let cipherText else {
@@ -631,7 +645,7 @@ public class PortalMpc: PortalMpcProtocol {
 
             if let ed25519Share = shares[PortalCurve.ED25519.rawValue] {
               //  The share's already been backed up, recover it
-              async let ed25519MpcShare = try recoverSigningShare(.ED25519, withMethod: method, andBackupShare: ed25519Share.share)
+              async let ed25519MpcShare = try recoverSigningShare(.ED25519, withMethod: method, andBackupShare: ed25519Share.share, reqId: traceId)
 
               let shareData = try await encoder.encode(ed25519MpcShare)
               guard let shareString = String(data: shareData, encoding: .utf8) else {
@@ -646,7 +660,7 @@ public class PortalMpc: PortalMpcProtocol {
             }
 
             if let secp256k1Share = shares[PortalCurve.SECP256K1.rawValue] {
-              async let secp256k1MpcShare = try recoverSigningShare(.SECP256K1, withMethod: method, andBackupShare: secp256k1Share.share)
+              async let secp256k1MpcShare = try recoverSigningShare(.SECP256K1, withMethod: method, andBackupShare: secp256k1Share.share, reqId: traceId)
 
               let shareData = try await encoder.encode(secp256k1MpcShare)
               guard let shareString = String(data: shareData, encoding: .utf8) else {
@@ -681,10 +695,10 @@ public class PortalMpc: PortalMpcProtocol {
         share.id
       }
 
-      try await self.api?.updateShareStatus(.signing, status: .STORED_CLIENT, sharePairIds: shareIds)
+      try await self.api?.updateShareStatus(.signing, status: .STORED_CLIENT, sharePairIds: shareIds, traceId: traceId)
 
       // Reset the metadata in the Keychain
-      try await self.api?.refreshClient()
+      try await self.api?.refreshClient(traceId: traceId)
       try await self.keychain?.loadMetadata()
 
       let addresses = try await keychain?.getAddresses() ?? [:]
@@ -706,6 +720,9 @@ public class PortalMpc: PortalMpcProtocol {
 
     try await walletModificationOperationGuard.acquire(for: "generateSolanaWallet")
 
+    // A single trace ID is shared across MPC reqId and follow-up API calls for this operation.
+    let traceId = generateTraceId()
+
     var newAddresses: [PortalNamespace: String?]
 
     do {
@@ -722,7 +739,7 @@ public class PortalMpc: PortalMpcProtocol {
       usingProgressCallback?(MpcStatus(status: .generatingShare, done: false))
 
       // generate the ED25519 share
-      let ed25519MpcShare = try await self.getSigningShare(.ED25519)
+      let ed25519MpcShare = try await self.getSigningShare(.ED25519, reqId: traceId)
 
       // create a share object to be stored to keychain
       var generateResponse: PortalMpcGenerateResponse = [:]
@@ -752,10 +769,10 @@ public class PortalMpc: PortalMpcProtocol {
       let shareIds: [String] = generateResponse.values.map { share in
         share.id
       }
-      try await self.api?.updateShareStatus(.signing, status: .STORED_CLIENT, sharePairIds: shareIds)
+      try await self.api?.updateShareStatus(.signing, status: .STORED_CLIENT, sharePairIds: shareIds, traceId: traceId)
 
       // Reset the metadata in the Keychain
-      try await self.api?.refreshClient()
+      try await self.api?.refreshClient(traceId: traceId)
       try await self.keychain?.loadMetadata()
       await walletModificationOperationGuard.release()
 
@@ -873,7 +890,8 @@ public class PortalMpc: PortalMpcProtocol {
   private func getBackupShare(
     _ forCurve: PortalCurve,
     withMethod: BackupMethods,
-    andSigningShare: String
+    andSigningShare: String,
+    reqId: String?
   ) async throws -> MpcShare {
     let mpcShare = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<MpcShare, Error>) in
       Task {
@@ -883,6 +901,7 @@ public class PortalMpc: PortalMpcProtocol {
           metadata.curve = forCurve
           metadata.backupMethod = withMethod.rawValue
           metadata.isMultiBackupEnabled = self.featureFlags?.isMultiBackupEnabled
+          metadata.reqId = reqId
 
           let mpcMetadataString = try metadata.jsonString()
 
@@ -914,13 +933,14 @@ public class PortalMpc: PortalMpcProtocol {
     return mpcShare
   }
 
-  private func getSigningShare(_ forCurve: PortalCurve) async throws -> MpcShare {
+  private func getSigningShare(_ forCurve: PortalCurve, reqId: String?) async throws -> MpcShare {
     let mpcShare = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<MpcShare, Error>) in
       Task {
         do {
           // Stringify the MPC metadata.
           var metadata = self.mpcMetadata
           metadata.curve = forCurve
+          metadata.reqId = reqId
 
           let mpcMetadataString = try metadata.jsonString()
           let response = forCurve == .ED25519
@@ -977,7 +997,7 @@ public class PortalMpc: PortalMpcProtocol {
     }
   }
 
-  private func recoverSigningShare(_ forCurve: PortalCurve, withMethod: BackupMethods, andBackupShare: String) async throws -> MpcShare {
+  private func recoverSigningShare(_ forCurve: PortalCurve, withMethod: BackupMethods, andBackupShare: String, reqId: String?) async throws -> MpcShare {
     let mpcShare = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<MpcShare, Error>) in
       Task {
         do {
@@ -986,6 +1006,7 @@ public class PortalMpc: PortalMpcProtocol {
           metadata.curve = forCurve
           metadata.backupMethod = withMethod.rawValue
           metadata.isMultiBackupEnabled = self.featureFlags?.isMultiBackupEnabled
+          metadata.reqId = reqId
 
           let mpcMetadataString = try metadata.jsonString()
 

--- a/Sources/PortalSwift/Core/Mpc/PortalMpcTypes.swift
+++ b/Sources/PortalSwift/Core/Mpc/PortalMpcTypes.swift
@@ -1,6 +1,14 @@
 public struct PortalMpcBackupResponse {
   public let cipherText: String
   public let shareIds: [String]
+  /// Operation-scoped trace ID used as MPC `reqId` and on follow-up API calls during backup.
+  public let traceId: String
+
+  public init(cipherText: String, shareIds: [String], traceId: String) {
+    self.cipherText = cipherText
+    self.shareIds = shareIds
+    self.traceId = traceId
+  }
 }
 
 public struct FormatShareResponse: Codable {

--- a/Sources/PortalSwift/Core/Mpc/PortalMpcTypes.swift
+++ b/Sources/PortalSwift/Core/Mpc/PortalMpcTypes.swift
@@ -159,6 +159,30 @@ struct GenerateResult: Codable {
   public var error: PortalError
 }
 
+/// The request body for the Enclave MPC API `POST /v1/generate` endpoint.
+struct GenerateApiRequest: Codable {
+  let usePreGenerated: Bool
+  let metadataStr: String
+}
+
+/// A single curve's share returned by the Enclave MPC API `POST /v1/generate` endpoint.
+/// `share` is the base64 (standard alphabet, no padding) of the serialized `MpcShare`.
+public struct GenerateApiCurveShare: Decodable {
+  public let share: String
+  public let id: String
+}
+
+/// The response from the Enclave MPC API `POST /v1/generate` endpoint.
+public struct GenerateApiResponse: Decodable {
+  public let secp256k1: GenerateApiCurveShare
+  public let ed25519: GenerateApiCurveShare
+
+  enum CodingKeys: String, CodingKey {
+    case secp256k1 = "SECP256K1"
+    case ed25519 = "ED25519"
+  }
+}
+
 /// The data for RotateResult.
 public struct RotateData: Codable {
   public var share: MpcShare

--- a/Sources/PortalSwift/Delegations/DelegationSubmitTypes.swift
+++ b/Sources/PortalSwift/Delegations/DelegationSubmitTypes.swift
@@ -1,0 +1,130 @@
+//
+//  DelegationSubmitTypes.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+//  Supporting types for the high-level delegation submit methods
+//  (approveAndSubmit / revokeAndSubmit / transferAndSubmit).
+//
+
+import Foundation
+
+// MARK: - DelegationTransaction
+
+/// A single transaction to be signed and broadcast by a delegation submit flow.
+///
+/// Delegation endpoints return either EVM transaction objects or base64-encoded Solana transaction
+/// strings. This enum models both shapes in a type-safe way (avoiding `Any`).
+public enum DelegationTransaction: Equatable {
+  /// An EVM transaction, signed and sent via `eth_sendTransaction`.
+  case evm(ConstructedEipTransaction)
+  /// A base64-encoded Solana transaction, signed and sent via `sol_signAndSendTransaction`.
+  case solana(String)
+
+  /// The EVM transaction, if this is an `.evm` case.
+  public var evmTransaction: ConstructedEipTransaction? {
+    if case let .evm(transaction) = self { return transaction }
+    return nil
+  }
+
+  /// The encoded Solana transaction, if this is a `.solana` case.
+  public var solanaTransaction: String? {
+    if case let .solana(encoded) = self { return encoded }
+    return nil
+  }
+}
+
+// MARK: - DelegationSignAndSend
+
+/// Signer function used by the high-level delegation submit methods.
+///
+/// Receives a single `DelegationTransaction` (EVM object or Solana encoded string) and the CAIP-2
+/// chain ID, signs and broadcasts it, and returns the resulting transaction hash.
+public typealias DelegationSignAndSend = (_ transaction: DelegationTransaction, _ chainId: String) async throws -> String
+
+// MARK: - DelegationSubmitStep
+
+/// The step of a high-level delegation submit flow, emitted via `DelegationSubmitOptions.onProgress`.
+public enum DelegationSubmitStep: String, Equatable {
+  /// A transaction is about to be signed and sent.
+  case signing
+  /// A transaction has been broadcast and a hash was returned.
+  case submitted
+}
+
+// MARK: - DelegationSubmitProgress
+
+/// Progress event emitted during a high-level delegation submit flow.
+public struct DelegationSubmitProgress: Equatable {
+  /// The current step (`.signing` or `.submitted`).
+  public let step: DelegationSubmitStep
+  /// The 0-based index of the transaction within the sequence.
+  public let index: Int
+  /// The total number of transactions in the sequence.
+  public let total: Int
+  /// The transaction hash (only present on `.submitted`).
+  public let hash: String?
+
+  public init(step: DelegationSubmitStep, index: Int, total: Int, hash: String? = nil) {
+    self.step = step
+    self.index = index
+    self.total = total
+    self.hash = hash
+  }
+}
+
+// MARK: - DelegationSubmitResult
+
+/// Result of a high-level delegation submit flow.
+public struct DelegationSubmitResult: Equatable {
+  /// The transaction hashes, one per broadcast transaction, in submission order.
+  public let hashes: [String]
+
+  public init(hashes: [String]) {
+    self.hashes = hashes
+  }
+}
+
+// MARK: - DelegationSubmitOptions
+
+/// Per-call options for the high-level delegation submit methods.
+public struct DelegationSubmitOptions {
+  /// Optional per-call signer override. When provided, it takes precedence over the instance-level
+  /// signer configured via `Delegations.setSignAndSendTransaction(_:)`.
+  public let signAndSendTransaction: DelegationSignAndSend?
+  /// Optional callback invoked with `DelegationSubmitProgress` events as each transaction is signed
+  /// and submitted.
+  public let onProgress: ((DelegationSubmitProgress) -> Void)?
+
+  public init(
+    signAndSendTransaction: DelegationSignAndSend? = nil,
+    onProgress: ((DelegationSubmitProgress) -> Void)? = nil
+  ) {
+    self.signAndSendTransaction = signAndSendTransaction
+    self.onProgress = onProgress
+  }
+}
+
+// MARK: - DelegationsError
+
+/// Errors specific to the high-level delegation submit flows.
+public enum DelegationsError: LocalizedError, Equatable {
+  /// No signer was configured via options or `Delegations.setSignAndSendTransaction(_:)`.
+  case noSignerConfigured
+  /// The delegation response contained no transactions to sign.
+  case noTransactions
+  /// The signer returned an empty or invalid transaction hash.
+  case invalidTransactionHash(index: Int, chainId: String)
+
+  public var errorDescription: String? {
+    switch self {
+    case .noSignerConfigured:
+      return "[Delegations] No signer configured. Call setSignAndSendTransaction() on the instance or pass signAndSendTransaction in options."
+    case .noTransactions:
+      return "No transactions in delegation response."
+    case let .invalidTransactionHash(index, chainId):
+      return "Invalid transaction hash returned from signAndSendTransaction at index \(index) for chain \(chainId)."
+    }
+  }
+}

--- a/Sources/PortalSwift/Delegations/Delegations.swift
+++ b/Sources/PortalSwift/Delegations/Delegations.swift
@@ -36,6 +36,51 @@ public protocol DelegationsProtocol {
   /// - Returns: Response containing transaction data and metadata
   /// - Throws: `URLError` if the URL cannot be constructed, or other network/decoding errors if the request fails.
   func transferFrom(request: TransferFromRequest) async throws -> TransferFromResponse
+
+  /// Configures the default signer used by the high-level submit methods when no per-call override is given.
+  /// - Parameter fn: The signer function that signs and broadcasts a transaction and returns its hash.
+  func setSignAndSendTransaction(_ fn: @escaping DelegationSignAndSend)
+
+  /// Approves a delegation and signs/broadcasts the resulting transaction(s) in one call.
+  /// - Parameters:
+  ///   - request: The approval request containing chain, token, delegateAddress, and amount
+  ///   - options: Optional per-call signer override and progress callback
+  /// - Returns: The broadcast transaction hashes
+  /// - Throws: `DelegationsError` or network/signing errors
+  func approveAndSubmit(request: ApproveDelegationRequest, options: DelegationSubmitOptions) async throws -> DelegationSubmitResult
+
+  /// Revokes a delegation and signs/broadcasts the resulting transaction(s) in one call.
+  /// - Parameters:
+  ///   - request: The revocation request containing chain, token, and delegateAddress
+  ///   - options: Optional per-call signer override and progress callback
+  /// - Returns: The broadcast transaction hashes
+  /// - Throws: `DelegationsError` or network/signing errors
+  func revokeAndSubmit(request: RevokeDelegationRequest, options: DelegationSubmitOptions) async throws -> DelegationSubmitResult
+
+  /// Executes a delegated transfer and signs/broadcasts the resulting transaction(s) in one call.
+  /// - Parameters:
+  ///   - request: The transfer request containing chain, token, fromAddress, toAddress, and amount
+  ///   - options: Optional per-call signer override and progress callback
+  /// - Returns: The broadcast transaction hashes
+  /// - Throws: `DelegationsError` or network/signing errors
+  func transferAndSubmit(request: TransferFromRequest, options: DelegationSubmitOptions) async throws -> DelegationSubmitResult
+}
+
+public extension DelegationsProtocol {
+  /// Convenience overload allowing `approveAndSubmit` to be called without options.
+  func approveAndSubmit(request: ApproveDelegationRequest) async throws -> DelegationSubmitResult {
+    try await approveAndSubmit(request: request, options: DelegationSubmitOptions())
+  }
+
+  /// Convenience overload allowing `revokeAndSubmit` to be called without options.
+  func revokeAndSubmit(request: RevokeDelegationRequest) async throws -> DelegationSubmitResult {
+    try await revokeAndSubmit(request: request, options: DelegationSubmitOptions())
+  }
+
+  /// Convenience overload allowing `transferAndSubmit` to be called without options.
+  func transferAndSubmit(request: TransferFromRequest) async throws -> DelegationSubmitResult {
+    try await transferAndSubmit(request: request, options: DelegationSubmitOptions())
+  }
 }
 
 /// Delegations provider implementation.
@@ -71,10 +116,27 @@ public protocol DelegationsProtocol {
 public class Delegations: DelegationsProtocol {
   private let api: PortalDelegationsApiProtocol
 
+  /// Instance-level signer used by the high-level submit methods when no per-call override is given.
+  ///
+  /// - Note: This is expected to be configured once (typically during `Portal` initialization) before
+  ///   any submit call is made. Access is not synchronized, so reconfiguring it via
+  ///   `setSignAndSendTransaction(_:)` while a submit call is in flight is not thread-safe. To vary
+  ///   the signer per call, pass `DelegationSubmitOptions.signAndSendTransaction` instead.
+  private var signAndSendTransactionFn: DelegationSignAndSend?
+
   /// Create an instance of Delegations.
   /// - Parameter api: The PortalDelegationsApi instance to use for delegation operations.
   public init(api: PortalDelegationsApiProtocol) {
     self.api = api
+  }
+
+  /// Configures the default signer used by `approveAndSubmit`, `revokeAndSubmit`, and
+  /// `transferAndSubmit` when no per-call `DelegationSubmitOptions.signAndSendTransaction` is provided.
+  ///
+  /// Typically wired once during Portal initialization.
+  /// - Parameter fn: The signer function that signs and broadcasts a transaction and returns its hash.
+  public func setSignAndSendTransaction(_ fn: @escaping DelegationSignAndSend) {
+    self.signAndSendTransactionFn = fn
   }
 
   /// Approves a delegation for a specified token on a given chain.
@@ -141,5 +203,107 @@ public class Delegations: DelegationsProtocol {
   /// - Throws: `URLError` if the URL cannot be constructed, or network/decoding errors if the request fails.
   public func transferFrom(request: TransferFromRequest) async throws -> TransferFromResponse {
     try await api.transferFrom(request: request)
+  }
+
+  // MARK: - High-Level Submit Methods
+
+  /// Approves a delegation and signs/broadcasts the resulting transaction(s) in one call.
+  ///
+  /// Constructs the approval transaction(s) via `approve`, then signs and submits each transaction
+  /// sequentially. Confirmation is not awaited; callers can use `DelegationSubmitResult.hashes` to
+  /// track confirmations themselves.
+  public func approveAndSubmit(request: ApproveDelegationRequest, options: DelegationSubmitOptions) async throws -> DelegationSubmitResult {
+    let signAndSend = try resolveSigner(options)
+    let response = try await api.approve(request: request)
+    return try await executeAndTrack(
+      transactions: normalizeToTransactionList(transactions: response.transactions, encodedTransactions: response.encodedTransactions),
+      chainId: request.chain,
+      signAndSend: signAndSend,
+      onProgress: options.onProgress
+    )
+  }
+
+  /// Revokes a delegation and signs/broadcasts the resulting transaction(s) in one call.
+  ///
+  /// Constructs the revocation transaction(s) via `revoke`, then signs and submits each transaction
+  /// sequentially. Confirmation is not awaited.
+  public func revokeAndSubmit(request: RevokeDelegationRequest, options: DelegationSubmitOptions) async throws -> DelegationSubmitResult {
+    let signAndSend = try resolveSigner(options)
+    let response = try await api.revoke(request: request)
+    return try await executeAndTrack(
+      transactions: normalizeToTransactionList(transactions: response.transactions, encodedTransactions: response.encodedTransactions),
+      chainId: request.chain,
+      signAndSend: signAndSend,
+      onProgress: options.onProgress
+    )
+  }
+
+  /// Executes a delegated transfer and signs/broadcasts the resulting transaction(s) in one call.
+  ///
+  /// Constructs the transfer transaction(s) via `transferFrom`, then signs and submits each
+  /// transaction sequentially. The caller must have been previously approved as a delegate.
+  /// Confirmation is not awaited.
+  public func transferAndSubmit(request: TransferFromRequest, options: DelegationSubmitOptions) async throws -> DelegationSubmitResult {
+    let signAndSend = try resolveSigner(options)
+    let response = try await api.transferFrom(request: request)
+    return try await executeAndTrack(
+      transactions: normalizeToTransactionList(transactions: response.transactions, encodedTransactions: response.encodedTransactions),
+      chainId: request.chain,
+      signAndSend: signAndSend,
+      onProgress: options.onProgress
+    )
+  }
+
+  // MARK: - Private Helpers
+
+  /// Resolves the signer to use, preferring the per-call override, then the instance-level signer.
+  /// - Throws: `DelegationsError.noSignerConfigured` if neither is configured.
+  private func resolveSigner(_ options: DelegationSubmitOptions) throws -> DelegationSignAndSend {
+    if let signer = options.signAndSendTransaction {
+      return signer
+    }
+    if let signer = signAndSendTransactionFn {
+      return signer
+    }
+    throw DelegationsError.noSignerConfigured
+  }
+
+  /// Normalizes a delegation response into a single ordered list of transactions to sign.
+  ///
+  /// Prefers EVM `transactions` when non-empty, otherwise falls back to Solana `encodedTransactions`.
+  private func normalizeToTransactionList(transactions: [ConstructedEipTransaction]?, encodedTransactions: [String]?) -> [DelegationTransaction] {
+    if let transactions, !transactions.isEmpty {
+      return transactions.map { .evm($0) }
+    }
+    if let encodedTransactions, !encodedTransactions.isEmpty {
+      return encodedTransactions.map { .solana($0) }
+    }
+    return []
+  }
+
+  /// Signs and broadcasts each transaction sequentially, emitting progress and collecting hashes.
+  /// - Throws: `DelegationsError.noTransactions` if empty, or `DelegationsError.invalidTransactionHash`
+  ///   if the signer returns an empty hash.
+  private func executeAndTrack(
+    transactions: [DelegationTransaction],
+    chainId: String,
+    signAndSend: DelegationSignAndSend,
+    onProgress: ((DelegationSubmitProgress) -> Void)?
+  ) async throws -> DelegationSubmitResult {
+    guard !transactions.isEmpty else {
+      throw DelegationsError.noTransactions
+    }
+    let total = transactions.count
+    var hashes: [String] = []
+    for (index, tx) in transactions.enumerated() {
+      onProgress?(DelegationSubmitProgress(step: .signing, index: index, total: total))
+      let hash = try await signAndSend(tx, chainId)
+      guard !hash.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        throw DelegationsError.invalidTransactionHash(index: index, chainId: chainId)
+      }
+      hashes.append(hash)
+      onProgress?(DelegationSubmitProgress(step: .submitted, index: index, total: total, hash: hash))
+    }
+    return DelegationSubmitResult(hashes: hashes)
   }
 }

--- a/Sources/PortalSwift/EvmAccountType/EvmAccountType.swift
+++ b/Sources/PortalSwift/EvmAccountType/EvmAccountType.swift
@@ -34,7 +34,7 @@ public enum EvmAccountTypeError: LocalizedError, Equatable {
 /// Minimal protocol for portal capabilities required by EvmAccountType (rawSign and request).
 /// Portal conforms to this protocol; tests can use a small mock.
 public protocol EvmAccountTypePortalDependency: AnyObject {
-  func rawSign(message: String, chainId: String, signatureApprovalMemo: String?) async throws -> PortalProviderResult
+  func rawSign(message: String, chainId: String, signatureApprovalMemo: String?, traceId: String?) async throws -> PortalProviderResult
   func request(chainId: String, method: PortalRequestMethod, params: [Any], options: RequestOptions?) async throws -> PortalProviderResult
 }
 
@@ -73,7 +73,7 @@ public class EvmAccountType: EvmAccountTypeProtocol {
 
   /// Retrieves the account type for the client's wallet on the given chain.
   public func getStatus(chainId: String) async throws -> EvmAccountTypeResponse {
-    return try await api.getStatus(chainId: chainId)
+    return try await api.getStatus(chainId: chainId, traceId: nil)
   }
 
   /// Returns the EOA and smart contract addresses for the client's wallet on the given chain.
@@ -90,6 +90,9 @@ public class EvmAccountType: EvmAccountTypeProtocol {
   /// Steps: validate eip155 namespace → getStatus → require EIP_155_EOA → build authorization list →
   /// raw sign hash (without 0x) → build authorization transaction (subsidized) → return tx hash.
   public func upgradeTo7702(chainId: String) async throws -> String {
+    // A single trace ID is shared across all requests for this operation.
+    let traceId = generateTraceId()
+
     // 1. Validate chain namespace is eip155
     let blockchain = try PortalBlockchain(fromChainId: chainId)
     guard blockchain.namespace == .eip155 else {
@@ -97,7 +100,7 @@ public class EvmAccountType: EvmAccountTypeProtocol {
     }
 
     // 2. Get status and require EIP_155_EOA
-    let statusResponse = try await getStatus(chainId: chainId)
+    let statusResponse = try await api.getStatus(chainId: chainId, traceId: traceId)
     guard statusResponse.data.status == "EIP_155_EOA" else {
       throw EvmAccountTypeError.invalidAccountType(statusResponse.data.status)
     }
@@ -107,19 +110,19 @@ public class EvmAccountType: EvmAccountTypeProtocol {
     }
 
     // 3. Build authorization list and get hash
-    let authListResponse = try await api.buildAuthorizationList(chainId: chainId, subsidize: true)
+    let authListResponse = try await api.buildAuthorizationList(chainId: chainId, subsidize: true, traceId: traceId)
     let hash = authListResponse.data.hash
     let messageToSign = hash.hasPrefix("0x") ? String(hash.dropFirst(2)) : hash
 
     // 4. Raw sign the hash
-    let signResult = try await portal.rawSign(message: messageToSign, chainId: chainId, signatureApprovalMemo: nil)
+    let signResult = try await portal.rawSign(message: messageToSign, chainId: chainId, signatureApprovalMemo: nil, traceId: traceId)
     guard let signature = signResult.result as? String else {
       throw EvmAccountTypeError.invalidSignatureResponse
     }
     let signatureWithoutPrefix = signature.hasPrefix("0x") ? String(signature.dropFirst(2)) : signature
 
     // 5. Build authorization transaction
-    let buildTxResponse = try await api.buildAuthorizationTransaction(chainId: chainId, signature: signatureWithoutPrefix, subsidize: true)
+    let buildTxResponse = try await api.buildAuthorizationTransaction(chainId: chainId, signature: signatureWithoutPrefix, subsidize: true, traceId: traceId)
     guard let txHash = buildTxResponse.data.transactionHash else {
       throw EvmAccountTypeError.invalidTransactionResponse
     }

--- a/Sources/PortalSwift/Mocks/Constants.swift
+++ b/Sources/PortalSwift/Mocks/Constants.swift
@@ -415,6 +415,15 @@ public enum MockConstants {
     }
   }
 
+  /// Base64-encoded (standard alphabet, no padding) JSON of `mockMpcShare`, mimicking what the
+  /// Enclave MPC API `POST /v1/generate` returns for each curve's `share`.
+  public static var mockBase64EncodedMpcShare: String {
+    get throws {
+      let mockMpcShareData = try JSONEncoder().encode(mockMpcShare)
+      return mockMpcShareData.base64EncodedString().replacingOccurrences(of: "=", with: "")
+    }
+  }
+
   public static var mockCreateWalletResponse: PortalCreateWalletResponse {
     let mockCreateWalletResponse: PortalCreateWalletResponse = (
       ethereum: mockEip155Address,

--- a/Sources/PortalSwift/Mocks/Core/MockMpc/MockPortalMpc.swift
+++ b/Sources/PortalSwift/Mocks/Core/MockMpc/MockPortalMpc.swift
@@ -16,7 +16,8 @@ public class MockPortalMpc: PortalMpcProtocol {
     usingProgressCallback?(MpcStatus(status: .done, done: true))
     return PortalMpcBackupResponse(
       cipherText: MockConstants.mockCiphertext,
-      shareIds: [MockConstants.mockMpcShareId, MockConstants.mockMpcShareId]
+      shareIds: [MockConstants.mockMpcShareId, MockConstants.mockMpcShareId],
+      traceId: generateTraceId()
     )
   }
 
@@ -62,7 +63,8 @@ public class MockPortalMpc: PortalMpcProtocol {
       backupResponse:
       PortalMpcBackupResponse(
         cipherText: MockConstants.mockCiphertext,
-        shareIds: [MockConstants.mockMpcShareId, MockConstants.mockMpcShareId]
+        shareIds: [MockConstants.mockMpcShareId, MockConstants.mockMpcShareId],
+        traceId: generateTraceId()
       )
     )
   }

--- a/Sources/PortalSwift/Mocks/Provider/MockPortalMpcSigner.swift
+++ b/Sources/PortalSwift/Mocks/Provider/MockPortalMpcSigner.swift
@@ -14,7 +14,8 @@ public class MockPortalMpcSigner: PortalMpcSigner {
     andRpcUrl _: String,
     usingBlockchain _: PortalBlockchain,
     signatureApprovalMemo _: String?,
-    sponsorGas _: Bool?
+    sponsorGas _: Bool?,
+    reqId _: String? = nil
   ) async throws -> String {
     switch withPayload.method {
     case .eth_sendTransaction, .eth_sendRawTransaction:

--- a/Sources/PortalSwift/Mocks/Utils/MockPortalRequests.swift
+++ b/Sources/PortalSwift/Mocks/Utils/MockPortalRequests.swift
@@ -9,8 +9,14 @@ import Foundation
 
 public actor MockPortalRequests: PortalRequestsProtocol {
   private let encoder = JSONEncoder()
+  private let failEnclaveGenerate: Bool
 
-  public init() {}
+  /// Number of times the `/v1/generate` (pre-generated wallet) endpoint was requested.
+  public private(set) var generateCallsCount = 0
+
+  public init(failEnclaveGenerate: Bool = false) {
+    self.failEnclaveGenerate = failEnclaveGenerate
+  }
 
   public func delete(_ url: URL, withBearerToken _: String? = nil) async throws -> Data {
     switch url.path {
@@ -100,6 +106,17 @@ public actor MockPortalRequests: PortalRequestsProtocol {
     postAndPayloadParam = andPayload
 
     switch url.path {
+    case "/v1/generate":
+      self.generateCallsCount += 1
+      if self.failEnclaveGenerate {
+        throw PortalRequestsError.internalServerError("500 - simulated pre-generated wallet failure", url: url.absoluteString)
+      }
+      let share = try MockConstants.mockBase64EncodedMpcShare
+      let json = "{\"SECP256K1\":{\"share\":\"\(share)\",\"id\":\"\(MockConstants.mockMpcShareId)\"},\"ED25519\":{\"share\":\"\(share)\",\"id\":\"\(MockConstants.mockMpcShareId)\"}}"
+      guard let data = json.data(using: .utf8) else {
+        throw PortalRequestsError.couldNotParseHttpResponse
+      }
+      return data
     case "/api/v1/analytics/identify", "/api/v1/analytics/track":
       let mockMetricsResponseData = try encoder.encode(MockConstants.mockMetricsResponse)
       return mockMetricsResponseData

--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -38,7 +38,7 @@ public final class Portal: PortalProtocol {
   public var rpcConfig: [String: String]
 
   /// Access to yield-related functionality.
-  public lazy var yield: Yield = .init(api: self.api)
+  public lazy var yield: Yield = .init(api: self.api, portal: self)
 
   /// Access to ramps-related (on/off-ramp) functionality.
   public lazy var ramps: Ramps = .init(api: self.api)
@@ -2440,6 +2440,8 @@ public final class Portal: PortalProtocol {
 }
 
 extension Portal: EvmAccountTypePortalDependency {}
+
+extension Portal: YieldXyzPortalDependency {}
 
 /*****************************************
  * Supporting Enums & Structs

--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -136,7 +136,7 @@ public final class Portal: PortalProtocol {
 
     // Creating this as a variable first so it's usable to
     // fetch the client in the Task at the end of the initializer
-    let api = api ?? PortalApi(apiKey: apiKey, apiHost: apiHost, provider: provider)
+    let api = api ?? PortalApi(apiKey: apiKey, apiHost: apiHost, enclaveMPCHost: enclaveMPCHost, provider: provider)
     self.api = api
     self.keychain.api = api
     self.provider.api = api

--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -50,7 +50,14 @@ public final class Portal: PortalProtocol {
   public lazy var security: Security = .init(api: self.api)
 
   /// Access to delegation-related functionality.
-  public lazy var delegations: DelegationsProtocol = Delegations(api: self.api.delegations)
+  public lazy var delegations: DelegationsProtocol = {
+    let delegations = Delegations(api: self.api.delegations)
+    delegations.setSignAndSendTransaction { [weak self] transaction, chainId in
+      guard let self else { throw DelegationsError.noSignerConfigured }
+      return try await self.signDelegationTransaction(transaction, chainId: chainId)
+    }
+    return delegations
+  }()
 
   /// Access to EVM Account Type functionality (EIP-7702 upgrade, account type status).
   public lazy var evmAccountType: EvmAccountTypeProtocol = EvmAccountType(api: self.api.evmAccountType, portal: self)
@@ -2530,4 +2537,37 @@ public enum PortalSharePairType: String, Codable {
 
 public enum PortalSolError: LocalizedError {
   case failedToGetTransactionHash
+}
+
+// MARK: - Delegations
+
+extension Portal {
+  /// Default signer for high-level delegation submit flows.
+  ///
+  /// Maps a `DelegationTransaction` to the appropriate provider request (EVM `eth_sendTransaction`
+  /// or Solana `sol_signAndSendTransaction`), broadcasts it, and returns the transaction hash.
+  ///
+  /// Returns an empty string when the provider result is not a hash so that the caller
+  /// (`Delegations.executeAndTrack`) can raise `DelegationsError.invalidTransactionHash` with the
+  /// correct transaction index rather than a hardcoded index of 0.
+  private func signDelegationTransaction(_ transaction: DelegationTransaction, chainId: String) async throws -> String {
+    let method: PortalRequestMethod
+    let params: [Any]
+    switch transaction {
+    case let .evm(tx):
+      var dict: [String: String] = ["from": tx.from, "to": tx.to]
+      if let data = tx.data { dict["data"] = data }
+      if let value = tx.value { dict["value"] = value }
+      method = .eth_sendTransaction
+      params = [dict]
+    case let .solana(encoded):
+      method = .sol_signAndSendTransaction
+      params = [encoded]
+    }
+    let result = try await request(chainId: chainId, method: method, params: params, options: nil)
+    // Return an empty string when the provider result is not a hash so that the caller
+    // (`Delegations.executeAndTrack`) can raise `DelegationsError.invalidTransactionHash` with the
+    // correct transaction index rather than a hardcoded index of 0.
+    return result.result as? String ?? ""
+  }
 }

--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -529,14 +529,15 @@ public final class Portal: PortalProtocol {
     // Run backup
     let response = try await mpc.backup(method, usingProgressCallback: usingProgressCallback)
 
-    // Build the storage callback
+    // Build the storage callback — reuse the backup operation's trace ID for correlation.
     let storageCallback: () async throws -> Void = {
       try await self.api.updateShareStatus(
         .backup,
         status: .STORED_CLIENT_BACKUP_SHARE,
-        sharePairIds: response.shareIds
+        sharePairIds: response.shareIds,
+        traceId: response.traceId
       )
-      try await self.api.refreshClient()
+      try await self.api.refreshClient(traceId: response.traceId)
       try await self.keychain.loadMetadata()
     }
 
@@ -797,14 +798,15 @@ public final class Portal: PortalProtocol {
     // Run generateSolanaWalletAndBackupShares
     let result = try await mpc.generateSolanaWalletAndBackupShares(backupMethod: method, usingProgressCallback: usingProgressCallback)
 
-    // Build the storage callback
+    // Build the storage callback — reuse the backup operation's trace ID for correlation.
     let storageCallback: () async throws -> Void = {
       try await self.api.updateShareStatus(
         .backup,
         status: .STORED_CLIENT_BACKUP_SHARE,
-        sharePairIds: result.backupResponse.shareIds
+        sharePairIds: result.backupResponse.shareIds,
+        traceId: result.backupResponse.traceId
       )
-      try await self.api.refreshClient()
+      try await self.api.refreshClient(traceId: result.backupResponse.traceId)
     }
 
     return (
@@ -1516,7 +1518,7 @@ public final class Portal: PortalProtocol {
   ///   - The `rawTxHex` and signatures are required for broadcasting the transaction using `broadcastBitcoinP2wpkhTransaction`.
   ///   - Only native BTC transactions are supported; token transfers (e.g., ERC-20 equivalents) are not applicable to Bitcoin P2WPKH.
   public func buildBitcoinP2wpkhTransaction(chainId: String, params: BuildTransactionParam) async throws -> BuildBitcoinP2wpkhTransactionResponse {
-    return try await api.buildBitcoinP2wpkhTransaction(chainId: chainId, params: params)
+    return try await api.buildBitcoinP2wpkhTransaction(chainId: chainId, params: params, traceId: nil)
   }
 
   /// Builds an EIP-155 compliant transaction for Ethereum-compatible chains.
@@ -1535,7 +1537,7 @@ public final class Portal: PortalProtocol {
   /// - Note: Only valid for EVM-compatible chains. For Solana transactions,
   ///   use `buildSolanaTransaction(_:params:)` instead.
   public func buildEip155Transaction(chainId: String, params: BuildTransactionParam) async throws -> BuildEip115TransactionResponse {
-    return try await api.buildEip155Transaction(chainId: chainId, params: params)
+    return try await api.buildEip155Transaction(chainId: chainId, params: params, traceId: nil)
   }
 
   /// Builds a Solana transaction.
@@ -1553,7 +1555,7 @@ public final class Portal: PortalProtocol {
   /// - Note: Only valid for Solana chains. For EVM-compatible chains,
   ///   use `buildEip155Transaction(_:params:)` instead.
   public func buildSolanaTransaction(chainId: String, params: BuildTransactionParam) async throws -> BuildSolanaTransactionResponse {
-    return try await api.buildSolanaTransaction(chainId: chainId, params: params)
+    return try await api.buildSolanaTransaction(chainId: chainId, params: params, traceId: nil)
   }
 
   /// Broadcasts a Bitcoin P2WPKH transaction to the network.
@@ -1579,7 +1581,7 @@ public final class Portal: PortalProtocol {
   ///   - This method requires a valid wallet with completed signing shares for the specified `chainId`. Use `doesWalletExist(_:)` to verify wallet existence.
   ///   - Broadcasting a transaction does not guarantee inclusion in a block; monitor the transaction hash for confirmation status.
   public func broadcastBitcoinP2wpkhTransaction(chainId: String, params: BroadcastParam) async throws -> BroadcastBitcoinP2wpkhTransactionResponse {
-    return try await api.broadcastBitcoinP2wpkhTransaction(chainId: chainId, params: params)
+    return try await api.broadcastBitcoinP2wpkhTransaction(chainId: chainId, params: params, traceId: nil)
   }
 
   /// Retrieves the capabilities of the current wallet.
@@ -1652,6 +1654,8 @@ public final class Portal: PortalProtocol {
     }
 
     let namespace = PortalNamespace(rawValue: String(chainParts[0]))
+    // A single trace ID is shared across all build/sign/broadcast requests for this operation.
+    let traceId = params.traceId ?? generateTraceId()
     // Build the appropriate transaction based on chain type
     let transactionParam = BuildTransactionParam(
       to: params.to,
@@ -1662,14 +1666,14 @@ public final class Portal: PortalProtocol {
     switch namespace {
     case .eip155:
       // Build and send EVM transaction
-      let transactionResponse = try await buildEip155Transaction(chainId: chainId, params: transactionParam)
+      let transactionResponse = try await api.buildEip155Transaction(chainId: chainId, params: transactionParam, traceId: traceId)
 
       // Send the transaction using eth_sendTransaction
       let sendResponse = try await request(
         chainId: chainId,
         method: .eth_sendTransaction,
         params: [transactionResponse.transaction],
-        options: RequestOptions(signatureApprovalMemo: params.signatureApprovalMemo, sponsorGas: params.sponsorGas)
+        options: RequestOptions(signatureApprovalMemo: params.signatureApprovalMemo, sponsorGas: params.sponsorGas, traceId: traceId)
       )
 
       guard let txHash = sendResponse.result as? String else {
@@ -1681,14 +1685,14 @@ public final class Portal: PortalProtocol {
 
     case .solana:
       // Build and send Solana transaction
-      let transactionResponse = try await buildSolanaTransaction(chainId: chainId, params: transactionParam)
+      let transactionResponse = try await api.buildSolanaTransaction(chainId: chainId, params: transactionParam, traceId: traceId)
 
       // Send the transaction using sol_signAndSendTransaction
       let sendResponse = try await request(
         chainId: chainId,
         method: .sol_signAndSendTransaction,
         params: [transactionResponse.transaction],
-        options: RequestOptions(signatureApprovalMemo: params.signatureApprovalMemo, sponsorGas: params.sponsorGas)
+        options: RequestOptions(signatureApprovalMemo: params.signatureApprovalMemo, sponsorGas: params.sponsorGas, traceId: traceId)
       )
 
       guard let txHash = sendResponse.result as? String else {
@@ -1706,12 +1710,12 @@ public final class Portal: PortalProtocol {
       }
 
       // Build the transaction
-      let transactionResponse = try await buildBitcoinP2wpkhTransaction(chainId: chainId, params: transactionParam)
+      let transactionResponse = try await api.buildBitcoinP2wpkhTransaction(chainId: chainId, params: transactionParam, traceId: traceId)
 
       // Raw sign each of the signature hashes of the partially-signed bitcoin tx (psbt)
       var signatures: [String] = []
       for signatureHash in transactionResponse.transaction.signatureHashes {
-        let signResponse = try await rawSign(message: signatureHash, chainId: chainId)
+        let signResponse = try await rawSign(message: signatureHash, chainId: chainId, traceId: traceId)
 
         guard let signature = signResponse.result as? String else {
           throw PortalClassError.invalidResponseTypeForRequest
@@ -1721,9 +1725,10 @@ public final class Portal: PortalProtocol {
       }
 
       // Broadcast the transaction
-      let broadcastResponse = try await broadcastBitcoinP2wpkhTransaction(
+      let broadcastResponse = try await api.broadcastBitcoinP2wpkhTransaction(
         chainId: chainId,
-        params: BroadcastParam(signatures: signatures, rawTxHex: transactionResponse.transaction.rawTxHex)
+        params: BroadcastParam(signatures: signatures, rawTxHex: transactionResponse.transaction.rawTxHex),
+        traceId: traceId
       )
 
       // Construct and return response
@@ -2269,14 +2274,15 @@ public final class Portal: PortalProtocol {
   public func rawSign(
     message: String,
     chainId: String,
-    signatureApprovalMemo: String? = nil
+    signatureApprovalMemo: String? = nil,
+    traceId: String?
   ) async throws -> PortalProviderResult {
     return try await self.provider.request(
       chainId: chainId,
       method: .rawSign,
       params: [AnyCodable(message)],
       connect: nil,
-      options: RequestOptions(signatureApprovalMemo: signatureApprovalMemo)
+      options: RequestOptions(signatureApprovalMemo: signatureApprovalMemo, traceId: traceId)
     )
   }
 

--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -44,7 +44,21 @@ public final class Portal: PortalProtocol {
   public lazy var ramps: Ramps = .init(api: self.api)
 
   /// Access to trading-related functionality.
-  public lazy var trading: Trading = .init(api: self.api)
+  public lazy var trading: Trading = .init(
+    api: self.api,
+    signAndSendTransaction: { [weak self] transaction, chainId in
+      guard let self else {
+        throw PortalClassError.clientNotAvailable
+      }
+      return try await self.signAndSendTransaction(transaction, chainId: chainId)
+    },
+    waitForConfirmation: { [weak self] txHash, chainId in
+      guard let self else {
+        throw PortalClassError.clientNotAvailable
+      }
+      return try await self.waitForTransactionConfirmation(txHash: txHash, chainId: chainId)
+    }
+  )
 
   /// Access to security-related functionality.
   public lazy var security: Security = .init(api: self.api)
@@ -995,6 +1009,68 @@ public final class Portal: PortalProtocol {
     }
 
     return try await self.provider.request(chainId: chainId, method: method, params: anyCodableParams, connect: nil, options: options)
+  }
+
+  /// Signs and submits an EVM transaction via `eth_sendTransaction`, returning the transaction hash.
+  /// - Parameters:
+  ///   - transaction: The transaction to sign and submit.
+  ///   - chainId: A CAIP-2 Blockchain ID associated with the transaction.
+  /// - Returns: The transaction hash.
+  private func signAndSendTransaction(_ transaction: ETHTransactionParam, chainId: String) async throws -> String {
+    let response = try await self.request(chainId: chainId, method: .eth_sendTransaction, params: [transaction])
+    guard let txHash = response.result as? String else {
+      throw PortalClassError.invalidResponseTypeForRequest
+    }
+    return txHash
+  }
+
+  /// Polls `eth_getTransactionReceipt` until the transaction is mined and confirmed.
+  /// - Parameters:
+  ///   - txHash: The transaction hash to wait for.
+  ///   - chainId: A CAIP-2 Blockchain ID associated with the transaction.
+  ///   - maxAttempts: The maximum number of polling attempts (default: 30).
+  ///   - waitingInSeconds: The delay between attempts, in seconds (default: 2).
+  /// - Returns: `.confirmed` on success, `.reverted` if the transaction was mined but reverted, or
+  ///   `.timedOut` if no definitive receipt was obtained within `maxAttempts` (still pending or the
+  ///   node was unreachable).
+  /// - Throws: `CancellationError` if the surrounding task is cancelled, so callers can stop promptly.
+  private func waitForTransactionConfirmation(
+    txHash: String,
+    chainId: String,
+    maxAttempts: Int = 30,
+    waitingInSeconds: Int = 2
+  ) async throws -> LifiConfirmationResult {
+    // Clamp so the nanosecond conversion is non-negative and can't overflow UInt64 for a very
+    // large `waitingInSeconds`.
+    let maxWaitingSeconds = Int(UInt64.max / 1_000_000_000)
+    let waitingTimeInNanoSeconds = UInt64(min(max(0, waitingInSeconds), maxWaitingSeconds)) * 1_000_000_000
+
+    for attempt in 0 ..< maxAttempts {
+      try Task.checkCancellation()
+
+      // Sleep only between attempts, not before the first check — the receipt may already be
+      // available. Kept outside the do/catch below so cancellation propagates instead of retrying.
+      if attempt > 0 {
+        try await Task.sleep(nanoseconds: waitingTimeInNanoSeconds)
+      }
+
+      do {
+        let response = try await self.request(chainId: chainId, method: .eth_getTransactionReceipt, params: [txHash])
+        if let innerResponse = response.result as? EthTransactionResponse,
+           let status = innerResponse.result?.status
+        {
+          return status == "0x1" ? .confirmed : .reverted
+        }
+        // No receipt yet; keep polling until mined.
+      } catch is CancellationError {
+        throw CancellationError()
+      } catch {
+        // Transient RPC failure: log and retry rather than reporting a false revert.
+        PortalLogger.shared.error("Portal.waitForTransactionConfirmation() - Error checking receipt: \(error.localizedDescription)")
+      }
+    }
+
+    return .timedOut
   }
 
   public func getRpcUrl(forChainId: String) async -> String? {

--- a/Sources/PortalSwift/Portal.swift
+++ b/Sources/PortalSwift/Portal.swift
@@ -40,6 +40,9 @@ public final class Portal: PortalProtocol {
   /// Access to yield-related functionality.
   public lazy var yield: Yield = .init(api: self.api)
 
+  /// Access to ramps-related (on/off-ramp) functionality.
+  public lazy var ramps: Ramps = .init(api: self.api)
+
   /// Access to trading-related functionality.
   public lazy var trading: Trading = .init(api: self.api)
 

--- a/Sources/PortalSwift/PortalProtocol.swift
+++ b/Sources/PortalSwift/PortalProtocol.swift
@@ -19,6 +19,7 @@ public protocol PortalProtocol {
   var rpcConfig: [String: String] { get set }
   var apiKey: String { get }
   var yield: Yield { get }
+  var ramps: Ramps { get }
   var trading: Trading { get }
   var security: Security { get }
   var delegations: DelegationsProtocol { get }

--- a/Sources/PortalSwift/PortalProtocol.swift
+++ b/Sources/PortalSwift/PortalProtocol.swift
@@ -109,7 +109,7 @@ public protocol PortalProtocol {
   func broadcastBitcoinP2wpkhTransaction(chainId: String, params: BroadcastParam) async throws -> BroadcastBitcoinP2wpkhTransactionResponse
   func getWalletCapabilities() async throws -> WalletCapabilitiesResponse
   func provisionWallet(cipherText: String, method: BackupMethods.RawValue, backupConfigs: BackupConfigs?, completion: @escaping (Result<String>) -> Void, progress: ((MpcStatus) -> Void)?)
-  func rawSign(message: String, chainId: String, signatureApprovalMemo: String?) async throws -> PortalProviderResult
+  func rawSign(message: String, chainId: String, signatureApprovalMemo: String?, traceId: String?) async throws -> PortalProviderResult
   func createPortalConnectInstance(webSocketServer: String) throws -> PortalConnect
   func receiveTestnetAsset(chainId: String, params: FundParams) async throws -> FundResponse
   func sendAsset(chainId: String, params: SendAssetParams) async throws -> SendAssetResponse
@@ -210,7 +210,12 @@ public extension PortalProtocol {
   }
 
   func rawSign(message: String, chainId: String) async throws -> PortalProviderResult {
-    return try await rawSign(message: message, chainId: chainId, signatureApprovalMemo: nil)
+    return try await rawSign(message: message, chainId: chainId, signatureApprovalMemo: nil, traceId: nil)
+  }
+
+  /// Backward-compatible overload preserving the original call shape (without `traceId`).
+  func rawSign(message: String, chainId: String, signatureApprovalMemo: String?) async throws -> PortalProviderResult {
+    return try await rawSign(message: message, chainId: chainId, signatureApprovalMemo: signatureApprovalMemo, traceId: nil)
   }
 
   @available(*, deprecated, message: "Use request(chainId:method:params:options:) instead.")

--- a/Sources/PortalSwift/PortalTypes.swift
+++ b/Sources/PortalSwift/PortalTypes.swift
@@ -38,15 +38,18 @@ public struct FeatureFlags {
   public var isMultiBackupEnabled: Bool?
   public var useEnclaveMPCApi: Bool?
   public var usePresignatures: Bool?
+  public var usePreGeneratedWallet: Bool?
 
   public init(
     isMultiBackupEnabled: Bool? = nil,
     useEnclaveMPCApi: Bool? = nil,
-    usePresignatures: Bool? = nil
+    usePresignatures: Bool? = nil,
+    usePreGeneratedWallet: Bool? = nil
   ) {
     self.isMultiBackupEnabled = isMultiBackupEnabled
     self.useEnclaveMPCApi = useEnclaveMPCApi
     self.usePresignatures = usePresignatures
+    self.usePreGeneratedWallet = usePreGeneratedWallet
   }
 }
 

--- a/Sources/PortalSwift/PortalTypes.swift
+++ b/Sources/PortalSwift/PortalTypes.swift
@@ -176,6 +176,9 @@ public struct SendAssetParams: Codable {
   public let signatureApprovalMemo: String?
   /// sponsorGas: Optional flag to `enable/disable` sponsor the gas,  to be used for the send asset request.
   public var sponsorGas: Bool?
+  /// traceId: Optional trace ID for request tracing. If not provided, a trace ID is generated
+  /// at the start of `sendAsset` and shared across all underlying build/sign/broadcast requests.
+  public var traceId: String?
 
   /// Initializes parameters for sending an asset.
   /// - Parameters:
@@ -184,18 +187,21 @@ public struct SendAssetParams: Codable {
   ///   - token: The token to send (use "NATIVE" for chain's native token)
   ///   - signatureApprovalMemo: Optional signature approval memo to use for the request.
   ///   - sponsorGas: Optional flag to `enable/disable` sponsor the gas, to be used for the send asset request.
+  ///   - traceId: Optional trace ID for request tracing. If not provided, one is generated automatically.
   public init(
     to: String,
     amount: String,
     token: String,
     signatureApprovalMemo: String? = nil,
-    sponsorGas: Bool? = nil
+    sponsorGas: Bool? = nil,
+    traceId: String? = nil
   ) {
     self.to = to
     self.amount = amount
     self.token = token
     self.signatureApprovalMemo = signatureApprovalMemo
     self.sponsorGas = sponsorGas
+    self.traceId = traceId
   }
 }
 

--- a/Sources/PortalSwift/Provider/MpcSigner/PortalMpcSigner.swift
+++ b/Sources/PortalSwift/Provider/MpcSigner/PortalMpcSigner.swift
@@ -49,7 +49,8 @@ public class PortalMpcSigner: PortalSignerProtocol {
     andRpcUrl: String,
     usingBlockchain: PortalBlockchain,
     signatureApprovalMemo: String? = nil,
-    sponsorGas: Bool? = nil
+    sponsorGas: Bool? = nil,
+    reqId: String? = nil
   ) async throws -> String {
     var mpcMetadata = self.mpcMetadata
     mpcMetadata.curve = usingBlockchain.curve
@@ -57,6 +58,7 @@ public class PortalMpcSigner: PortalSignerProtocol {
     mpcMetadata.isRaw = withPayload.isRaw
     mpcMetadata.signatureApprovalMemo = signatureApprovalMemo
     mpcMetadata.sponsorGas = sponsorGas
+    mpcMetadata.reqId = reqId
 
     if featureFlags?.usePresignatures == true,
        let presignature = await presignatureSource?.consumePresignature(forCurve: usingBlockchain.curve)

--- a/Sources/PortalSwift/Provider/MpcSigner/PortalMpcSignerTypes.swift
+++ b/Sources/PortalSwift/Provider/MpcSigner/PortalMpcSignerTypes.swift
@@ -29,6 +29,7 @@ public protocol PortalSignerProtocol {
     andRpcUrl: String,
     usingBlockchain: PortalBlockchain,
     signatureApprovalMemo: String?,
-    sponsorGas: Bool?
+    sponsorGas: Bool?,
+    reqId: String?
   ) async throws -> String
 }

--- a/Sources/PortalSwift/Provider/PortalProvider.swift
+++ b/Sources/PortalSwift/Provider/PortalProvider.swift
@@ -236,6 +236,9 @@ public class PortalProvider: PortalProviderProtocol {
     }
 
     let id = UUID().uuidString
+    // A single trace ID is shared across the request. If the caller provided one
+    // via options, reuse it; otherwise generate a fresh one for this request.
+    let traceId = options?.traceId ?? generateTraceId()
 
     // This switch is here to handle methods that should be
     // resolved by the provider directly before passing the
@@ -251,14 +254,14 @@ public class PortalProvider: PortalProviderProtocol {
     case .wallet_switchEthereumChain, .wallet_revokePermissions, .wallet_requestPermissions:
       return PortalProviderResult(id: id, result: "null")
     case .wallet_getCapabilities:
-      let walletCapabilities = try await self.api?.getWalletCapabilities()
+      let walletCapabilities = try await self.api?.getWalletCapabilities(traceId: traceId)
       return PortalProviderResult(id: id, result: walletCapabilities ?? "null")
     default:
       if blockchain.shouldMethodBeSigned(method) {
         let payload = PortalProviderRequestWithId(id: id, method: method, params: params, chainId: chainId)
-        return try await self.handleSignRequest(chainId, withPayload: payload, forId: id, onBlockchain: blockchain, connect: connect, options: options)
+        return try await self.handleSignRequest(chainId, withPayload: payload, forId: id, onBlockchain: blockchain, connect: connect, options: options, traceId: traceId)
       } else {
-        return try await self.handleRpcRequest(chainId, withMethod: method, andParams: params, forId: id)
+        return try await self.handleRpcRequest(chainId, withMethod: method, andParams: params, forId: id, traceId: traceId)
       }
     }
   }
@@ -395,7 +398,8 @@ public class PortalProvider: PortalProviderProtocol {
     _ chainId: String,
     withMethod: PortalRequestMethod,
     andParams: [AnyCodable]?,
-    forId: String
+    forId: String,
+    traceId: String? = nil
   ) async throws -> PortalProviderResult {
     let rpcUrl = try getRpcUrl(chainId)
 
@@ -410,7 +414,8 @@ public class PortalProvider: PortalProviderProtocol {
         url: url,
         method: .post,
         payload: payload,
-        bearerToken: rpcUrl.starts(with: "https://api.portalhq.") ? self.apiKey : nil
+        bearerToken: rpcUrl.starts(with: "https://api.portalhq.") ? self.apiKey : nil,
+        traceId: traceId
       )
 
       switch withMethod {
@@ -482,7 +487,8 @@ public class PortalProvider: PortalProviderProtocol {
     forId _: String,
     onBlockchain: PortalBlockchain,
     connect: PortalConnect? = nil,
-    options: RequestOptions? = nil
+    options: RequestOptions? = nil,
+    traceId: String? = nil
   ) async throws -> PortalProviderResult {
     guard try await self.getApproval(onChainId, forPayload: withPayload, connect: connect) else {
       throw ProviderSigningError.userDeclinedApproval
@@ -498,7 +504,8 @@ public class PortalProvider: PortalProviderProtocol {
       andRpcUrl: rpcUrl,
       usingBlockchain: onBlockchain,
       signatureApprovalMemo: options?.signatureApprovalMemo,
-      sponsorGas: options?.sponsorGas
+      sponsorGas: options?.sponsorGas,
+      reqId: traceId ?? options?.traceId
     )
 
     return PortalProviderResult(id: withPayload.id, result: signature)

--- a/Sources/PortalSwift/Provider/Types/RequestOptions.swift
+++ b/Sources/PortalSwift/Provider/Types/RequestOptions.swift
@@ -12,11 +12,17 @@ public struct RequestOptions: Codable {
   /// sponsorGas: Optional flag to `enable/disable` sponsor the gas,  to be used for the request.
   public var sponsorGas: Bool? = nil
 
+  /// traceId: Optional trace ID for request correlation. Forwarded as the `X-Portal-Trace-Id`
+  /// header on RPC requests and mapped to the MPC signing metadata `reqId`.
+  public var traceId: String? = nil
+
   public init(
     signatureApprovalMemo: String? = nil,
-    sponsorGas: Bool? = nil
+    sponsorGas: Bool? = nil,
+    traceId: String? = nil
   ) {
     self.signatureApprovalMemo = signatureApprovalMemo
     self.sponsorGas = sponsorGas
+    self.traceId = traceId
   }
 }

--- a/Sources/PortalSwift/Ramps/Noah/Noah.swift
+++ b/Sources/PortalSwift/Ramps/Noah/Noah.swift
@@ -1,0 +1,121 @@
+//
+//  Noah.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+
+/// Protocol defining the Noah on/off-ramp provider surface.
+public protocol NoahProtocol {
+  /// Start a Noah KYC session for the current customer.
+  /// - Parameter request: KYC request payload (return URL, fiat options, etc.).
+  /// - Returns: `NoahInitiateKycResponse` containing the hosted KYC URL.
+  /// - Throws: An error if the operation fails.
+  func initiateKyc(request: NoahInitiateKycRequest) async throws -> NoahInitiateKycResponse
+
+  /// Initiate a Noah payin (on-ramp) and receive bank deposit instructions.
+  /// - Parameter request: Payin request payload.
+  /// - Returns: `NoahInitiatePayinResponse` containing the payin id and bank details.
+  /// - Throws: An error if the operation fails.
+  func initiatePayin(request: NoahInitiatePayinRequest) async throws -> NoahInitiatePayinResponse
+
+  /// Simulate a Noah payin (sandbox-only fiat deposit).
+  /// - Parameter request: Simulate payin request payload.
+  /// - Returns: `NoahSimulatePayinResponse` containing the simulated fiat deposit id.
+  /// - Throws: An error if the operation fails.
+  func simulatePayin(request: NoahSimulatePayinRequest) async throws -> NoahSimulatePayinResponse
+
+  /// List stored Noah payment methods for the current customer.
+  /// - Parameter request: Pagination / capability filter. Use the no-argument
+  ///   overload to call with default request values.
+  /// - Returns: `NoahGetPaymentMethodsResponse` with the stored payment methods.
+  /// - Throws: An error if the operation fails.
+  func getPaymentMethods(request: NoahGetPaymentMethodsRequest) async throws -> NoahGetPaymentMethodsResponse
+
+  /// List the countries and fiat currencies supported for Noah payouts.
+  /// - Returns: `NoahGetPayoutCountriesResponse` keyed by country code.
+  /// - Throws: An error if the operation fails.
+  func getPayoutCountries() async throws -> NoahGetPayoutCountriesResponse
+
+  /// List Noah payout channels matching the supplied filters.
+  /// - Parameter request: Payout channels filter request.
+  /// - Returns: `NoahGetPayoutChannelsResponse` containing matching channels.
+  /// - Throws: An error if the operation fails.
+  func getPayoutChannels(request: NoahGetPayoutChannelsRequest) async throws -> NoahGetPayoutChannelsResponse
+
+  /// Fetch the dynamic form schema for the given Noah payout channel.
+  /// - Parameter channelId: The Noah channel identifier (will be percent-encoded).
+  /// - Returns: `NoahGetPayoutChannelFormResponse` containing the form schema and metadata.
+  /// - Throws: An error if the operation fails.
+  func getPayoutChannelForm(channelId: String) async throws -> NoahGetPayoutChannelFormResponse
+
+  /// Request a Noah payout quote for the given channel and form responses.
+  /// - Parameter request: Payout quote request payload.
+  /// - Returns: `NoahGetPayoutQuoteResponse` containing the quote and any next step.
+  /// - Throws: An error if the operation fails.
+  func getPayoutQuote(request: NoahGetPayoutQuoteRequest) async throws -> NoahGetPayoutQuoteResponse
+
+  /// Initiate a Noah payout from a previously quoted payout.
+  /// - Parameter request: Initiate payout request payload (includes trigger conditions).
+  /// - Returns: `NoahInitiatePayoutResponse` containing the destination address and conditions.
+  /// - Throws: An error if the operation fails.
+  func initiatePayout(request: NoahInitiatePayoutRequest) async throws -> NoahInitiatePayoutResponse
+}
+
+public extension NoahProtocol {
+  /// Convenience overload for `getPaymentMethods` using default request values.
+  func getPaymentMethods() async throws -> NoahGetPaymentMethodsResponse {
+    try await getPaymentMethods(request: NoahGetPaymentMethodsRequest())
+  }
+}
+
+/// Noah on/off-ramp provider implementation.
+///
+/// Thin domain wrapper that forwards calls to a `PortalNoahApiProtocol`.
+public class Noah: NoahProtocol {
+  private let api: PortalNoahApiProtocol
+
+  /// Create an instance of `Noah`.
+  /// - Parameter api: The `PortalNoahApi` instance to use for Noah operations.
+  public init(api: PortalNoahApiProtocol) {
+    self.api = api
+  }
+
+  public func initiateKyc(request: NoahInitiateKycRequest) async throws -> NoahInitiateKycResponse {
+    return try await api.initiateKyc(request: request)
+  }
+
+  public func initiatePayin(request: NoahInitiatePayinRequest) async throws -> NoahInitiatePayinResponse {
+    return try await api.initiatePayin(request: request)
+  }
+
+  public func simulatePayin(request: NoahSimulatePayinRequest) async throws -> NoahSimulatePayinResponse {
+    return try await api.simulatePayin(request: request)
+  }
+
+  public func getPaymentMethods(request: NoahGetPaymentMethodsRequest) async throws -> NoahGetPaymentMethodsResponse {
+    return try await api.getPaymentMethods(request: request)
+  }
+
+  public func getPayoutCountries() async throws -> NoahGetPayoutCountriesResponse {
+    return try await api.getPayoutCountries()
+  }
+
+  public func getPayoutChannels(request: NoahGetPayoutChannelsRequest) async throws -> NoahGetPayoutChannelsResponse {
+    return try await api.getPayoutChannels(request: request)
+  }
+
+  public func getPayoutChannelForm(channelId: String) async throws -> NoahGetPayoutChannelFormResponse {
+    return try await api.getPayoutChannelForm(channelId: channelId)
+  }
+
+  public func getPayoutQuote(request: NoahGetPayoutQuoteRequest) async throws -> NoahGetPayoutQuoteResponse {
+    return try await api.getPayoutQuote(request: request)
+  }
+
+  public func initiatePayout(request: NoahInitiatePayoutRequest) async throws -> NoahInitiatePayoutResponse {
+    return try await api.initiatePayout(request: request)
+  }
+}

--- a/Sources/PortalSwift/Ramps/Ramps.swift
+++ b/Sources/PortalSwift/Ramps/Ramps.swift
@@ -1,0 +1,24 @@
+//
+//  Ramps.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+
+/// The main entry point for ramps-related (on/off-ramp) functionality in the Portal SDK.
+///
+/// This class provides access to various on/off-ramp providers and their capabilities.
+/// Currently supports Noah as the primary ramps provider.
+public class Ramps {
+  /// Access to the Noah on/off-ramp provider functionality.
+  /// This property can be set for custom implementations.
+  public var noah: NoahProtocol
+
+  /// Create an instance of `Ramps`.
+  /// - Parameter api: The Portal API instance to use for ramps operations.
+  init(api: PortalApiProtocol) {
+    self.noah = Noah(api: api.noah)
+  }
+}

--- a/Sources/PortalSwift/Trading/Lifi.swift
+++ b/Sources/PortalSwift/Trading/Lifi.swift
@@ -13,16 +13,74 @@ public protocol LifiProtocol {
   func getQuote(request: LifiQuoteRequest) async throws -> LifiQuoteResponse
   func getStatus(request: LifiStatusRequest) async throws -> LifiStatusResponse
   func getRouteStep(request: LifiStepTransactionRequest) async throws -> LifiStepTransactionResponse
+  func tradeAsset(params: LifiTradeAssetParams) async throws -> LifiTradeAssetResult
+  func pollStatus(
+    request: LifiStatusRequest,
+    onUpdate: ((LifiStatusRawResponse) -> Bool)?,
+    options: LifiPollStatusOptions
+  ) async throws -> LifiStatusRawResponse
+}
+
+public extension LifiProtocol {
+  /// Convenience overload that polls with default options and no update callback.
+  func pollStatus(request: LifiStatusRequest) async throws -> LifiStatusRawResponse {
+    return try await pollStatus(request: request, onUpdate: nil, options: LifiPollStatusOptions())
+  }
+
+  /// Convenience overload that polls with custom options and no update callback.
+  func pollStatus(request: LifiStatusRequest, options: LifiPollStatusOptions) async throws -> LifiStatusRawResponse {
+    return try await pollStatus(request: request, onUpdate: nil, options: options)
+  }
+
+  /// Convenience overload that polls with an update callback and default options.
+  func pollStatus(
+    request: LifiStatusRequest,
+    onUpdate: @escaping (LifiStatusRawResponse) -> Bool
+  ) async throws -> LifiStatusRawResponse {
+    return try await pollStatus(request: request, onUpdate: onUpdate, options: LifiPollStatusOptions())
+  }
 }
 
 /// Lifi provider implementation for trading functionality.
 public class Lifi: LifiProtocol {
+  /// The smallest interval, in milliseconds, allowed between status polls (guards against busy-waiting).
+  private static let minPollIntervalMs = 100
+
+  /// The largest millisecond value that can be converted to nanoseconds without overflowing `UInt64`.
+  private static let maxSleepMs = Int(UInt64.max / 1_000_000)
+
+  /// The largest integer a `Double` can represent exactly (2^53); beyond this, integer values can
+  /// be silently rounded, so a numeric `value` above it must be provided as a string instead.
+  private static let maxSafeIntegerDouble = Double(9_007_199_254_740_992)
+
+  /// Converts a millisecond duration into nanoseconds for `Task.sleep`, clamping to a non-negative
+  /// value that can't overflow `UInt64` when multiplied by 1_000_000.
+  private static func sleepNanoseconds(fromMs ms: Int) -> UInt64 {
+    return UInt64(min(max(0, ms), maxSleepMs)) * 1_000_000
+  }
+
   private let api: PortalLifiTradingApiProtocol
+  private let signAndSendTransaction: LifiSignAndSendTransaction?
+  private let waitForConfirmation: LifiWaitForConfirmation?
+  private let stepPollOptions: LifiPollStatusOptions
+  private let logger = PortalLogger.shared
 
   /// Create an instance of Lifi.
-  /// - Parameter api: The PortalLifiTradingApi instance to use for trading operations.
-  public init(api: PortalLifiTradingApiProtocol) {
+  /// - Parameters:
+  ///   - api: The PortalLifiTradingApi instance to use for trading operations.
+  ///   - signAndSendTransaction: Closure that signs and submits an EVM transaction (injected by Portal).
+  ///   - waitForConfirmation: Closure that waits for on-chain confirmation (injected by Portal).
+  ///   - stepPollOptions: Polling configuration used per-step while executing `tradeAsset`.
+  public init(
+    api: PortalLifiTradingApiProtocol,
+    signAndSendTransaction: LifiSignAndSendTransaction? = nil,
+    waitForConfirmation: LifiWaitForConfirmation? = nil,
+    stepPollOptions: LifiPollStatusOptions = LifiPollStatusOptions(everyMs: 10_000, initialDelayMs: 0, timeoutMs: 600_000)
+  ) {
     self.api = api
+    self.signAndSendTransaction = signAndSendTransaction
+    self.waitForConfirmation = waitForConfirmation
+    self.stepPollOptions = stepPollOptions
   }
 
   /// Retrieves routes from the Lifi integration.
@@ -43,5 +101,331 @@ public class Lifi: LifiProtocol {
   /// Retrieves an unsigned transaction from the Lifi integration that has yet to be signed/submitted.
   public func getRouteStep(request: LifiStepTransactionRequest) async throws -> LifiStepTransactionResponse {
     return try await api.getRouteStep(request: request)
+  }
+
+  /// High-level bridging method that fetches routes, executes each step sequentially
+  /// (sign, confirm on-chain, poll LiFi status until terminal), and returns the resulting
+  /// transaction hashes, executed steps, and the selected route.
+  /// - Parameter params: The parameters describing the desired trade.
+  /// - Returns: A `LifiTradeAssetResult` containing the executed transaction hashes, steps, and route.
+  public func tradeAsset(params: LifiTradeAssetParams) async throws -> LifiTradeAssetResult {
+    let report: (LifiTradeAssetProgressStatus, LifiTradeAssetProgressData) -> Void = { status, data in
+      params.onProgress?(status, data)
+    }
+
+    do {
+      return try await executeTradeAsset(params: params, report: report)
+    } catch is CancellationError {
+      // A cancelled trade is not a failure; propagate without reporting `.failed`.
+      throw CancellationError()
+    } catch {
+      let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+      report(.failed, LifiTradeAssetProgressData(errorMessage: message))
+      throw error
+    }
+  }
+
+  /// Polls the LiFi status for a transfer until it reaches DONE (or `onUpdate` returns `false`).
+  /// - Parameters:
+  ///   - request: The status request describing which transfer to poll.
+  ///   - onUpdate: Optional callback invoked on each non-terminal status. Return `false` to stop polling.
+  ///   - options: Polling configuration (interval, initial delay, timeout).
+  /// - Returns: The `LifiStatusRawResponse` for a DONE transfer, or the most recent non-terminal
+  ///   status if `onUpdate` returned `false` to stop polling early.
+  /// - Throws: `LifiTradeAssetError.lifiTransferFailed` if the transfer reaches a FAILED terminal
+  ///   state, or `LifiTradeAssetError.pollTimeout` if the timeout elapses first.
+  public func pollStatus(
+    request: LifiStatusRequest,
+    onUpdate: ((LifiStatusRawResponse) -> Bool)?,
+    options: LifiPollStatusOptions
+  ) async throws -> LifiStatusRawResponse {
+    return try await pollStatusUntilTerminal(request: request, options: options, onUpdate: onUpdate)
+  }
+
+  /*******************************************
+   * Private functions
+   *******************************************/
+
+  private func executeTradeAsset(
+    params: LifiTradeAssetParams,
+    report: @escaping (LifiTradeAssetProgressStatus, LifiTradeAssetProgressData) -> Void
+  ) async throws -> LifiTradeAssetResult {
+    guard let signAndSend = signAndSendTransaction else {
+      throw LifiTradeAssetError.missingSigner
+    }
+    guard let waitForConfirmation = waitForConfirmation else {
+      throw LifiTradeAssetError.missingConfirmation
+    }
+
+    report(.fetchingRoutes, LifiTradeAssetProgressData())
+
+    let routesRequest = LifiRoutesRequest(
+      fromChainId: params.fromChain,
+      fromAmount: params.amount,
+      fromTokenAddress: params.fromToken,
+      toChainId: params.toChain,
+      toTokenAddress: params.toToken,
+      fromAddress: params.fromAddress,
+      // Honor the documented behavior: when no recipient is provided, fall back to the sender.
+      toAddress: params.toAddress ?? params.fromAddress
+    )
+
+    let routesResponse = try await api.getRoutes(request: routesRequest)
+    guard let routes = routesResponse.data?.rawResponse.routes, !routes.isEmpty else {
+      throw LifiTradeAssetError.noRoutesFound
+    }
+
+    let routeIndex = params.routeIndex ?? 0
+    guard routeIndex >= 0, routeIndex < routes.count else {
+      throw LifiTradeAssetError.routeIndexOutOfBounds
+    }
+
+    let route = routes[routeIndex]
+    guard !route.steps.isEmpty else {
+      throw LifiTradeAssetError.routeHasNoSteps
+    }
+
+    let totalSteps = route.steps.count
+    report(.routeSelected, LifiTradeAssetProgressData(routeIndex: routeIndex, totalSteps: totalSteps, route: route))
+
+    var hashes: [String] = []
+    var executedSteps: [LifiStep] = []
+
+    for (stepIndex, step) in route.steps.enumerated() {
+      report(.preparingStep, LifiTradeAssetProgressData(routeIndex: routeIndex, stepIndex: stepIndex, totalSteps: totalSteps, route: route, step: step))
+
+      let stepResponse = try await api.getRouteStep(request: step)
+      guard let rawStep = stepResponse.data?.rawResponse else {
+        throw LifiTradeAssetError.missingTransactionRequest
+      }
+      executedSteps.append(rawStep)
+
+      guard let transactionRequest = rawStep.transactionRequest else {
+        // No transaction request at all on the step.
+        throw LifiTradeAssetError.missingTransactionRequest
+      }
+      guard let txParams = transactionRequest.value as? [String: Any] else {
+        // Present, but not the expected object shape — malformed rather than missing.
+        throw LifiTradeAssetError.invalidTransactionRequest
+      }
+
+      let ethTransaction = try parseLifiTransactionRequest(txParams)
+      let network = resolveStepNetworkCaip2(step: rawStep, txParams: txParams)
+
+      report(.signing, LifiTradeAssetProgressData(routeIndex: routeIndex, stepIndex: stepIndex, totalSteps: totalSteps, route: route, step: rawStep))
+
+      let txHash = try await signAndSend(ethTransaction, network)
+      hashes.append(txHash)
+
+      report(.submitted, LifiTradeAssetProgressData(routeIndex: routeIndex, stepIndex: stepIndex, totalSteps: totalSteps, route: route, step: rawStep, txHash: txHash))
+      report(.confirming, LifiTradeAssetProgressData(routeIndex: routeIndex, stepIndex: stepIndex, totalSteps: totalSteps, route: route, step: rawStep, txHash: txHash))
+
+      let confirmation = try await waitForConfirmation(txHash, network)
+      switch confirmation {
+      case .confirmed:
+        break
+      case .reverted:
+        throw LifiTradeAssetError.transactionConfirmationFailed(txHash)
+      case .timedOut:
+        throw LifiTradeAssetError.transactionConfirmationTimedOut(txHash)
+      }
+
+      report(.lifiPending, LifiTradeAssetProgressData(routeIndex: routeIndex, stepIndex: stepIndex, totalSteps: totalSteps, route: route, step: rawStep, txHash: txHash))
+
+      let statusRequest = LifiStatusRequest(
+        txHash: txHash,
+        bridge: statusBridgeFromTool(rawStep.tool),
+        fromChain: rawStep.action.fromChainId,
+        toChain: rawStep.action.toChainId
+      )
+
+      let terminal = try await pollStatusUntilTerminal(
+        request: statusRequest,
+        options: stepPollOptions,
+        onUpdate: { raw in
+          report(.lifiPending, LifiTradeAssetProgressData(routeIndex: routeIndex, stepIndex: stepIndex, totalSteps: totalSteps, route: route, step: rawStep, txHash: txHash, lifiStatus: raw))
+          return true
+        }
+      )
+
+      report(.stepDone, LifiTradeAssetProgressData(routeIndex: routeIndex, stepIndex: stepIndex, totalSteps: totalSteps, route: route, step: rawStep, txHash: txHash, lifiStatus: terminal))
+    }
+
+    report(.complete, LifiTradeAssetProgressData(routeIndex: routeIndex, totalSteps: totalSteps, route: route))
+
+    return LifiTradeAssetResult(hashes: hashes, steps: executedSteps, route: route)
+  }
+
+  private func pollStatusUntilTerminal(
+    request: LifiStatusRequest,
+    options: LifiPollStatusOptions,
+    onUpdate: ((LifiStatusRawResponse) -> Bool)?
+  ) async throws -> LifiStatusRawResponse {
+    let startTime = Date()
+
+    // Clamp interval/delay/timeout so the UInt64 conversions below can't trap on negatives, a
+    // zero/negative `everyMs` can't turn the loop into a busy-wait, and a negative `timeoutMs`
+    // can't force an instant timeout.
+    let initialDelayMs = max(0, options.initialDelayMs)
+    let pollIntervalMs = max(Self.minPollIntervalMs, options.everyMs)
+    let timeoutMs = max(0, options.timeoutMs)
+
+    if initialDelayMs > 0 {
+      // Use `try` (not `try?`) so task cancellation propagates during the initial delay.
+      try await Task.sleep(nanoseconds: Self.sleepNanoseconds(fromMs: initialDelayMs))
+    }
+
+    while true {
+      try Task.checkCancellation()
+
+      let elapsedMs = Int(Date().timeIntervalSince(startTime) * 1000.0)
+      if elapsedMs >= timeoutMs {
+        throw LifiTradeAssetError.pollTimeout
+      }
+
+      do {
+        let response = try await api.getStatus(request: request)
+        if let raw = response.data?.rawResponse {
+          switch raw.status {
+          case .done:
+            return raw
+          case .failed:
+            let detail = raw.substatusMessage ?? raw.substatus?.rawValue ?? "LiFi transfer FAILED"
+            throw LifiTradeAssetError.lifiTransferFailed(detail)
+          default:
+            if let onUpdate = onUpdate {
+              let carryOn = onUpdate(raw)
+              if !carryOn {
+                return raw
+              }
+            }
+          }
+        } else {
+          // No status payload — log the API-level error (if any) so a persistent failure isn't
+          // surfaced as an opaque pollTimeout with no diagnostic signal, then keep polling.
+          logger.warn("Lifi.pollStatus() - getStatus returned no data, will retry: \(response.error ?? "unknown error")")
+        }
+      } catch let error as LifiTradeAssetError {
+        // Terminal/programmer errors should propagate; transient network errors are retried below.
+        throw error
+      } catch is CancellationError {
+        // Cancellation must stop polling immediately rather than being treated as transient.
+        throw CancellationError()
+      } catch {
+        logger.warn("Lifi.pollStatus() - transient error, will retry: \(error.localizedDescription)")
+      }
+
+      // Sleep until the next poll, but never past the remaining timeout so the overall deadline
+      // is honored (rather than overshooting by up to one interval). Recompute elapsed AFTER the
+      // status call so time spent awaiting the network is counted. Use `try` (not `try?`) so task
+      // cancellation propagates between polls.
+      let elapsedAfterStatusMs = Int(Date().timeIntervalSince(startTime) * 1000.0)
+      let remainingMs = max(0, timeoutMs - elapsedAfterStatusMs)
+      try await Task.sleep(nanoseconds: Self.sleepNanoseconds(fromMs: min(pollIntervalMs, remainingMs)))
+    }
+  }
+
+  /// Parses a LiFi step's `transactionRequest` dictionary into an `ETHTransactionParam`.
+  private func parseLifiTransactionRequest(_ txParams: [String: Any]) throws -> ETHTransactionParam {
+    guard let from = txParams["from"] as? String,
+          let to = txParams["to"] as? String
+    else {
+      throw LifiTradeAssetError.invalidTransactionRequest
+    }
+
+    // Default to no value when the key is absent (native no-value txs). When it IS present, fail
+    // fast on anything invalid rather than silently signing "0x0" (a wrong amount).
+    var value = "0x0"
+    if let rawValue = txParams["value"] {
+      if let valueString = rawValue as? String {
+        value = valueString
+      } else if let valueInt = rawValue as? Int {
+        guard valueInt >= 0 else {
+          throw LifiTradeAssetError.invalidTransactionRequest
+        }
+        // Use %llx (64-bit) so large wei amounts are not truncated like %x (32-bit) would.
+        value = String(format: "0x%llx", UInt64(valueInt))
+      } else if let valueDouble = rawValue as? Double {
+        // Some decoders surface JSON numbers as Double. EVM `value` is an integer wei amount, so
+        // reject fractional values and anything outside the IEEE-754 safe-integer range (±2^53) —
+        // beyond that a Double can't represent every integer, so converting could silently sign a
+        // different amount. Such values must be provided as a string instead.
+        guard valueDouble >= 0,
+              valueDouble <= Self.maxSafeIntegerDouble,
+              valueDouble.rounded(.towardZero) == valueDouble
+        else {
+          throw LifiTradeAssetError.invalidTransactionRequest
+        }
+        value = String(format: "0x%llx", UInt64(valueDouble))
+      } else {
+        // Present but an unexpected type — malformed, don't silently fall back to "0x0".
+        throw LifiTradeAssetError.invalidTransactionRequest
+      }
+    }
+
+    let data = txParams["data"] as? String ?? "0x"
+
+    var ethTransaction = ETHTransactionParam(from: from, to: to, value: value, data: data)
+
+    // Map gasLimit -> gas; leave nonce nil so multi-step trades get a fresh nonce per step.
+    if let gasLimit = txParams["gasLimit"] as? String {
+      ethTransaction.gas = gasLimit
+    } else if let gas = txParams["gas"] as? String {
+      ethTransaction.gas = gas
+    }
+    if let gasPrice = txParams["gasPrice"] as? String {
+      ethTransaction.gasPrice = gasPrice
+    }
+    if let maxFeePerGas = txParams["maxFeePerGas"] as? String {
+      ethTransaction.maxFeePerGas = maxFeePerGas
+    }
+    if let maxPriorityFeePerGas = txParams["maxPriorityFeePerGas"] as? String {
+      ethTransaction.maxPriorityFeePerGas = maxPriorityFeePerGas
+    }
+
+    return ethTransaction
+  }
+
+  /// Resolves the CAIP-2 network identifier for a step, preferring the transaction request's
+  /// chainId and falling back to the step's action.fromChainId.
+  private func resolveStepNetworkCaip2(step: LifiStep, txParams: [String: Any]?) -> String {
+    var raw: String?
+    if let chainIdValue = txParams?["chainId"] {
+      if let intValue = chainIdValue as? Int, intValue > 0 {
+        raw = String(intValue)
+      } else if let stringValue = chainIdValue as? String {
+        raw = stringValue
+      } else if let doubleValue = chainIdValue as? Double, let intValue = Int(exactly: doubleValue), intValue > 0 {
+        // `Int(exactly:)` yields nil for non-integral or out-of-range values (including 2^63);
+        // non-positive chain ids are rejected too. Anything invalid falls back to the step's chain.
+        raw = String(intValue)
+      }
+    }
+    if raw == nil {
+      raw = step.action.fromChainId
+    }
+    return normalizeToCaip2(raw ?? "")
+  }
+
+  /// Normalizes a chain identifier into CAIP-2 form (e.g. "8453" -> "eip155:8453").
+  /// Only a positive integer (hex or decimal) is mapped to `eip155:<n>`; already-namespaced values
+  /// pass through, and anything unrecognized is returned unchanged rather than emitting a malformed
+  /// identifier like `eip155:-1`, `eip155:0x...`, or `eip155:`.
+  private func normalizeToCaip2(_ value: String) -> String {
+    if value.hasPrefix("eip155:") || value.hasPrefix("solana:") {
+      return value
+    }
+    if value.hasPrefix("0x"), let intValue = Int(value.dropFirst(2), radix: 16), intValue > 0 {
+      return "eip155:\(intValue)"
+    }
+    if let intValue = Int(value), intValue > 0 {
+      return "eip155:\(intValue)"
+    }
+    return value
+  }
+
+  /// Maps a LiFi tool string to a `LifiStatusBridge`, if it corresponds to a known bridge.
+  private func statusBridgeFromTool(_ tool: String) -> LifiStatusBridge? {
+    return LifiStatusBridge(rawValue: tool)
   }
 }

--- a/Sources/PortalSwift/Trading/Trading.swift
+++ b/Sources/PortalSwift/Trading/Trading.swift
@@ -19,9 +19,22 @@ public class Trading {
   public var zeroX: ZeroXProtocol
 
   /// Create an instance of Trading.
-  /// - Parameter api: The Portal API instance to use for trading operations.
-  init(api: PortalApiProtocol) {
-    self.lifi = Lifi(api: api.lifi)
+  /// - Parameters:
+  ///   - api: The Portal API instance to use for trading operations.
+  ///   - signAndSendTransaction: Closure that signs and submits an EVM transaction (injected by Portal),
+  ///     enabling the high-level `lifi.tradeAsset` bridging method.
+  ///   - waitForConfirmation: Closure that waits for on-chain confirmation (injected by Portal),
+  ///     enabling the high-level `lifi.tradeAsset` bridging method.
+  init(
+    api: PortalApiProtocol,
+    signAndSendTransaction: LifiSignAndSendTransaction? = nil,
+    waitForConfirmation: LifiWaitForConfirmation? = nil
+  ) {
+    self.lifi = Lifi(
+      api: api.lifi,
+      signAndSendTransaction: signAndSendTransaction,
+      waitForConfirmation: waitForConfirmation
+    )
     self.zeroX = ZeroX(api: api.zeroX)
   }
 }

--- a/Sources/PortalSwift/Utils/HttpRequest.swift
+++ b/Sources/PortalSwift/Utils/HttpRequest.swift
@@ -184,6 +184,11 @@ public class HttpRequest<T: Codable, BodyType> {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
       }
 
+      // Guarantee a trace ID header for the legacy HTTP path.
+      if self.headers[PORTAL_TRACE_ID_HEADER] == nil {
+        request.setValue(generateTraceId(), forHTTPHeaderField: PORTAL_TRACE_ID_HEADER)
+      }
+
       // Set the request body to the string literal of the Dictionary
       if self.headers["Content-Type"] != nil && (self.headers["Content-Type"]!).contains("multipart") {
         let rawBody = (body as! [String: Any])["rawBody"] as! String

--- a/Sources/PortalSwift/Utils/PortalAPIRequest.swift
+++ b/Sources/PortalSwift/Utils/PortalAPIRequest.swift
@@ -37,7 +37,8 @@ public class PortalAPIRequest: PortalBaseRequestProtocol {
     url: URL,
     method: HttpMethod = .get,
     payload: (any Codable)? = nil,
-    bearerToken: String? = nil
+    bearerToken: String? = nil,
+    traceId: String? = nil
   ) {
     self.url = url
     self.method = method
@@ -45,7 +46,8 @@ public class PortalAPIRequest: PortalBaseRequestProtocol {
 
     var defaultHeaders = [
       "Accept": "application/json",
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
+      PORTAL_TRACE_ID_HEADER: traceId ?? generateTraceId()
     ]
     if let bearerToken = bearerToken {
       defaultHeaders["Authorization"] = "Bearer \(bearerToken)"

--- a/Sources/PortalSwift/Utils/PortalRequests.swift
+++ b/Sources/PortalSwift/Utils/PortalRequests.swift
@@ -160,7 +160,7 @@ public class PortalRequests: PortalRequestsProtocol {
 
   // MARK: - Private Methods
 
-  private func createBaseRequest(url: URL, method: HttpMethod, bearerToken: String?) throws -> URLRequest {
+  private func createBaseRequest(url: URL, method: HttpMethod, bearerToken: String?, traceId: String? = nil) throws -> URLRequest {
     var request = URLRequest(url: url)
     request.httpMethod = method.rawValue
 
@@ -170,6 +170,7 @@ public class PortalRequests: PortalRequestsProtocol {
 
     request.addValue("application/json", forHTTPHeaderField: "Accept")
     request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.addValue(traceId ?? generateTraceId(), forHTTPHeaderField: PORTAL_TRACE_ID_HEADER)
 
     return request
   }
@@ -180,6 +181,11 @@ public class PortalRequests: PortalRequestsProtocol {
 
     for (key, value) in portalRequest.headers {
       request.addValue(value, forHTTPHeaderField: key)
+    }
+
+    // Guarantee a trace ID header even if a custom request omitted it.
+    if portalRequest.headers[PORTAL_TRACE_ID_HEADER] == nil {
+      request.addValue(generateTraceId(), forHTTPHeaderField: PORTAL_TRACE_ID_HEADER)
     }
 
     if let payload = portalRequest.payload {

--- a/Sources/PortalSwift/Utils/PortalTracing.swift
+++ b/Sources/PortalSwift/Utils/PortalTracing.swift
@@ -1,0 +1,17 @@
+//
+//  PortalTracing.swift
+//  PortalSwift
+//
+//  Utilities for request tracing via the `X-Portal-Trace-Id` header.
+//
+
+import Foundation
+
+/// The trace ID header used by connect-api (client + custodian APIs).
+public let PORTAL_TRACE_ID_HEADER = "X-Portal-Trace-Id"
+
+/// Generates a UUID v4 trace ID for request correlation.
+/// The value is lowercased to stay consistent with the other Portal SDKs.
+public func generateTraceId() -> String {
+  UUID().uuidString.lowercased()
+}

--- a/Sources/PortalSwift/Yield/Yield.swift
+++ b/Sources/PortalSwift/Yield/Yield.swift
@@ -17,8 +17,19 @@ public class Yield {
   public var yieldxyz: YieldXyzProtocol
 
   /// Create an instance of Yield.
-  /// - Parameter api: The Portal API instance to use for yield operations.
-  init(api: PortalApiProtocol) {
-    self.yieldxyz = YieldXyz(api: api.yieldxyz)
+  /// - Parameters:
+  ///   - api: The Portal API instance to use for yield operations.
+  ///   - portal: The portal dependency used by high-level `deposit`/`withdraw` for signing,
+  ///     address resolution and confirmation. May be `nil` when only low-level methods are used.
+  init(api: PortalApiProtocol, portal: YieldXyzPortalDependency? = nil) {
+    self.yieldxyz = YieldXyz(api: api.yieldxyz, portal: portal)
+  }
+
+  /// Returns the available validators for a native-staking yield.
+  /// - Parameter yieldId: The yield identifier.
+  /// - Returns: The validators for the yield.
+  /// - Throws: `YieldXyzError.noValidators` if none are returned, or network errors.
+  public func getValidators(yieldId: String) async throws -> [YieldXyzValidator] {
+    try await yieldxyz.getValidators(yieldId: yieldId)
   }
 }

--- a/Sources/PortalSwift/Yield/YieldNetwork.swift
+++ b/Sources/PortalSwift/Yield/YieldNetwork.swift
@@ -1,0 +1,49 @@
+//
+//  YieldNetwork.swift
+//  PortalSwift
+//
+//  Created by Portal Labs
+//
+
+import Foundation
+
+/// Helpers for interpreting Yield.xyz transaction `network` strings.
+///
+/// Yield transaction networks are usually already CAIP-2 (e.g. `eip155:1`, `solana:...`). The
+/// friendly-slug map is a fallback for the rare cases where a friendly EVM name is returned.
+enum YieldNetwork {
+  private static let evmSlugToCaip2: [String: String] = [
+    "ethereum": "eip155:1",
+    "ethereum-sepolia": "eip155:11155111",
+    "ethereum-holesky": "eip155:17000",
+    "ethereum-hoodi": "eip155:560048",
+    "polygon": "eip155:137",
+    "binance": "eip155:56",
+    "bsc": "eip155:56",
+    "avalanche": "eip155:43114",
+    "avalanche-c": "eip155:43114",
+    "arbitrum": "eip155:42161",
+    "optimism": "eip155:10",
+    "base": "eip155:8453",
+    "gnosis": "eip155:100",
+    "linea": "eip155:59144",
+    "celo": "eip155:42220"
+  ]
+
+  /// Resolves a Yield network string to an EIP-155 CAIP-2 id when it is an EVM network, else nil.
+  static func resolveToCaip2(_ network: String) -> String? {
+    let trimmed = network.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty { return nil }
+    if trimmed.hasPrefix("eip155:") { return trimmed }
+    if trimmed.lowercased().hasPrefix("solana") { return nil }
+    return evmSlugToCaip2[trimmed.lowercased()]
+  }
+
+  static func isEvm(_ network: String) -> Bool {
+    resolveToCaip2(network) != nil
+  }
+
+  static func isSolana(_ network: String) -> Bool {
+    network.trimmingCharacters(in: .whitespacesAndNewlines).lowercased().hasPrefix("solana")
+  }
+}

--- a/Sources/PortalSwift/Yield/YieldXyz.swift
+++ b/Sources/PortalSwift/Yield/YieldXyz.swift
@@ -58,16 +58,55 @@ public protocol YieldXyzProtocol {
   /// - Returns: A `YieldXyzExitResponse` containing the action details.
   /// - Throws: An error if the operation fails.
   func exit(request: YieldXyzExitRequest) async throws -> YieldXyzExitResponse
+
+  /// High-level deposit: resolves the yield, builds enter transactions, signs and submits each
+  /// transaction sequentially, waits for confirmation, and tracks each hash.
+  /// - Parameters:
+  ///   - params: Either an explicit `yieldId` + `amount`, or `chain` (full CAIP-2) + `token` + `amount`.
+  ///   - options: Optional progress callback and confirmation polling tuning.
+  /// - Returns: A `YieldDepositResult` with the submitted hashes, yield id, status and action details.
+  /// - Throws: `YieldXyzError` or network/signing errors.
+  func deposit(params: YieldDepositParams, options: YieldSubmitOptions?) async throws -> YieldDepositResult
+
+  /// High-level withdraw; same parameters and behavior as `deposit`.
+  func withdraw(params: YieldWithdrawParams, options: YieldSubmitOptions?) async throws -> YieldWithdrawResult
+
+  /// Returns the available validators for a native-staking yield.
+  /// - Parameter yieldId: The yield identifier.
+  /// - Returns: The validators for the yield.
+  /// - Throws: `YieldXyzError.apiError` if the backend returns an error payload,
+  ///   `YieldXyzError.noValidators` if the validators list is missing or empty, or network errors.
+  func getValidators(yieldId: String) async throws -> [YieldXyzValidator]
+}
+
+public extension YieldXyzProtocol {
+  /// Convenience overload of `deposit` without options.
+  func deposit(params: YieldDepositParams) async throws -> YieldDepositResult {
+    try await deposit(params: params, options: nil)
+  }
+
+  /// Convenience overload of `withdraw` without options.
+  func withdraw(params: YieldWithdrawParams) async throws -> YieldWithdrawResult {
+    try await withdraw(params: params, options: nil)
+  }
 }
 
 /// YieldXyz provider implementation for discovering and managing yield opportunities.
 public class YieldXyz: YieldXyzProtocol {
   private let api: PortalYieldXyzApiProtocol
+  /// Portal dependency used by `deposit`/`withdraw` for signing, address resolution and confirmation.
+  /// Held weakly to avoid a retain cycle with `Portal`.
+  private weak var portal: YieldXyzPortalDependency?
+  private let logger = PortalLogger.shared
 
   /// Create an instance of YieldXyz.
-  /// - Parameter api: The PortalYieldXyzApi instance to use for yield operations.
-  public init(api: PortalYieldXyzApiProtocol) {
+  /// - Parameters:
+  ///   - api: The PortalYieldXyzApi instance to use for yield operations.
+  ///   - portal: The portal (or mock) providing `request`, `getAddress` and `getTransactionDetails`.
+  ///     Required for high-level `deposit`/`withdraw`; may be `nil` when only the low-level API is used.
+  public init(api: PortalYieldXyzApiProtocol, portal: YieldXyzPortalDependency? = nil) {
     self.api = api
+    self.portal = portal
   }
 
   /// Discovers yield opportunities based on the provided parameters.
@@ -137,5 +176,377 @@ public class YieldXyz: YieldXyzProtocol {
   /// - Throws: An error if the operation fails.
   public func exit(request: YieldXyzExitRequest) async throws -> YieldXyzExitResponse {
     return try await api.exitYield(request: request)
+  }
+
+  // MARK: - High-level deposit / withdraw
+
+  public func deposit(params: YieldDepositParams, options: YieldSubmitOptions? = nil) async throws -> YieldDepositResult {
+    let resolved = try await resolveYieldIdAndChain(params: params)
+    let address = try await resolveAddress(forCaip2: resolved.chainCaip2)
+    let arguments = mergeAmount(params.amount, into: params.arguments)
+    let request = YieldXyzEnterRequest(yieldId: resolved.yieldId, address: address, arguments: arguments)
+
+    let response = try await api.enterYield(request: request)
+    guard let raw = response.data?.rawResponse else {
+      if let error = response.error { throw YieldXyzError.apiError(error) }
+      throw YieldXyzError.noTransactions
+    }
+
+    let base = try await executeAndTrack(
+      transactions: raw.transactions,
+      yieldId: raw.yieldId,
+      details: makeDetails(yieldId: raw.yieldId, intent: raw.intent, type: raw.type, executionPattern: raw.executionPattern, status: raw.status, amount: raw.amount, amountUsd: raw.amountUsd),
+      fromAddress: address,
+      options: options
+    )
+
+    return YieldDepositResult(
+      hashes: base.hashes,
+      yieldId: base.yieldId,
+      status: base.status,
+      chain: resolved.resolvedChain,
+      token: resolved.resolvedToken,
+      yieldOpportunityDetails: base.details
+    )
+  }
+
+  public func withdraw(params: YieldWithdrawParams, options: YieldSubmitOptions? = nil) async throws -> YieldWithdrawResult {
+    let resolved = try await resolveYieldIdAndChain(params: params)
+    let address = try await resolveAddress(forCaip2: resolved.chainCaip2)
+    let arguments = mergeAmount(params.amount, into: params.arguments)
+    let request = YieldXyzExitRequest(yieldId: resolved.yieldId, address: address, arguments: arguments)
+
+    let response = try await api.exitYield(request: request)
+    guard let raw = response.data?.rawResponse else {
+      if let error = response.error { throw YieldXyzError.apiError(error) }
+      throw YieldXyzError.noTransactions
+    }
+
+    let base = try await executeAndTrack(
+      transactions: raw.transactions,
+      yieldId: raw.yieldId,
+      details: makeDetails(yieldId: raw.yieldId, intent: raw.intent, type: raw.type, executionPattern: raw.executionPattern, status: raw.status, amount: raw.amount, amountUsd: raw.amountUsd),
+      fromAddress: address,
+      options: options
+    )
+
+    return YieldWithdrawResult(
+      hashes: base.hashes,
+      yieldId: base.yieldId,
+      status: base.status,
+      chain: resolved.resolvedChain,
+      token: resolved.resolvedToken,
+      yieldOpportunityDetails: base.details
+    )
+  }
+
+  public func getValidators(yieldId: String) async throws -> [YieldXyzValidator] {
+    let response = try await api.getYieldValidators(yieldId: yieldId)
+    if let error = response.error, !error.isEmpty {
+      throw YieldXyzError.apiError(error)
+    }
+    let validators = response.data?.validators ?? response.data?.rawResponse?.validators ?? response.data?.rawResponse?.items
+    guard let validators = validators, !validators.isEmpty else {
+      throw YieldXyzError.noValidators(yieldId)
+    }
+    return validators
+  }
+
+  // MARK: - High-level helpers
+
+  private struct ResolvedYield {
+    let yieldId: String
+    /// CAIP-2 chain id used to resolve the wallet address.
+    let chainCaip2: String?
+    /// Only set when resolved via chain + token (echoed back in the result).
+    let resolvedChain: String?
+    let resolvedToken: String?
+  }
+
+  private func resolveYieldIdAndChain(params: YieldDepositParams) async throws -> ResolvedYield {
+    switch params.target {
+    case let .yieldId(raw):
+      let yieldId = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !yieldId.isEmpty else { throw YieldXyzError.emptyYieldId }
+      let chain = try await resolveChainFromYieldId(yieldId)
+      return ResolvedYield(yieldId: yieldId, chainCaip2: chain, resolvedChain: nil, resolvedToken: nil)
+    case let .chainAndToken(chain, token):
+      let caip2 = try requireFullCaip2(chain)
+      let trimmedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
+      let yieldId = try await resolveYieldIdFromDefaults(chainCaip2: caip2, token: trimmedToken)
+      return ResolvedYield(yieldId: yieldId, chainCaip2: caip2, resolvedChain: caip2, resolvedToken: trimmedToken)
+    }
+  }
+
+  private func requireFullCaip2(_ chain: String) throws -> String {
+    let trimmed = chain.trimmingCharacters(in: .whitespacesAndNewlines)
+    let parts = trimmed.split(separator: ":")
+    guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else {
+      throw YieldXyzError.invalidChainId(chain)
+    }
+    return trimmed
+  }
+
+  private func resolveYieldIdFromDefaults(chainCaip2: String, token: String) async throws -> String {
+    guard !token.isEmpty else { throw YieldXyzError.noYieldForChainToken("\(chainCaip2):") }
+    let response = try await api.getYieldDefaults(includeOpportunities: false)
+    if let error = response.error, !error.isEmpty {
+      throw YieldXyzError.apiError(error)
+    }
+    let key = "\(chainCaip2):\(token)"
+    guard let entry = response.data?[key], let yieldId = entry.yieldId, !yieldId.isEmpty else {
+      throw YieldXyzError.noYieldForChainToken(key)
+    }
+    return yieldId
+  }
+
+  private func resolveChainFromYieldId(_ yieldId: String) async throws -> String {
+    let response = try await api.getYields(request: YieldXyzGetYieldsRequest(yieldId: yieldId))
+    if let error = response.error, !error.isEmpty {
+      throw YieldXyzError.apiError(error)
+    }
+    guard let network = response.data?.rawResponse.items.first?.network, !network.isEmpty else {
+      throw YieldXyzError.yieldNotFound(yieldId)
+    }
+    return YieldNetwork.resolveToCaip2(network) ?? network
+  }
+
+  private func resolveAddress(forCaip2 chainCaip2: String?) async throws -> String {
+    guard let portal = portal else { throw YieldXyzError.portalNotInitialized }
+    guard let chainCaip2 = chainCaip2 else { throw YieldXyzError.addressUnavailable("unknown") }
+    guard let address = await portal.getAddress(chainCaip2), !address.isEmpty else {
+      throw YieldXyzError.addressUnavailable(chainCaip2)
+    }
+    return address
+  }
+
+  private func mergeAmount(_ amount: String, into arguments: YieldXyzEnterArguments?) -> YieldXyzEnterArguments {
+    (arguments ?? YieldXyzEnterArguments()).withAmount(amount)
+  }
+
+  private func makeDetails(
+    yieldId: String,
+    intent: YieldXyzActionIntent?,
+    type: YieldXyzActionType?,
+    executionPattern: YieldXyzActionExecutionPattern?,
+    status: YieldXyzActionStatus?,
+    amount: String?,
+    amountUsd: String?
+  ) -> YieldOpportunityDetails {
+    YieldOpportunityDetails(
+      yieldId: yieldId,
+      intent: intent,
+      type: type,
+      executionPattern: executionPattern,
+      status: status,
+      amount: amount,
+      amountUsd: amountUsd
+    )
+  }
+
+  private struct ExecuteResult {
+    let hashes: [String]
+    let yieldId: String
+    let status: YieldSubmitResultStatus
+    let details: YieldOpportunityDetails
+  }
+
+  private enum ConfirmationResult {
+    case confirmed
+    case failed
+    case uncertain
+    case skipped
+  }
+
+  private func executeAndTrack(
+    transactions: [YieldXyzActionTransaction],
+    yieldId: String,
+    details: YieldOpportunityDetails,
+    fromAddress: String,
+    options: YieldSubmitOptions?
+  ) async throws -> ExecuteResult {
+    guard let portal = portal else { throw YieldXyzError.portalNotInitialized }
+    guard !transactions.isEmpty else { throw YieldXyzError.noTransactions }
+
+    let sorted = transactions.sorted { $0.stepIndex < $1.stepIndex }
+    let total = sorted.count
+    let waiterAvailable = sorted.contains { YieldNetwork.isEvm($0.network) || YieldNetwork.isSolana($0.network) }
+    let confirmationsRequired = waiterAvailable ? total : 0
+
+    var hashes: [String] = []
+    var confirmationsReached = 0
+    var failedEarly = false
+
+    loop: for (index, tx) in sorted.enumerated() {
+      guard !tx.id.isEmpty else { throw YieldXyzError.missingTransactionField("id") }
+      guard !tx.network.isEmpty else { throw YieldXyzError.missingTransactionField("network for \(tx.id)") }
+      guard let unsigned = tx.unsignedTransaction else {
+        throw YieldXyzError.missingTransactionField("unsignedTransaction for \(tx.id)")
+      }
+
+      let isEvm = YieldNetwork.isEvm(tx.network)
+      let isSolana = YieldNetwork.isSolana(tx.network)
+      let chainId = isEvm ? (YieldNetwork.resolveToCaip2(tx.network) ?? tx.network) : tx.network
+
+      options?.onProgress?(YieldSubmitProgress(step: .signing, index: index, total: total))
+
+      let hash: String
+      if isEvm {
+        hash = try await signAndSendEvm(unsigned: unsigned, chainId: chainId, fromAddress: fromAddress, portal: portal)
+      } else if isSolana {
+        hash = try await signAndSendSolana(unsigned: unsigned, chainId: chainId, portal: portal)
+      } else {
+        throw YieldXyzError.unsupportedNetwork(tx.network)
+      }
+      hashes.append(hash)
+
+      options?.onProgress?(YieldSubmitProgress(step: .submitted, index: index, total: total, hash: hash))
+
+      if isEvm || isSolana {
+        options?.onProgress?(YieldSubmitProgress(step: .confirming, index: index, total: total, hash: hash))
+        let confirmation = try await waitForConfirmation(hash: hash, chainId: chainId, isEvm: isEvm, isSolana: isSolana, options: options, portal: portal)
+        switch confirmation {
+        case .confirmed:
+          confirmationsReached += 1
+          options?.onProgress?(YieldSubmitProgress(step: .confirmed, index: index, total: total, hash: hash))
+          await trackHashBestEffort(transactionId: tx.id, hash: hash)
+        case .failed:
+          failedEarly = true
+          await trackHashBestEffort(transactionId: tx.id, hash: hash)
+          break loop
+        case .uncertain:
+          await trackHashBestEffort(transactionId: tx.id, hash: hash)
+          break loop
+        case .skipped:
+          await trackHashBestEffort(transactionId: tx.id, hash: hash)
+        }
+      } else {
+        await trackHashBestEffort(transactionId: tx.id, hash: hash)
+      }
+    }
+
+    let status: YieldSubmitResultStatus
+    if failedEarly {
+      status = .failed
+    } else if confirmationsRequired == 0 || confirmationsReached == confirmationsRequired {
+      status = .success
+    } else {
+      status = .partialSuccess
+    }
+
+    return ExecuteResult(hashes: hashes, yieldId: yieldId, status: status, details: details)
+  }
+
+  private func signAndSendEvm(unsigned: String, chainId: String, fromAddress: String, portal: YieldXyzPortalDependency) async throws -> String {
+    let dict = parseUnsignedToDict(unsigned)
+    guard let to = dict["to"] as? String else { throw YieldXyzError.missingTransactionField("to") }
+
+    let from = (dict["from"] as? String) ?? fromAddress
+    let value = (dict["value"] as? String) ?? "0x0"
+    let data = (dict["data"] as? String) ?? ""
+
+    // Preserve fee fields; intentionally omit nonce so the MPC signer auto-fetches the pending nonce.
+    var param = ETHTransactionParam(from: from, to: to, value: value, data: data)
+    if let gas = (dict["gasLimit"] as? String) ?? (dict["gas"] as? String) { param.gas = gas }
+    if let maxFeePerGas = dict["maxFeePerGas"] as? String { param.maxFeePerGas = maxFeePerGas }
+    if let maxPriorityFeePerGas = dict["maxPriorityFeePerGas"] as? String { param.maxPriorityFeePerGas = maxPriorityFeePerGas }
+    if let gasPrice = dict["gasPrice"] as? String { param.gasPrice = gasPrice }
+
+    let result = try await portal.request(chainId: chainId, method: .eth_sendTransaction, params: [param], options: nil)
+    guard let hash = result.result as? String else { throw YieldXyzError.invalidSignResponse }
+    return hash
+  }
+
+  private func signAndSendSolana(unsigned: String, chainId: String, portal: YieldXyzPortalDependency) async throws -> String {
+    // The serialized Yield.xyz transaction string is passed through to the MPC signer (matches RN).
+    let result = try await portal.request(chainId: chainId, method: .sol_signAndSendTransaction, params: [unsigned], options: nil)
+    guard let hash = result.result as? String else { throw YieldXyzError.invalidSignResponse }
+    return hash
+  }
+
+  private func parseUnsignedToDict(_ unsigned: String) -> [String: Any] {
+    guard let data = unsigned.data(using: .utf8),
+          let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+      return [:]
+    }
+    // Unwrap a single nested object (mirrors RN's normalizeEvmTransactionParams).
+    if object.count == 1, let key = object.keys.first, let inner = object[key] as? [String: Any] {
+      return inner
+    }
+    return object
+  }
+
+  private func waitForConfirmation(
+    hash: String,
+    chainId: String,
+    isEvm: Bool,
+    isSolana: Bool,
+    options: YieldSubmitOptions?,
+    portal: YieldXyzPortalDependency
+  ) async throws -> ConfirmationResult {
+    let pollInterval = max(1, options?.pollIntervalSeconds ?? 4)
+    let timeout = max(pollInterval, options?.timeoutSeconds ?? 900)
+    let maxAttempts = max(1, timeout / pollInterval)
+    let sleepNanos = UInt64(pollInterval) * 1_000_000_000
+
+    if isEvm {
+      for attempt in 0 ..< maxAttempts {
+        // Poll immediately on the first attempt; sleep only between subsequent polls.
+        if attempt > 0 {
+          try await Task.sleep(nanoseconds: sleepNanos)
+        }
+        do {
+          let response = try await portal.request(chainId: chainId, method: .eth_getTransactionReceipt, params: [hash], options: nil)
+          if let receipt = response.result as? EthTransactionResponse, let status = receipt.result?.status {
+            return status == "0x1" ? .confirmed : .failed
+          }
+        } catch is CancellationError {
+          throw CancellationError()
+        } catch {
+          // keep polling
+        }
+      }
+      return .uncertain
+    }
+
+    if isSolana {
+      for attempt in 0 ..< maxAttempts {
+        if attempt > 0 {
+          try await Task.sleep(nanoseconds: sleepNanos)
+        }
+        do {
+          let details = try await portal.getTransactionDetails(chain: chainId, signature: hash)
+          if let sol = details.data.solanaTransaction {
+            if sol.error != nil { return .failed }
+            let status = sol.status.lowercased()
+            if status == "confirmed" || status == "finalized" || status == "success" { return .confirmed }
+            if status == "failed" { return .failed }
+          }
+        } catch is CancellationError {
+          throw CancellationError()
+        } catch {
+          // keep polling
+        }
+      }
+      return .uncertain
+    }
+
+    return .skipped
+  }
+
+  private func trackHash(transactionId: String, hash: String) async throws {
+    _ = try await api.submitTransactionHash(request: YieldXyzTrackTransactionRequest(transactionId: transactionId, hash: hash))
+  }
+
+  /// Best-effort hash tracking: failures are logged but do not fail the overall deposit/withdraw result.
+  private func trackHashBestEffort(transactionId: String, hash: String) async {
+    do {
+      try await trackHash(transactionId: transactionId, hash: hash)
+    } catch {
+      logger.error(
+        "YieldXyz.trackHashBestEffort() - Failed to submit transaction hash for transactionId=\(transactionId) hash=\(hash): \(error.localizedDescription)"
+      )
+    }
   }
 }

--- a/Sources/PortalSwift/Yield/YieldXyzHighLevel.swift
+++ b/Sources/PortalSwift/Yield/YieldXyzHighLevel.swift
@@ -1,0 +1,208 @@
+//
+//  YieldXyzHighLevel.swift
+//  PortalSwift
+//
+//  Created by Portal Labs
+//
+
+import Foundation
+
+/// Identifies the yield to act on for a high-level deposit/withdraw.
+///
+/// - `yieldId`: an explicit yield identifier (skips the defaults lookup).
+/// - `chainAndToken`: a full CAIP-2 chain (e.g. `eip155:1`) plus a token symbol (e.g. `USDC`);
+///   the SDK resolves the `yieldId` from the Portal yield defaults.
+public enum YieldActionTarget {
+  case yieldId(String)
+  case chainAndToken(chain: String, token: String)
+}
+
+/// Parameters for a high-level `deposit` / `withdraw`.
+///
+/// The wallet address is auto-resolved from the Portal wallet for the resolved chain, so it is
+/// not part of these parameters. Use `arguments` to provide yield-specific inputs such as
+/// `validatorAddress` for native staking; `amount` is merged into the action arguments.
+public struct YieldDepositParams {
+  public let target: YieldActionTarget
+  public let amount: String
+  public let arguments: YieldXyzEnterArguments?
+
+  public init(target: YieldActionTarget, amount: String, arguments: YieldXyzEnterArguments? = nil) {
+    self.target = target
+    self.amount = amount
+    self.arguments = arguments
+  }
+}
+
+public typealias YieldWithdrawParams = YieldDepositParams
+
+/// Per-transaction progress step emitted by `YieldSubmitOptions.onProgress`.
+public enum YieldSubmitStep: String {
+  case signing
+  case submitted
+  case confirming
+  case confirmed
+}
+
+/// A single progress event for a deposit/withdraw transaction.
+public struct YieldSubmitProgress {
+  public let step: YieldSubmitStep
+  public let index: Int
+  public let total: Int
+  public let hash: String?
+
+  public init(step: YieldSubmitStep, index: Int, total: Int, hash: String? = nil) {
+    self.step = step
+    self.index = index
+    self.total = total
+    self.hash = hash
+  }
+}
+
+/// Final status of a high-level deposit/withdraw.
+public enum YieldSubmitResultStatus: String {
+  case success = "SUCCESS"
+  case partialSuccess = "PARTIAL_SUCCESS"
+  case failed = "FAILED"
+}
+
+/// A summary of the executed yield action.
+///
+/// Note: this is action-level metadata, NOT the full yield opportunity. Use `discover` for full
+/// opportunity details.
+public struct YieldOpportunityDetails {
+  public let yieldId: String
+  public let intent: YieldXyzActionIntent?
+  public let type: YieldXyzActionType?
+  public let executionPattern: YieldXyzActionExecutionPattern?
+  public let status: YieldXyzActionStatus?
+  public let amount: String?
+  public let amountUsd: String?
+
+  public init(
+    yieldId: String,
+    intent: YieldXyzActionIntent? = nil,
+    type: YieldXyzActionType? = nil,
+    executionPattern: YieldXyzActionExecutionPattern? = nil,
+    status: YieldXyzActionStatus? = nil,
+    amount: String? = nil,
+    amountUsd: String? = nil
+  ) {
+    self.yieldId = yieldId
+    self.intent = intent
+    self.type = type
+    self.executionPattern = executionPattern
+    self.status = status
+    self.amount = amount
+    self.amountUsd = amountUsd
+  }
+}
+
+/// Result of a high-level `deposit` / `withdraw`.
+public struct YieldDepositResult {
+  public let hashes: [String]
+  public let yieldId: String
+  public let status: YieldSubmitResultStatus
+  /// Set only when the action was resolved via `chainAndToken`.
+  public let chain: String?
+  /// Set only when the action was resolved via `chainAndToken`.
+  public let token: String?
+  public let yieldOpportunityDetails: YieldOpportunityDetails
+
+  public init(
+    hashes: [String],
+    yieldId: String,
+    status: YieldSubmitResultStatus,
+    chain: String? = nil,
+    token: String? = nil,
+    yieldOpportunityDetails: YieldOpportunityDetails
+  ) {
+    self.hashes = hashes
+    self.yieldId = yieldId
+    self.status = status
+    self.chain = chain
+    self.token = token
+    self.yieldOpportunityDetails = yieldOpportunityDetails
+  }
+}
+
+public typealias YieldWithdrawResult = YieldDepositResult
+
+/// Options for high-level `deposit` / `withdraw`.
+public struct YieldSubmitOptions {
+  /// Called for each transaction with `signing`, `submitted`, `confirming`, and `confirmed` steps.
+  public let onProgress: ((YieldSubmitProgress) -> Void)?
+  /// Seconds between confirmation polls (default 4).
+  public let pollIntervalSeconds: Int
+  /// Max seconds to wait for a transaction to confirm before treating it as uncertain (default 900).
+  public let timeoutSeconds: Int
+
+  public init(
+    onProgress: ((YieldSubmitProgress) -> Void)? = nil,
+    pollIntervalSeconds: Int = 4,
+    timeoutSeconds: Int = 900
+  ) {
+    self.onProgress = onProgress
+    self.pollIntervalSeconds = pollIntervalSeconds
+    self.timeoutSeconds = timeoutSeconds
+  }
+}
+
+/// Errors thrown by the high-level YieldXyz deposit/withdraw flow.
+public enum YieldXyzError: LocalizedError, Equatable {
+  case portalNotInitialized
+  case emptyYieldId
+  case invalidChainId(String)
+  case noYieldForChainToken(String)
+  case yieldNotFound(String)
+  case addressUnavailable(String)
+  case noTransactions
+  case missingTransactionField(String)
+  case unsupportedNetwork(String)
+  case invalidSignResponse
+  case transactionFailed(String)
+  case noValidators(String)
+  /// Backend returned an error payload (HTTP may still have succeeded with `data == nil`).
+  case apiError(String)
+
+  public var errorDescription: String? {
+    switch self {
+    case .portalNotInitialized:
+      return "Portal instance is not available for signing or sending transactions."
+    case .emptyYieldId:
+      return "yieldId is required and must not be empty."
+    case let .invalidChainId(chain):
+      return "chain must be a full CAIP-2 id (e.g. eip155:1). Received: \"\(chain)\""
+    case let .noYieldForChainToken(key):
+      return "No default yield for key \"\(key)\". Use chain and token exactly as in the Portal yield defaults."
+    case let .yieldNotFound(yieldId):
+      return "Yield \"\(yieldId)\" was not found."
+    case let .addressUnavailable(chain):
+      return "No wallet address available for chain \"\(chain)\". Create or load a wallet first."
+    case .noTransactions:
+      return "No transactions in yield action response."
+    case let .missingTransactionField(field):
+      return "Transaction is missing required field: \(field)."
+    case let .unsupportedNetwork(network):
+      return "Unsupported network for high-level deposit/withdraw: \(network)."
+    case .invalidSignResponse:
+      return "Invalid response from signing/sending the transaction."
+    case let .transactionFailed(hash):
+      return "Transaction \(hash) failed on-chain."
+    case let .noValidators(yieldId):
+      return "No validators found for yieldId \"\(yieldId)\"."
+    case let .apiError(message):
+      return message
+    }
+  }
+}
+
+/// Minimal Portal capabilities required by the high-level YieldXyz deposit/withdraw flow.
+///
+/// `Portal` conforms to this protocol; tests can substitute a small mock. Mirrors the
+/// `EvmAccountTypePortalDependency` pattern.
+public protocol YieldXyzPortalDependency: AnyObject {
+  func request(chainId: String, method: PortalRequestMethod, params: [Any], options: RequestOptions?) async throws -> PortalProviderResult
+  func getAddress(_ forChainId: String) async -> String?
+  func getTransactionDetails(chain: String, signature: String) async throws -> GetTransactionDetailsResponse
+}

--- a/Tests/PortalSwiftTests/Core/PortalApiTests.swift
+++ b/Tests/PortalSwiftTests/Core/PortalApiTests.swift
@@ -86,6 +86,84 @@ extension PortalApiTests {
   }
 }
 
+// MARK: - generatePreGeneratedShares tests
+
+extension PortalApiTests {
+  func test_generatePreGeneratedShares_onSuccess_returnsBothCurveShares() async throws {
+    // given
+    let mockRequests = MockPortalRequests()
+    initPortalApiWith(requests: mockRequests)
+
+    // and given
+    let response = try await api?.generatePreGeneratedShares(metadataStr: "{\"clientPlatform\":\"NATIVE_IOS\"}")
+
+    // then: decode the base64 shares back into MpcShare and compare (base64 string key ordering is not stable)
+    let secpData = try XCTUnwrap(PortalMpc.decodeStandardBase64(try XCTUnwrap(response?.secp256k1.share)))
+    let edData = try XCTUnwrap(PortalMpc.decodeStandardBase64(try XCTUnwrap(response?.ed25519.share)))
+    let secpShare = try JSONDecoder().decode(MpcShare.self, from: secpData)
+    let edShare = try JSONDecoder().decode(MpcShare.self, from: edData)
+    XCTAssertEqual(secpShare, MockConstants.mockMpcShare)
+    XCTAssertEqual(edShare, MockConstants.mockMpcShare)
+    XCTAssertEqual(response?.secp256k1.id, MockConstants.mockMpcShareId)
+    XCTAssertEqual(response?.ed25519.id, MockConstants.mockMpcShareId)
+
+    let generateCallsCount = await mockRequests.generateCallsCount
+    XCTAssertEqual(generateCallsCount, 1)
+  }
+
+  func test_generatePreGeneratedShares_sendsCorrectRequest() async throws {
+    // given
+    let mockRequests = MockPortalRequests()
+    initPortalApiWith(requests: mockRequests)
+
+    // and given
+    let metadata = "{\"clientPlatform\":\"NATIVE_IOS\"}"
+    _ = try await api?.generatePreGeneratedShares(metadataStr: metadata)
+
+    // then: the request targets /v1/generate on the enclave host with the correct body
+    let request = await mockRequests.executeRequestParam
+    XCTAssertEqual(request?.url.path, "/v1/generate")
+    XCTAssertEqual(request?.url.absoluteString, "https://mpc-client.portalhq.io/v1/generate")
+    XCTAssertEqual(request?.method, .post)
+    let payload = request?.payload as? GenerateApiRequest
+    XCTAssertEqual(payload?.usePreGenerated, true)
+    XCTAssertEqual(payload?.metadataStr, metadata)
+  }
+
+  func test_generatePreGeneratedShares_usesCustomEnclaveHost() async throws {
+    // given
+    let mockRequests = MockPortalRequests()
+    let customApi = PortalApi(
+      apiKey: MockConstants.mockApiKey,
+      apiHost: MockConstants.mockHost,
+      enclaveMPCHost: "mpc-client.portalhq.dev",
+      requests: mockRequests
+    )
+
+    // and given
+    _ = try await customApi.generatePreGeneratedShares(metadataStr: "{}")
+
+    // then
+    let request = await mockRequests.executeRequestParam
+    XCTAssertEqual(request?.url.absoluteString, "https://mpc-client.portalhq.dev/v1/generate")
+  }
+
+  func test_generatePreGeneratedShares_onServerError_throws() async throws {
+    // given
+    let mockRequests = MockPortalRequests(failEnclaveGenerate: true)
+    initPortalApiWith(requests: mockRequests)
+
+    do {
+      // and given
+      _ = try await api?.generatePreGeneratedShares(metadataStr: "{}")
+      XCTFail("Expected error not thrown when the enclave generate endpoint fails.")
+    } catch {
+      // then
+      XCTAssertNotNil(error)
+    }
+  }
+}
+
 // MARK: - eject tests
 
 extension PortalApiTests {

--- a/Tests/PortalSwiftTests/Core/PortalMpcTests.swift
+++ b/Tests/PortalSwiftTests/Core/PortalMpcTests.swift
@@ -43,6 +43,7 @@ extension PortalMpcTests {
     portalApi: PortalApiProtocol = PortalApi(apiKey: MockConstants.mockApiKey, requests: MockPortalRequests()),
     keychain: PortalKeychainProtocol = MockPortalKeychain(),
     mobile: Mobile = MockMobileWrapper(),
+    featureFlags: FeatureFlags? = nil,
     gDriveStorage: PortalStorage? = nil,
     passwordStorage: PortalStorage? = nil,
     iCloudStorage: PortalStorage? = nil,
@@ -55,7 +56,8 @@ extension PortalMpcTests {
       apiKey: MockConstants.mockApiKey,
       api: self.portalApi,
       keychain: self.keychain,
-      mobile: mobile
+      mobile: mobile,
+      featureFlags: featureFlags
     )
 
     if let gDriveStorage {
@@ -909,6 +911,508 @@ extension PortalMpcTests {
     _ = try await mpc?.generate()
 
     XCTAssertEqual(portalApiMock.refreshClientCallsCount, 1)
+  }
+
+  // MARK: - Pre-generated wallet (usePreGeneratedWallet) Tests
+
+  func test_featureFlags_usePreGeneratedWallet_defaultsToOff() {
+    // given a FeatureFlags created without specifying usePreGeneratedWallet
+    let featureFlags = FeatureFlags()
+
+    // then it defaults to nil (off) and is not treated as enabled
+    XCTAssertNil(featureFlags.usePreGeneratedWallet)
+    XCTAssertNotEqual(featureFlags.usePreGeneratedWallet, true)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenUsePreGeneratedWalletEnabled_usesApiAndNotBinary() async throws {
+    // given
+    let mockRequests = MockPortalRequests()
+    let api = PortalApi(apiKey: MockConstants.mockApiKey, requests: mockRequests)
+    let mobileSpy = MobileSpy()
+    initPortalMpcWith(
+      portalApi: api,
+      mobile: mobileSpy,
+      featureFlags: FeatureFlags(usePreGeneratedWallet: true)
+    )
+
+    // and given
+    let addresses = try await mpc?.generate()
+
+    // then: the API path was used (single /v1/generate call) and the binary was not invoked
+    let generateCallsCount = await mockRequests.generateCallsCount
+    XCTAssertEqual(generateCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 0)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 0)
+    XCTAssertEqual(addresses?[.eip155], MockConstants.mockEip155Address)
+    XCTAssertEqual(addresses?[.solana], MockConstants.mockSolanaAddress)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenUsePreGeneratedWalletEnabled_andApiFails_fallsBackToBinary() async throws {
+    // given
+    let mockRequests = MockPortalRequests(failEnclaveGenerate: true)
+    let api = PortalApi(apiKey: MockConstants.mockApiKey, requests: mockRequests)
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(
+      portalApi: api,
+      mobile: mobileSpy,
+      featureFlags: FeatureFlags(usePreGeneratedWallet: true)
+    )
+
+    // and given
+    let addresses = try await mpc?.generate()
+
+    // then: API was attempted, then the binary fallback ran and the wallet was created
+    let generateCallsCount = await mockRequests.generateCallsCount
+    XCTAssertEqual(generateCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 1)
+    XCTAssertEqual(addresses?[.eip155], MockConstants.mockEip155Address)
+    XCTAssertEqual(addresses?[.solana], MockConstants.mockSolanaAddress)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenUsePreGeneratedWalletDisabled_usesBinaryAndNotApi() async throws {
+    // given
+    let mockRequests = MockPortalRequests()
+    let api = PortalApi(apiKey: MockConstants.mockApiKey, requests: mockRequests)
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(
+      portalApi: api,
+      mobile: mobileSpy,
+      featureFlags: FeatureFlags(usePreGeneratedWallet: false)
+    )
+
+    // and given
+    _ = try await mpc?.generate()
+
+    // then: the binary path was used and the API was never called
+    let generateCallsCount = await mockRequests.generateCallsCount
+    XCTAssertEqual(generateCallsCount, 0)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 1)
+  }
+
+  func test_decodeStandardBase64_roundTripsMpcShare() throws {
+    // given a base64 (no padding) of an MpcShare, as the Enclave MPC API returns
+    let shareData = try JSONEncoder().encode(MockConstants.mockMpcShare)
+    let base64NoPadding = shareData.base64EncodedString().replacingOccurrences(of: "=", with: "")
+
+    // when
+    let decoded = PortalMpc.decodeStandardBase64(base64NoPadding)
+
+    // then it decodes back into an equivalent MpcShare
+    XCTAssertNotNil(decoded)
+    let mpcShare = try JSONDecoder().decode(MpcShare.self, from: decoded!)
+    XCTAssertEqual(mpcShare.signingSharePairId, MockConstants.mockMpcShareId)
+  }
+
+  func test_decodeStandardBase64_handlesAllPaddingRemainders() {
+    // Standard-alphabet base64 with the `=` padding stripped, as the API returns.
+    XCTAssertEqual(PortalMpc.decodeStandardBase64("YWJj").flatMap { String(data: $0, encoding: .utf8) }, "abc") // len 4, no padding needed
+    XCTAssertEqual(PortalMpc.decodeStandardBase64("YQ").flatMap { String(data: $0, encoding: .utf8) }, "a") // remainder 2
+    XCTAssertEqual(PortalMpc.decodeStandardBase64("YWI").flatMap { String(data: $0, encoding: .utf8) }, "ab") // remainder 3
+    XCTAssertEqual(PortalMpc.decodeStandardBase64("YWJjZA").flatMap { String(data: $0, encoding: .utf8) }, "abcd") // remainder 2
+  }
+
+  func test_decodeStandardBase64_returnsNil_forInvalidInput() {
+    XCTAssertNil(PortalMpc.decodeStandardBase64("@@@@"))
+    XCTAssertNil(PortalMpc.decodeStandardBase64("not base64!"))
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenUsePreGeneratedWalletEnabled_stillUpdatesShareStatusAndRefreshesClient() async throws {
+    // given
+    let apiSpy = PortalApiSpy()
+    apiSpy.generatePreGeneratedSharesReturnValue = try Self.makePreGeneratedApiResponse()
+    initPortalMpcWith(portalApi: apiSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given
+    _ = try await mpc?.generate()
+
+    // then: the post-generate lifecycle steps still run exactly as with the binary path
+    XCTAssertEqual(apiSpy.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(apiSpy.updateShareStatusCallsCount, 1)
+    XCTAssertEqual(apiSpy.updateShareStatusTypeParam, .signing)
+    XCTAssertEqual(apiSpy.updateShareStatusStatusParam, .STORED_CLIENT)
+    XCTAssertEqual(apiSpy.updateShareStatusSharePairIdsParam, [MockConstants.mockMpcShareId, MockConstants.mockMpcShareId])
+    XCTAssertEqual(apiSpy.refreshClientCallsCount, 1)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenUsePreGeneratedWalletEnabled_passesIosMetadataToApi() async throws {
+    // given
+    let apiMock = PortalApiMock()
+    apiMock.generatePreGeneratedSharesReturnValue = try Self.makePreGeneratedApiResponse()
+    initPortalMpcWith(portalApi: apiMock, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given
+    _ = try await mpc?.generate()
+
+    // then: the same metadata we send to the binary is forwarded to the API
+    let metadataStr = apiMock.generatePreGeneratedSharesMetadataParam ?? ""
+    XCTAssertFalse(metadataStr.isEmpty)
+    let metadata = try JSONDecoder().decode(MpcMetadata.self, from: Data(metadataStr.utf8))
+    XCTAssertEqual(metadata.clientPlatform, "NATIVE_IOS")
+    XCTAssertEqual(metadata.mpcServerVersion, "v6")
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenUsePreGeneratedWalletEnabled_storesTransformedShares() async throws {
+    // given
+    let mockRequests = MockPortalRequests()
+    let api = PortalApi(apiKey: MockConstants.mockApiKey, requests: mockRequests)
+    let keychainSpy = PortalKeychainSpy()
+    initPortalMpcWith(portalApi: api, keychain: keychainSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given
+    _ = try await mpc?.generate()
+
+    // then: the base64 API shares are transformed into the same stored format as the binary path
+    XCTAssertEqual(keychainSpy.setSharesCallCount, 1)
+    let stored = keychainSpy.setSharesParams.first
+    XCTAssertNotNil(stored?["ED25519"])
+    XCTAssertNotNil(stored?["SECP256K1"])
+    XCTAssertEqual(stored?["SECP256K1"]?.id, MockConstants.mockMpcShareId)
+
+    let storedShareString = stored?["SECP256K1"]?.share ?? ""
+    let decodedMpcShare = try JSONDecoder().decode(MpcShare.self, from: Data(storedShareString.utf8))
+    XCTAssertEqual(decodedMpcShare.signingSharePairId, MockConstants.mockMpcShareId)
+    XCTAssertEqual(decodedMpcShare, MockConstants.mockMpcShare)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenApiShareHasEmptySigningSharePairId_surfacesErrorAndDoesNotFallBackToBinary() async throws {
+    // given: an API response whose decoded MpcShare has no signingSharePairId
+    let apiMock = PortalApiMock()
+    let badJson = "{\"clientId\":\"\",\"signingSharePairId\":\"\",\"share\":\"s\",\"ssid\":\"x\"}"
+    let badShare = Data(badJson.utf8).base64EncodedString().replacingOccurrences(of: "=", with: "")
+    apiMock.generatePreGeneratedSharesReturnValue = GenerateApiResponse(
+      secp256k1: GenerateApiCurveShare(share: badShare, id: "id"),
+      ed25519: GenerateApiCurveShare(share: badShare, id: "id")
+    )
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given / then: a validation failure is not a 5xx, so it surfaces without a binary retry
+    do {
+      _ = try await mpc?.generate()
+      XCTFail("Expected generate() to rethrow the share-validation error")
+    } catch {
+      // expected
+    }
+
+    XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 0)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 0)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenApiShareHasInvalidBase64_surfacesErrorAndDoesNotFallBackToBinary() async throws {
+    // given: an API response with an undecodable base64 share
+    let apiMock = PortalApiMock()
+    apiMock.generatePreGeneratedSharesReturnValue = GenerateApiResponse(
+      secp256k1: GenerateApiCurveShare(share: "@@@@", id: "id"),
+      ed25519: GenerateApiCurveShare(share: "@@@@", id: "id")
+    )
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given / then: a decode failure is not a 5xx, so it surfaces without a binary retry
+    do {
+      _ = try await mpc?.generate()
+      XCTFail("Expected generate() to rethrow the share-decode error")
+    } catch {
+      // expected
+    }
+
+    XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 0)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 0)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenApiThrowsNon5xxError_surfacesErrorAndDoesNotFallBackToBinary() async throws {
+    // given: the API method throws a non-5xx error (e.g. a network timeout)
+    let apiMock = PortalApiMock()
+    apiMock.generatePreGeneratedSharesErrorToThrow = URLError(.timedOut)
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given / then: only 5xx errors fall back, so this surfaces without a binary retry
+    do {
+      _ = try await mpc?.generate()
+      XCTFail("Expected generate() to rethrow the non-5xx error")
+    } catch {
+      // expected
+    }
+
+    XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 0)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 0)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenApiThrows5xxError_fallsBackToBinary_viaApiDouble() async throws {
+    // given: the API method throws a server-side (5xx) error
+    let apiMock = PortalApiMock()
+    apiMock.generatePreGeneratedSharesErrorToThrow = PortalRequestsError.internalServerError(
+      "500 - simulated pre-generated wallet failure",
+      url: "https://mpc-client.portalhq.io/v1/generate"
+    )
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given
+    let addresses = try await mpc?.generate()
+
+    // then: the 5xx triggered the binary fallback, which created the wallet
+    XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 1)
+    XCTAssertEqual(addresses?[.eip155], MockConstants.mockEip155Address)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenUsePreGeneratedWalletEnabled_storesDecodedSigningSharePairId_notEnvelopeId() async throws {
+    // given: an API response whose envelope `id` differs from the share's decoded signingSharePairId
+    let apiSpy = PortalApiSpy()
+    apiSpy.generatePreGeneratedSharesReturnValue = try Self.makePreGeneratedApiResponse(id: "envelope-id-that-differs")
+    let keychainSpy = PortalKeychainSpy()
+    initPortalMpcWith(portalApi: apiSpy, keychain: keychainSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given
+    _ = try await mpc?.generate()
+
+    // then: the stored id (and the id sent to updateShareStatus) uses the decoded
+    // signingSharePairId, keeping the API path identical to the binary path.
+    let stored = keychainSpy.setSharesParams.first
+    XCTAssertEqual(stored?["SECP256K1"]?.id, MockConstants.mockMpcShareId)
+    XCTAssertEqual(stored?["ED25519"]?.id, MockConstants.mockMpcShareId)
+    XCTAssertEqual(apiSpy.updateShareStatusSharePairIdsParam, [MockConstants.mockMpcShareId, MockConstants.mockMpcShareId])
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenApiRejectsWith4xx_surfacesErrorAndDoesNotFallBackToBinary() async throws {
+    // given: the enclave rejects the claim with a 4xx client error (e.g. "wallet already exists")
+    let apiMock = PortalApiMock()
+    apiMock.generatePreGeneratedSharesErrorToThrow = PortalRequestsError.clientError(
+      "400 - {\"error\":\"Wallet already exists\"}",
+      url: "https://mpc-client.portalhq.io/v1/generate"
+    )
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given / then: a 4xx is not retryable, so it surfaces rather than falling back
+    do {
+      _ = try await mpc?.generate()
+      XCTFail("Expected generate() to rethrow the 4xx client error")
+    } catch {
+      XCTAssertFalse(PortalMpc.isRetryableServerError(error))
+    }
+
+    // and: the binary fallback was NOT attempted
+    XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 0)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 0)
+  }
+
+  // MARK: isRetryableServerError classifier (exhaustive)
+
+  func test_isRetryableServerError_returnsTrue_forInternalServerError() {
+    // The SDK maps any 5xx response to `.internalServerError` (see PortalRequests.buildError),
+    // so classification is by error-class, independent of the specific status code or body.
+    XCTAssertTrue(PortalMpc.isRetryableServerError(
+      PortalRequestsError.internalServerError("500 - internal error", url: "u")
+    ))
+    XCTAssertTrue(PortalMpc.isRetryableServerError(
+      PortalRequestsError.internalServerError("502 - bad gateway", url: "u")
+    ))
+    XCTAssertTrue(PortalMpc.isRetryableServerError(
+      PortalRequestsError.internalServerError("503 - service unavailable", url: "u")
+    ))
+    XCTAssertTrue(PortalMpc.isRetryableServerError(
+      PortalRequestsError.internalServerError("", url: "")
+    ))
+  }
+
+  func test_isRetryableServerError_returnsFalse_forClientError() {
+    XCTAssertFalse(PortalMpc.isRetryableServerError(
+      PortalRequestsError.clientError("400 - {\"error\":\"Wallet already exists\"}", url: "u")
+    ))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(
+      PortalRequestsError.clientError("404 - not found", url: "u")
+    ))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(
+      PortalRequestsError.clientError("429 - too many requests", url: "u")
+    ))
+  }
+
+  func test_isRetryableServerError_returnsFalse_forOtherPortalRequestsErrors() {
+    XCTAssertFalse(PortalMpc.isRetryableServerError(PortalRequestsError.unauthorized))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(PortalRequestsError.redirectError("302 - redirect")))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(PortalRequestsError.couldNotParseHttpResponse))
+  }
+
+  func test_isRetryableServerError_returnsFalse_forNonRequestErrors() {
+    // Network/transport errors are not classed as 5xx and therefore do not fall back.
+    XCTAssertFalse(PortalMpc.isRetryableServerError(URLError(.timedOut)))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(URLError(.networkConnectionLost)))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(URLError(.cannotConnectToHost)))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(URLError(.notConnectedToInternet)))
+    // Share transform/validation failures are not retryable either.
+    XCTAssertFalse(PortalMpc.isRetryableServerError(MpcError.unableToDecodeShare))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(MpcError.unexpectedErrorOnGenerate("boom")))
+    XCTAssertFalse(PortalMpc.isRetryableServerError(NSError(domain: "com.portal.test", code: 42)))
+  }
+
+  // MARK: generate() retry — errors that surface without falling back
+
+  @available(iOS 16, *)
+  func test_generate_whenApiThrowsUnauthorized_surfacesErrorAndDoesNotFallBackToBinary() async {
+    await assertGenerateSurfacesWithoutBinaryFallback(apiError: PortalRequestsError.unauthorized)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenApiThrowsRedirectError_surfacesErrorAndDoesNotFallBackToBinary() async {
+    await assertGenerateSurfacesWithoutBinaryFallback(apiError: PortalRequestsError.redirectError("302 - redirect"))
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenApiThrowsCouldNotParseHttpResponse_surfacesErrorAndDoesNotFallBackToBinary() async {
+    await assertGenerateSurfacesWithoutBinaryFallback(apiError: PortalRequestsError.couldNotParseHttpResponse)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_whenApiThrowsClientError_surfacesErrorAndDoesNotFallBackToBinary() async {
+    await assertGenerateSurfacesWithoutBinaryFallback(apiError: PortalRequestsError.clientError("404 - not found", url: "u"))
+  }
+
+  // MARK: generate() retry — 5xx fallback edge cases
+
+  @available(iOS 16, *)
+  func test_generate_when5xxAndBinaryAlsoFails_surfacesError() async throws {
+    // given: the API returns a 5xx (so we fall back) but the binary DKG also fails
+    let apiMock = PortalApiMock()
+    apiMock.generatePreGeneratedSharesErrorToThrow = PortalRequestsError.internalServerError("500 - boom", url: "u")
+    // MobileSpy defaults its generate return values to "", which fails to decode -> binary throws.
+    let mobileSpy = MobileSpy()
+    initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given / then: the binary failure surfaces (no infinite retry, no swallowing)
+    do {
+      _ = try await mpc?.generate()
+      XCTFail("Expected generate() to rethrow when both the API and the binary fallback fail")
+    } catch {
+      // expected
+    }
+
+    // and: the API was tried once, then the binary was attempted once per curve
+    XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 1)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_when5xxFallback_runsPostGenerateLifecycleWithBinaryShares() async throws {
+    // given: the API returns a 5xx, so generation falls back to the binary path
+    let apiSpy = PortalApiSpy()
+    apiSpy.generatePreGeneratedSharesErrorToThrow = PortalRequestsError.internalServerError("500 - boom", url: "u")
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    let keychainSpy = PortalKeychainSpy()
+    initPortalMpcWith(portalApi: apiSpy, keychain: keychainSpy, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given
+    _ = try await mpc?.generate()
+
+    // then: the API was attempted once and the binary produced both curves
+    XCTAssertEqual(apiSpy.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 1)
+
+    // and: the shared post-generate lifecycle still runs on the binary shares
+    XCTAssertEqual(keychainSpy.setSharesCallCount, 1)
+    XCTAssertEqual(apiSpy.updateShareStatusCallsCount, 1)
+    XCTAssertEqual(apiSpy.updateShareStatusTypeParam, .signing)
+    XCTAssertEqual(apiSpy.updateShareStatusStatusParam, .STORED_CLIENT)
+    XCTAssertEqual(apiSpy.refreshClientCallsCount, 1)
+  }
+
+  @available(iOS 16, *)
+  func test_generate_when5xxFallback_callsApiExactlyOnce_andDoesNotRetryApi() async throws {
+    // given: a 5xx from the API, with a working binary fallback
+    let apiMock = PortalApiMock()
+    apiMock.generatePreGeneratedSharesErrorToThrow = PortalRequestsError.internalServerError("503 - service unavailable", url: "u")
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    // and given
+    let addresses = try await mpc?.generate()
+
+    // then: the API path is tried exactly once (single attempt, then binary), never retried
+    XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 1)
+    XCTAssertEqual(addresses?[.eip155], MockConstants.mockEip155Address)
+  }
+
+  // MARK: Retry test helpers
+
+  /// Drives `generate()` with the pre-generated flag enabled and the API stubbed to throw
+  /// `apiError`, asserting the error surfaces (is rethrown) and the binary fallback is NOT
+  /// attempted. Used for the family of non-retryable (non-5xx) errors.
+  @available(iOS 16, *)
+  private func assertGenerateSurfacesWithoutBinaryFallback(
+    apiError: Error,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) async {
+    let apiMock = PortalApiMock()
+    apiMock.generatePreGeneratedSharesErrorToThrow = apiError
+    let mobileSpy = MobileSpy()
+    // Give the binary a valid response so, if a fallback ever fired, generation would succeed —
+    // making an incorrect fallback observable as a test failure rather than a decode error.
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    initPortalMpcWith(portalApi: apiMock, mobile: mobileSpy, featureFlags: FeatureFlags(usePreGeneratedWallet: true))
+
+    do {
+      _ = try await mpc?.generate()
+      XCTFail("Expected generate() to rethrow the non-retryable error", file: file, line: line)
+    } catch {
+      XCTAssertFalse(PortalMpc.isRetryableServerError(error), "Test error should be classified non-retryable", file: file, line: line)
+    }
+
+    XCTAssertEqual(apiMock.generatePreGeneratedSharesCallsCount, 1, "API should be attempted exactly once", file: file, line: line)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 0, "Binary ED25519 must not run for a non-retryable error", file: file, line: line)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 0, "Binary SECP256K1 must not run for a non-retryable error", file: file, line: line)
+  }
+
+  private static func makePreGeneratedApiResponse(id: String = MockConstants.mockMpcShareId) throws -> GenerateApiResponse {
+    let share = try MockConstants.mockBase64EncodedMpcShare
+    return GenerateApiResponse(
+      secp256k1: GenerateApiCurveShare(share: share, id: id),
+      ed25519: GenerateApiCurveShare(share: share, id: id)
+    )
   }
 }
 

--- a/Tests/PortalSwiftTests/Core/PortalNoahApiTests.swift
+++ b/Tests/PortalSwiftTests/Core/PortalNoahApiTests.swift
@@ -1,0 +1,501 @@
+//
+//  PortalNoahApiTests.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import AnyCodable
+@testable import PortalSwift
+import XCTest
+
+final class PortalNoahApiTests: XCTestCase {
+  private let encoder = JSONEncoder()
+
+  var api: PortalNoahApi?
+
+  override func setUpWithError() throws {
+    self.api = PortalNoahApi(
+      apiKey: MockConstants.mockApiKey,
+      apiHost: MockConstants.mockHost,
+      requests: PortalRequestsMock()
+    )
+  }
+
+  override func tearDownWithError() throws {
+    api = nil
+  }
+}
+
+// MARK: - Test Helpers
+
+extension PortalNoahApiTests {
+  func initPortalNoahApiWith(
+    apiKey: String = MockConstants.mockApiKey,
+    apiHost: String = MockConstants.mockHost,
+    requests: PortalRequestsProtocol = PortalRequestsMock()
+  ) {
+    self.api = PortalNoahApi(
+      apiKey: apiKey,
+      apiHost: apiHost,
+      requests: requests
+    )
+  }
+}
+
+// MARK: - initiateKyc tests
+
+extension PortalNoahApiTests {
+  func test_initiateKyc_willReturnCorrectResponse() async throws {
+    let mockResponse = NoahInitiateKycResponse.stub()
+    let portalRequestMock = PortalRequestsMock()
+    portalRequestMock.returnValueData = try encoder.encode(mockResponse)
+    initPortalNoahApiWith(requests: portalRequestMock)
+
+    let response = try await api?.initiateKyc(request: .stub())
+
+    XCTAssertNotNil(response)
+    XCTAssertEqual(response?.data.hostedUrl, NoahInitiateKycResponse.stub().data.hostedUrl)
+  }
+
+  func test_initiateKyc_willCall_executeRequest_onlyOnce() async throws {
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahInitiateKycResponse.stub())
+    initPortalNoahApiWith(requests: portalRequestsSpy)
+
+    _ = try await api?.initiateKyc(request: .stub())
+
+    XCTAssertEqual(portalRequestsSpy.executeCallsCount, 1)
+  }
+
+  @available(iOS 16.0, *)
+  func test_initiateKyc_willCall_executeRequest_passingCorrectUrlAndMethod() async throws {
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahInitiateKycResponse.stub())
+    initPortalNoahApiWith(requests: portalRequestsSpy)
+
+    _ = try await api?.initiateKyc(request: .stub())
+
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.method, .post)
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.url.path(), "/api/v3/clients/me/integrations/noah/customers/kyc")
+  }
+
+  func test_initiateKyc_willThrowCorrectError_whenExecuteRequestThrowsError() async throws {
+    let portalRequestsFailMock = PortalRequestsFailMock()
+    initPortalNoahApiWith(requests: portalRequestsFailMock)
+
+    do {
+      _ = try await api?.initiateKyc(request: .stub())
+      XCTFail("Expected error not thrown.")
+    } catch {
+      XCTAssertEqual(error as? URLError, portalRequestsFailMock.errorToThrow)
+    }
+  }
+}
+
+// MARK: - initiatePayin tests
+
+extension PortalNoahApiTests {
+  func test_initiatePayin_willReturnCorrectResponse() async throws {
+    let mockResponse = NoahInitiatePayinResponse.stub()
+    let portalRequestMock = PortalRequestsMock()
+    portalRequestMock.returnValueData = try encoder.encode(mockResponse)
+    initPortalNoahApiWith(requests: portalRequestMock)
+
+    let response = try await api?.initiatePayin(request: .stub())
+
+    XCTAssertNotNil(response?.data)
+    XCTAssertEqual(response?.data.payinId, "payin-1")
+  }
+
+  @available(iOS 16.0, *)
+  func test_initiatePayin_willCall_executeRequest_passingCorrectUrlAndMethod() async throws {
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahInitiatePayinResponse.stub())
+    initPortalNoahApiWith(requests: portalRequestsSpy)
+
+    _ = try await api?.initiatePayin(request: .stub())
+
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.method, .post)
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.url.path(), "/api/v3/clients/me/integrations/noah/payins")
+  }
+
+  func test_initiatePayin_willThrowCorrectError_whenExecuteRequestThrowsError() async throws {
+    let portalRequestsFailMock = PortalRequestsFailMock()
+    initPortalNoahApiWith(requests: portalRequestsFailMock)
+
+    do {
+      _ = try await api?.initiatePayin(request: .stub())
+      XCTFail("Expected error not thrown.")
+    } catch {
+      XCTAssertEqual(error as? URLError, portalRequestsFailMock.errorToThrow)
+    }
+  }
+}
+
+// MARK: - simulatePayin tests
+
+extension PortalNoahApiTests {
+  func test_simulatePayin_willReturnCorrectResponse() async throws {
+    let mockResponse = NoahSimulatePayinResponse.stub()
+    let portalRequestMock = PortalRequestsMock()
+    portalRequestMock.returnValueData = try encoder.encode(mockResponse)
+    initPortalNoahApiWith(requests: portalRequestMock)
+
+    let response = try await api?.simulatePayin(request: .stub())
+
+    XCTAssertNotNil(response?.data)
+    XCTAssertEqual(response?.data.fiatDepositId, "fiat-deposit-1")
+  }
+
+  @available(iOS 16.0, *)
+  func test_simulatePayin_willCall_executeRequest_passingCorrectUrlAndMethod() async throws {
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahSimulatePayinResponse.stub())
+    initPortalNoahApiWith(requests: portalRequestsSpy)
+
+    _ = try await api?.simulatePayin(request: .stub())
+
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.method, .post)
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.url.path(), "/api/v3/clients/me/integrations/noah/payins/simulate")
+  }
+}
+
+// MARK: - getPaymentMethods tests
+
+extension PortalNoahApiTests {
+  func test_getPaymentMethods_willReturnCorrectResponse() async throws {
+    let mockResponse = NoahGetPaymentMethodsResponse.stub()
+    let portalRequestMock = PortalRequestsMock()
+    portalRequestMock.returnValueData = try encoder.encode(mockResponse)
+    initPortalNoahApiWith(requests: portalRequestMock)
+
+    let response = try await api?.getPaymentMethods()
+
+    XCTAssertNotNil(response?.data)
+    XCTAssertEqual(response?.data.paymentMethods.count, 1)
+  }
+
+  @available(iOS 16.0, *)
+  func test_getPaymentMethods_willCall_executeRequest_passingCorrectUrlAndMethod() async throws {
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahGetPaymentMethodsResponse.stub())
+    initPortalNoahApiWith(requests: portalRequestsSpy)
+
+    _ = try await api?.getPaymentMethods()
+
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.method, .get)
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.url.path(), "/api/v3/clients/me/integrations/noah/payouts/payment-methods")
+  }
+
+  @available(iOS 16.0, *)
+  func test_getPaymentMethods_willCall_executeRequest_passingCorrectQueryParams() async throws {
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahGetPaymentMethodsResponse.stub())
+    initPortalNoahApiWith(requests: portalRequestsSpy)
+
+    let request = NoahGetPaymentMethodsRequest(
+      pageSize: 50,
+      pageToken: "abc",
+      capability: .payinTo
+    )
+
+    _ = try await api?.getPaymentMethods(request: request)
+
+    let query = portalRequestsSpy.executeRequestParam?.url.query() ?? ""
+    XCTAssertTrue(query.contains("pageSize=50"))
+    XCTAssertTrue(query.contains("pageToken=abc"))
+    XCTAssertTrue(query.contains("capability=PayinTo"))
+  }
+
+  @available(iOS 16.0, *)
+  func test_getPaymentMethods_percentEncodesReservedQueryCharacters() async throws {
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahGetPaymentMethodsResponse.stub())
+    initPortalNoahApiWith(requests: portalRequestsSpy)
+
+    let pageToken = "abc+/=def&ghi=1"
+    let request = NoahGetPaymentMethodsRequest(pageToken: pageToken)
+
+    _ = try await api?.getPaymentMethods(request: request)
+
+    let url = try XCTUnwrap(portalRequestsSpy.executeRequestParam?.url)
+    let absoluteString = url.absoluteString
+
+    // Reserved separators must be percent-encoded so they cannot inject params.
+    XCTAssertTrue(absoluteString.contains("%26"), "Expected '&' to be encoded as %26")
+    XCTAssertTrue(absoluteString.contains("%3D"), "Expected '=' to be encoded as %3D")
+    XCTAssertFalse(absoluteString.contains("pageToken=abc+/=def&ghi=1"))
+
+    // Decoded query item should round-trip the original token.
+    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    let decodedToken = components?.queryItems?.first(where: { $0.name == "pageToken" })?.value
+    XCTAssertEqual(decodedToken, pageToken)
+  }
+
+  @available(iOS 16.0, *)
+  func test_getPaymentMethods_omitsQueryParams_whenAllNil() async throws {
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahGetPaymentMethodsResponse.stub())
+    initPortalNoahApiWith(requests: portalRequestsSpy)
+
+    _ = try await api?.getPaymentMethods()
+
+    let query = portalRequestsSpy.executeRequestParam?.url.query()
+    XCTAssertNil(query)
+  }
+}
+
+// MARK: - getPayoutCountries tests
+
+extension PortalNoahApiTests {
+  func test_getPayoutCountries_willReturnCorrectResponse() async throws {
+    let mockResponse = NoahGetPayoutCountriesResponse.stub()
+    let portalRequestMock = PortalRequestsMock()
+    portalRequestMock.returnValueData = try encoder.encode(mockResponse)
+    initPortalNoahApiWith(requests: portalRequestMock)
+
+    let response = try await api?.getPayoutCountries()
+
+    XCTAssertNotNil(response?.data)
+    XCTAssertEqual(response?.data.countries["US"], ["USD"])
+  }
+
+  @available(iOS 16.0, *)
+  func test_getPayoutCountries_willCall_executeRequest_passingCorrectUrlAndMethod() async throws {
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahGetPayoutCountriesResponse.stub())
+    initPortalNoahApiWith(requests: portalRequestsSpy)
+
+    _ = try await api?.getPayoutCountries()
+
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.method, .get)
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.url.path(), "/api/v3/clients/me/integrations/noah/payouts/countries")
+  }
+}
+
+// MARK: - getPayoutChannels tests
+
+extension PortalNoahApiTests {
+  func test_getPayoutChannels_willReturnCorrectResponse() async throws {
+    let mockResponse = NoahGetPayoutChannelsResponse.stub()
+    let portalRequestMock = PortalRequestsMock()
+    portalRequestMock.returnValueData = try encoder.encode(mockResponse)
+    initPortalNoahApiWith(requests: portalRequestMock)
+
+    let response = try await api?.getPayoutChannels(request: .stub())
+
+    XCTAssertNotNil(response?.data)
+    XCTAssertEqual(response?.data.items.count, 1)
+  }
+
+  @available(iOS 16.0, *)
+  func test_getPayoutChannels_willCall_executeRequest_passingCorrectUrlAndMethod() async throws {
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahGetPayoutChannelsResponse.stub())
+    initPortalNoahApiWith(requests: portalRequestsSpy)
+
+    _ = try await api?.getPayoutChannels(request: .stub())
+
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.method, .get)
+    XCTAssertTrue(portalRequestsSpy.executeRequestParam?.url.path().contains("/api/v3/clients/me/integrations/noah/payouts/channels") ?? false)
+  }
+
+  @available(iOS 16.0, *)
+  func test_getPayoutChannels_willCall_executeRequest_passingCorrectQueryParams() async throws {
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahGetPayoutChannelsResponse.stub())
+    initPortalNoahApiWith(requests: portalRequestsSpy)
+
+    let request = NoahGetPayoutChannelsRequest(
+      cryptoCurrency: "USDC",
+      country: "US",
+      fiatCurrency: "USD",
+      fiatAmount: "100.00"
+    )
+
+    _ = try await api?.getPayoutChannels(request: request)
+
+    let query = portalRequestsSpy.executeRequestParam?.url.query()
+    XCTAssertTrue(query?.contains("country=US") ?? false)
+    XCTAssertTrue(query?.contains("cryptoCurrency=USDC") ?? false)
+    XCTAssertTrue(query?.contains("fiatCurrency=USD") ?? false)
+    XCTAssertTrue(query?.contains("fiatAmount=100.00") ?? false)
+  }
+
+  @available(iOS 16.0, *)
+  func test_getPayoutChannels_omitsNilFiatAmount() async throws {
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahGetPayoutChannelsResponse.stub())
+    initPortalNoahApiWith(requests: portalRequestsSpy)
+
+    let request = NoahGetPayoutChannelsRequest(
+      cryptoCurrency: "USDC",
+      country: "GB",
+      fiatCurrency: "GBP",
+      fiatAmount: nil
+    )
+
+    _ = try await api?.getPayoutChannels(request: request)
+
+    let query = portalRequestsSpy.executeRequestParam?.url.query() ?? ""
+    XCTAssertFalse(query.contains("fiatAmount="))
+    XCTAssertTrue(query.contains("country=GB"))
+  }
+}
+
+// MARK: - getPayoutChannelForm tests
+
+extension PortalNoahApiTests {
+  func test_getPayoutChannelForm_willReturnCorrectResponse() async throws {
+    let mockResponse = NoahGetPayoutChannelFormResponse.stub()
+    let portalRequestMock = PortalRequestsMock()
+    portalRequestMock.returnValueData = try encoder.encode(mockResponse)
+    initPortalNoahApiWith(requests: portalRequestMock)
+
+    let response = try await api?.getPayoutChannelForm(channelId: "channel-1")
+
+    XCTAssertNotNil(response?.data)
+    XCTAssertNotNil(response?.data.formMetadata)
+  }
+
+  @available(iOS 16.0, *)
+  func test_getPayoutChannelForm_willCall_executeRequest_passingCorrectUrlAndMethod() async throws {
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahGetPayoutChannelFormResponse.stub())
+    initPortalNoahApiWith(requests: portalRequestsSpy)
+
+    _ = try await api?.getPayoutChannelForm(channelId: "channel-1")
+
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.method, .get)
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.url.path(), "/api/v3/clients/me/integrations/noah/payouts/channels/channel-1/form")
+  }
+
+  @available(iOS 16.0, *)
+  func test_getPayoutChannelForm_percentEncodesChannelId() async throws {
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahGetPayoutChannelFormResponse.stub())
+    initPortalNoahApiWith(requests: portalRequestsSpy)
+
+    _ = try await api?.getPayoutChannelForm(channelId: "channel/with spaces & special?")
+
+    let url = try XCTUnwrap(portalRequestsSpy.executeRequestParam?.url)
+    let absoluteString = url.absoluteString
+    XCTAssertTrue(absoluteString.contains("/api/v3/clients/me/integrations/noah/payouts/channels/"))
+    XCTAssertTrue(absoluteString.contains("/form"))
+    // Slash must be escaped as a single path component (not alter the path).
+    XCTAssertTrue(absoluteString.contains("channel%2Fwith"))
+    // Raw special characters should not appear unencoded in the URL.
+    XCTAssertFalse(absoluteString.contains("channel/with spaces & special?"))
+  }
+
+  func test_getPayoutChannelForm_willThrowCorrectError_whenExecuteRequestThrowsError() async throws {
+    let portalRequestsFailMock = PortalRequestsFailMock()
+    initPortalNoahApiWith(requests: portalRequestsFailMock)
+
+    do {
+      _ = try await api?.getPayoutChannelForm(channelId: "channel-1")
+      XCTFail("Expected error not thrown.")
+    } catch {
+      XCTAssertEqual(error as? URLError, portalRequestsFailMock.errorToThrow)
+    }
+  }
+}
+
+// MARK: - getPayoutQuote tests
+
+extension PortalNoahApiTests {
+  func test_getPayoutQuote_willReturnCorrectResponse() async throws {
+    let mockResponse = NoahGetPayoutQuoteResponse.stub()
+    let portalRequestMock = PortalRequestsMock()
+    portalRequestMock.returnValueData = try encoder.encode(mockResponse)
+    initPortalNoahApiWith(requests: portalRequestMock)
+
+    let response = try await api?.getPayoutQuote(request: .stub())
+
+    XCTAssertNotNil(response?.data)
+    XCTAssertEqual(response?.data.payoutId, "payout-1")
+  }
+
+  @available(iOS 16.0, *)
+  func test_getPayoutQuote_willCall_executeRequest_passingCorrectUrlAndMethod() async throws {
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahGetPayoutQuoteResponse.stub())
+    initPortalNoahApiWith(requests: portalRequestsSpy)
+
+    _ = try await api?.getPayoutQuote(request: .stub())
+
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.method, .post)
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.url.path(), "/api/v3/clients/me/integrations/noah/payouts/quote")
+  }
+}
+
+// MARK: - initiatePayout tests
+
+extension PortalNoahApiTests {
+  func test_initiatePayout_willReturnCorrectResponse() async throws {
+    let mockResponse = NoahInitiatePayoutResponse.stub()
+    let portalRequestMock = PortalRequestsMock()
+    portalRequestMock.returnValueData = try encoder.encode(mockResponse)
+    initPortalNoahApiWith(requests: portalRequestMock)
+
+    let response = try await api?.initiatePayout(request: .stub())
+
+    XCTAssertNotNil(response?.data)
+    XCTAssertEqual(response?.data.conditions?.count, 1)
+  }
+
+  @available(iOS 16.0, *)
+  func test_initiatePayout_willCall_executeRequest_passingCorrectUrlAndMethod() async throws {
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahInitiatePayoutResponse.stub())
+    initPortalNoahApiWith(requests: portalRequestsSpy)
+
+    _ = try await api?.initiatePayout(request: .stub())
+
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.method, .post)
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.url.path(), "/api/v3/clients/me/integrations/noah/payouts")
+  }
+}
+
+// MARK: - Bearer token tests
+
+extension PortalNoahApiTests {
+  @available(iOS 16.0, *)
+  func test_initiateKyc_includesBearerToken() async throws {
+    let apiKey = "test-noah-key-123"
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahInitiateKycResponse.stub())
+    initPortalNoahApiWith(apiKey: apiKey, requests: portalRequestsSpy)
+
+    _ = try await api?.initiateKyc(request: .stub())
+
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.headers["Authorization"], "Bearer \(apiKey)")
+  }
+
+  @available(iOS 16.0, *)
+  func test_getPayoutCountries_includesBearerToken() async throws {
+    let apiKey = "test-noah-key-456"
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(NoahGetPayoutCountriesResponse.stub())
+    initPortalNoahApiWith(apiKey: apiKey, requests: portalRequestsSpy)
+
+    _ = try await api?.getPayoutCountries()
+
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.headers["Authorization"], "Bearer \(apiKey)")
+  }
+}
+
+// MARK: - API initialization tests
+
+extension PortalNoahApiTests {
+  func test_init_withDefaultHost() {
+    let api = PortalNoahApi(apiKey: "test-key")
+    XCTAssertNotNil(api)
+  }
+
+  func test_init_withLocalhostHost() {
+    let api = PortalNoahApi(apiKey: "test-key", apiHost: "localhost:3000")
+    XCTAssertNotNil(api)
+  }
+}

--- a/Tests/PortalSwiftTests/Core/PortalYieldXyzApiTests.swift
+++ b/Tests/PortalSwiftTests/Core/PortalYieldXyzApiTests.swift
@@ -1189,3 +1189,111 @@ extension PortalYieldXyzApiTests {
     XCTAssertEqual(portalRequestsSpy.executeRequestParam?.headers["Authorization"], "Bearer \(apiKey)")
   }
 }
+
+// MARK: - getYieldDefaults tests
+
+extension PortalYieldXyzApiTests {
+  func test_getYieldDefaults_willReturnCorrectResponse() async throws {
+    // given
+    let mockResponse = YieldXyzGetDefaultsResponse.stub()
+    let portalRequestMock = PortalRequestsMock()
+    portalRequestMock.returnValueData = try encoder.encode(mockResponse)
+    initPortalYieldXyzApiWith(requests: portalRequestMock)
+
+    // when
+    let response = try await api?.getYieldDefaults(includeOpportunities: false)
+
+    // then
+    XCTAssertNotNil(response?.data)
+    XCTAssertEqual(response?.data?["eip155:11155111:ETH"]?.yieldId, "yield-1")
+  }
+
+  @available(iOS 16.0, *)
+  func test_getYieldDefaults_willCall_executeRequest_passingCorrectUrlAndQuery() async throws {
+    // given
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(YieldXyzGetDefaultsResponse.stub())
+    initPortalYieldXyzApiWith(requests: portalRequestsSpy)
+
+    // when
+    _ = try await api?.getYieldDefaults(includeOpportunities: true)
+
+    // then
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.method, .get)
+    XCTAssertTrue(portalRequestsSpy.executeRequestParam?.url.path().contains("/api/v3/clients/me/integrations/yield-xyz/yields/defaults") ?? false)
+    XCTAssertTrue(portalRequestsSpy.executeRequestParam?.url.query()?.contains("includeOpportunities=true") ?? false)
+  }
+}
+
+// MARK: - getYieldValidators tests
+
+extension PortalYieldXyzApiTests {
+  func test_getYieldValidators_willReturnCorrectResponse() async throws {
+    // given
+    let mockResponse = YieldXyzGetValidatorsResponse.stub()
+    let portalRequestMock = PortalRequestsMock()
+    portalRequestMock.returnValueData = try encoder.encode(mockResponse)
+    initPortalYieldXyzApiWith(requests: portalRequestMock)
+
+    // when
+    let response = try await api?.getYieldValidators(yieldId: "monad-testnet-mon-native-staking")
+
+    // then
+    XCTAssertNotNil(response?.data)
+    XCTAssertEqual(response?.data?.rawResponse?.items?.count, 1)
+  }
+
+  @available(iOS 16.0, *)
+  func test_getYieldValidators_willCall_executeRequest_passingCorrectUrl() async throws {
+    // given
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(YieldXyzGetValidatorsResponse.stub())
+    initPortalYieldXyzApiWith(requests: portalRequestsSpy)
+
+    // when
+    _ = try await api?.getYieldValidators(yieldId: "monad-testnet-mon-native-staking")
+
+    // then
+    XCTAssertEqual(portalRequestsSpy.executeRequestParam?.method, .get)
+    XCTAssertTrue(portalRequestsSpy.executeRequestParam?.url.path().contains("/api/v3/clients/me/integrations/yield-xyz/yields/monad-testnet-mon-native-staking/validators") ?? false)
+  }
+
+  @available(iOS 16.0, *)
+  func test_getYieldValidators_percentEncodesSlashInYieldIdPathSegment() async throws {
+    // given
+    let portalRequestsSpy = PortalRequestsSpy()
+    portalRequestsSpy.returnData = try encoder.encode(YieldXyzGetValidatorsResponse.stub())
+    initPortalYieldXyzApiWith(requests: portalRequestsSpy)
+
+    // when
+    _ = try await api?.getYieldValidators(yieldId: "foo/bar")
+
+    // then - `/` must be encoded so it stays a single path segment
+    let path = portalRequestsSpy.executeRequestParam?.url.path() ?? ""
+    XCTAssertTrue(path.contains("/yields/foo%2Fbar/validators"), "Expected encoded path segment, got: \(path)")
+    XCTAssertFalse(path.contains("/yields/foo/bar/validators"))
+  }
+}
+
+// MARK: - Unknown-tolerant enum decoding
+
+extension PortalYieldXyzApiTests {
+  func test_enterYield_decodesUnknownTransactionTypeAndStatus_asUnknown() async throws {
+    // given - a transaction whose type/status are values not present in the SDK enums
+    let json = """
+    {"data":{"rawResponse":{"id":"a1","intent":"enter","type":"STAKE","yieldId":"y","address":"0x","transactions":[{"id":"t1","title":"t","network":"eip155:1","status":"SOME_NEW_STATUS","type":"SOME_NEW_TYPE","createdAt":"now","stepIndex":0,"unsignedTransaction":"0x00"}],"executionPattern":"synchronous","createdAt":"now","status":"CREATED"}}}
+    """
+    let portalRequestMock = PortalRequestsMock()
+    portalRequestMock.returnValueData = json.data(using: .utf8)
+    initPortalYieldXyzApiWith(requests: portalRequestMock)
+
+    // when - decoding must not throw
+    let response = try await api?.enterYield(request: YieldXyzEnterRequest(yieldId: "y", address: "0x"))
+
+    // then - unknown values fall back to .unknown rather than failing the whole decode
+    let tx = response?.data?.rawResponse.transactions.first
+    XCTAssertEqual(tx?.type, .unknown)
+    XCTAssertEqual(tx?.status, .unknown)
+    XCTAssertEqual(response?.data?.rawResponse.intent, .enter)
+  }
+}

--- a/Tests/PortalSwiftTests/Core/Spies/PortalKeychainSpy.swift
+++ b/Tests/PortalSwiftTests/Core/Spies/PortalKeychainSpy.swift
@@ -107,59 +107,88 @@ class PortalKeychainSpy: PortalKeychainProtocol {
 
   // MARK: - Presignature Storage
 
+  // Presignature operations can be invoked concurrently (e.g. concurrent fillBuffer calls),
+  // so all access to the mutable state below is guarded by this lock to avoid data races
+  // that would otherwise corrupt the underlying dictionary.
+  private let presignatureLock = NSLock()
+
+  private func withPresignatureLock<T>(_ body: () throws -> T) rethrows -> T {
+    presignatureLock.lock()
+    defer { presignatureLock.unlock() }
+    return try body()
+  }
+
   private var presignatureStore: [String: [PresignatureEntry]] = [:]
-  private(set) var getPresignaturesCallCount = 0
-  private(set) var insertPresignatureCallCount = 0
-  private(set) var popOldestPresignatureCallCount = 0
-  private(set) var deletePresignaturesCallCount = 0
+  private var _getPresignaturesCallCount = 0
+  private var _insertPresignatureCallCount = 0
+  private var _popOldestPresignatureCallCount = 0
+  private var _deletePresignaturesCallCount = 0
+  private var _cleanupExpiredPresignaturesCallCount = 0
+
+  var getPresignaturesCallCount: Int { withPresignatureLock { _getPresignaturesCallCount } }
+  var insertPresignatureCallCount: Int { withPresignatureLock { _insertPresignatureCallCount } }
+  var popOldestPresignatureCallCount: Int { withPresignatureLock { _popOldestPresignatureCallCount } }
+  var deletePresignaturesCallCount: Int { withPresignatureLock { _deletePresignaturesCallCount } }
+  var cleanupExpiredPresignaturesCallCount: Int { withPresignatureLock { _cleanupExpiredPresignaturesCallCount } }
+
   var insertPresignatureShouldThrow = false
   var deletePresignaturesShouldThrow = false
   var getSharesShouldThrow = false
 
   func getPresignatures(_ curve: String) async throws -> [PresignatureEntry] {
-    getPresignaturesCallCount += 1
-    return presignatureStore[curve] ?? []
+    withPresignatureLock {
+      _getPresignaturesCallCount += 1
+      return presignatureStore[curve] ?? []
+    }
   }
 
   func insertPresignature(_ curve: String, _ entry: PresignatureEntry) async throws {
-    insertPresignatureCallCount += 1
     if insertPresignatureShouldThrow {
+      withPresignatureLock { _insertPresignatureCallCount += 1 }
       throw NSError(domain: "PortalKeychainSpy", code: -1, userInfo: [NSLocalizedDescriptionKey: "Mock insert failure"])
     }
-    presignatureStore[curve, default: []].append(entry)
+    withPresignatureLock {
+      _insertPresignatureCallCount += 1
+      presignatureStore[curve, default: []].append(entry)
+    }
   }
 
   func popOldestPresignature(_ curve: String) async throws -> PresignatureEntry? {
-    popOldestPresignatureCallCount += 1
-    guard var entries = presignatureStore[curve], !entries.isEmpty else { return nil }
-    let oldest = entries.removeFirst()
-    presignatureStore[curve] = entries
-    return oldest
+    withPresignatureLock {
+      _popOldestPresignatureCallCount += 1
+      guard var entries = presignatureStore[curve], !entries.isEmpty else { return nil }
+      let oldest = entries.removeFirst()
+      presignatureStore[curve] = entries
+      return oldest
+    }
   }
 
   func deletePresignatures(_ curve: String) async throws {
-    deletePresignaturesCallCount += 1
     if deletePresignaturesShouldThrow {
+      withPresignatureLock { _deletePresignaturesCallCount += 1 }
       throw NSError(domain: "PortalKeychainSpy", code: -1, userInfo: [NSLocalizedDescriptionKey: "Mock delete failure"])
     }
-    presignatureStore[curve] = nil
+    withPresignatureLock {
+      _deletePresignaturesCallCount += 1
+      presignatureStore[curve] = nil
+    }
   }
-
-  private(set) var cleanupExpiredPresignaturesCallCount = 0
 
   @discardableResult
   func cleanupExpiredPresignatures(_ curve: String) async throws -> Int {
-    cleanupExpiredPresignaturesCallCount += 1
-    let entries = presignatureStore[curve] ?? []
     let now = Date()
     let formatter = ISO8601DateFormatter()
-    let valid = entries.filter { entry in
-      guard let expiresAt = formatter.date(from: entry.expiresAt) else { return false }
-      return expiresAt > now
+    return withPresignatureLock {
+      _cleanupExpiredPresignaturesCallCount += 1
+      let entries = presignatureStore[curve] ?? []
+      let valid = entries.filter { entry in
+        guard let expiresAt = formatter.date(from: entry.expiresAt) else { return false }
+        return expiresAt > now
+      }
+      let removed = entries.count - valid.count
+      presignatureStore[curve] = valid
+      return removed
     }
-    let removed = entries.count - valid.count
-    presignatureStore[curve] = valid
-    return removed
   }
 
   // MARK: - getAddress

--- a/Tests/PortalSwiftTests/Delegations/DelegationsAndSubmitTests.swift
+++ b/Tests/PortalSwiftTests/Delegations/DelegationsAndSubmitTests.swift
@@ -1,0 +1,317 @@
+//
+//  DelegationsAndSubmitTests.swift
+//  PortalSwiftTests
+//
+//  Created by Ahmed Ragab
+//
+//  Tests for the high-level Delegations submit methods
+//  (approveAndSubmit / revokeAndSubmit / transferAndSubmit).
+//
+
+@testable import PortalSwift
+import XCTest
+
+final class DelegationsAndSubmitTests: XCTestCase {
+  private var mockApi: PortalDelegationsApiMock!
+  private var sut: Delegations!
+
+  /// Records the transactions passed to the signer, in order, and returns canned hashes.
+  private final class RecordingSigner {
+    private let hashes: [String]
+    private(set) var signedTransactions: [DelegationTransaction] = []
+    private(set) var chainIds: [String] = []
+
+    init(hashes: [String] = ["0xhash0", "0xhash1", "0xhash2", "0xhash3"]) {
+      self.hashes = hashes
+    }
+
+    func asFn() -> DelegationSignAndSend {
+      { transaction, chainId in
+        self.signedTransactions.append(transaction)
+        self.chainIds.append(chainId)
+        return self.hashes[self.signedTransactions.count - 1]
+      }
+    }
+  }
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    mockApi = PortalDelegationsApiMock()
+    sut = Delegations(api: mockApi)
+  }
+
+  override func tearDownWithError() throws {
+    mockApi = nil
+    sut = nil
+    try super.tearDownWithError()
+  }
+
+  // MARK: - Signer Resolution
+
+  func testApproveAndSubmit_noSignerConfigured_throws() async {
+    mockApi.approveReturnValue = .stub()
+
+    do {
+      _ = try await sut.approveAndSubmit(request: .stub())
+      XCTFail("Expected error")
+    } catch let error as DelegationsError {
+      XCTAssertEqual(error, .noSignerConfigured)
+      // API should not be called when no signer is configured.
+      XCTAssertEqual(mockApi.approveCallCount, 0)
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  func testApproveAndSubmit_perCallSigner_overridesInstanceSigner() async throws {
+    let instanceSigner = RecordingSigner(hashes: ["0xinstance"])
+    let perCallSigner = RecordingSigner(hashes: ["0xpercall"])
+    sut.setSignAndSendTransaction(instanceSigner.asFn())
+    mockApi.approveReturnValue = .stub()
+
+    let result = try await sut.approveAndSubmit(
+      request: .stub(),
+      options: DelegationSubmitOptions(signAndSendTransaction: perCallSigner.asFn())
+    )
+
+    XCTAssertEqual(result.hashes, ["0xpercall"])
+    XCTAssertEqual(perCallSigner.signedTransactions.count, 1)
+    XCTAssertEqual(instanceSigner.signedTransactions.count, 0)
+  }
+
+  func testApproveAndSubmit_instanceSigner_usedWhenNoOverride() async throws {
+    let instanceSigner = RecordingSigner(hashes: ["0xinstance"])
+    sut.setSignAndSendTransaction(instanceSigner.asFn())
+    mockApi.approveReturnValue = .stub()
+
+    let result = try await sut.approveAndSubmit(request: .stub())
+
+    XCTAssertEqual(result.hashes, ["0xinstance"])
+    XCTAssertEqual(instanceSigner.signedTransactions.count, 1)
+  }
+
+  // MARK: - EVM vs Solana Normalization
+
+  func testApproveAndSubmit_evm_usesTransactions() async throws {
+    let signer = RecordingSigner()
+    sut.setSignAndSendTransaction(signer.asFn())
+    mockApi.approveReturnValue = .stub(transactions: [.stub()], encodedTransactions: nil)
+
+    let result = try await sut.approveAndSubmit(request: .stub(chain: "eip155:11155111"))
+
+    XCTAssertEqual(result.hashes, ["0xhash0"])
+    XCTAssertEqual(signer.signedTransactions.count, 1)
+    XCTAssertNotNil(signer.signedTransactions[0].evmTransaction)
+    XCTAssertEqual(signer.chainIds[0], "eip155:11155111")
+  }
+
+  func testApproveAndSubmit_solana_usesEncodedTransactions() async throws {
+    let signer = RecordingSigner()
+    sut.setSignAndSendTransaction(signer.asFn())
+    mockApi.approveReturnValue = .stub(transactions: nil, encodedTransactions: ["base64tx0", "base64tx1"])
+
+    let result = try await sut.approveAndSubmit(
+      request: .stub(chain: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1")
+    )
+
+    XCTAssertEqual(result.hashes, ["0xhash0", "0xhash1"])
+    XCTAssertEqual(signer.signedTransactions.compactMap(\.solanaTransaction), ["base64tx0", "base64tx1"])
+  }
+
+  func testApproveAndSubmit_prefersTransactionsWhenBothPresent() async throws {
+    let signer = RecordingSigner()
+    sut.setSignAndSendTransaction(signer.asFn())
+    mockApi.approveReturnValue = .stub(transactions: [.stub()], encodedTransactions: ["base64tx0"])
+
+    let result = try await sut.approveAndSubmit(request: .stub())
+
+    XCTAssertEqual(result.hashes, ["0xhash0"])
+    XCTAssertEqual(signer.signedTransactions.count, 1)
+    XCTAssertNotNil(signer.signedTransactions[0].evmTransaction)
+  }
+
+  // MARK: - Multi-Transaction Ordering
+
+  func testApproveAndSubmit_multipleTransactions_orderedHashes() async throws {
+    let signer = RecordingSigner()
+    sut.setSignAndSendTransaction(signer.asFn())
+    mockApi.approveReturnValue = .stub(
+      transactions: [.stub(from: "0xfrom0"), .stub(from: "0xfrom1")],
+      encodedTransactions: nil
+    )
+
+    let result = try await sut.approveAndSubmit(request: .stub())
+
+    XCTAssertEqual(result.hashes, ["0xhash0", "0xhash1"])
+    XCTAssertEqual(signer.signedTransactions.count, 2)
+    XCTAssertEqual(signer.signedTransactions[0].evmTransaction?.from, "0xfrom0")
+    XCTAssertEqual(signer.signedTransactions[1].evmTransaction?.from, "0xfrom1")
+  }
+
+  // MARK: - Errors
+
+  func testApproveAndSubmit_emptyTransactions_throws() async {
+    let signer = RecordingSigner()
+    sut.setSignAndSendTransaction(signer.asFn())
+    mockApi.approveReturnValue = .stub(transactions: [], encodedTransactions: nil)
+
+    do {
+      _ = try await sut.approveAndSubmit(request: .stub())
+      XCTFail("Expected error")
+    } catch let error as DelegationsError {
+      XCTAssertEqual(error, .noTransactions)
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  func testApproveAndSubmit_blankHash_throws() async {
+    sut.setSignAndSendTransaction { _, _ in "   " }
+    mockApi.approveReturnValue = .stub()
+
+    do {
+      _ = try await sut.approveAndSubmit(request: .stub())
+      XCTFail("Expected error")
+    } catch let error as DelegationsError {
+      XCTAssertEqual(error, .invalidTransactionHash(index: 0, chainId: "eip155:11155111"))
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  func testApproveAndSubmit_emptyHash_throws() async {
+    // The default Portal signer returns an empty string when the provider result is not a hash;
+    // `executeAndTrack` must catch that (not only whitespace-only strings).
+    sut.setSignAndSendTransaction { _, _ in "" }
+    mockApi.approveReturnValue = .stub()
+
+    do {
+      _ = try await sut.approveAndSubmit(request: .stub())
+      XCTFail("Expected error")
+    } catch let error as DelegationsError {
+      XCTAssertEqual(error, .invalidTransactionHash(index: 0, chainId: "eip155:11155111"))
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  func testApproveAndSubmit_invalidHashOnSecondTransaction_reportsCorrectIndex() async {
+    // Regression test for the default-signer path: a blank hash on a non-first transaction must
+    // report that transaction's index, not a hardcoded 0.
+    let signer = RecordingSigner(hashes: ["0xhash0", ""])
+    sut.setSignAndSendTransaction(signer.asFn())
+    mockApi.approveReturnValue = .stub(
+      transactions: [.stub(from: "0xfrom0"), .stub(from: "0xfrom1")],
+      encodedTransactions: nil
+    )
+
+    do {
+      _ = try await sut.approveAndSubmit(request: .stub())
+      XCTFail("Expected error")
+    } catch let error as DelegationsError {
+      XCTAssertEqual(error, .invalidTransactionHash(index: 1, chainId: "eip155:11155111"))
+      // The first transaction was signed before the failure surfaced.
+      XCTAssertEqual(signer.signedTransactions.count, 2)
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  func testApproveAndSubmit_apiError_propagates() async {
+    sut.setSignAndSendTransaction(RecordingSigner().asFn())
+    mockApi.approveError = URLError(.badServerResponse)
+
+    do {
+      _ = try await sut.approveAndSubmit(request: .stub())
+      XCTFail("Expected error")
+    } catch {
+      XCTAssertTrue(error is URLError)
+    }
+  }
+
+  func testApproveAndSubmit_signerError_propagates() async {
+    struct SignerError: Error {}
+    sut.setSignAndSendTransaction { _, _ in throw SignerError() }
+    mockApi.approveReturnValue = .stub()
+
+    do {
+      _ = try await sut.approveAndSubmit(request: .stub())
+      XCTFail("Expected error")
+    } catch {
+      XCTAssertTrue(error is SignerError)
+    }
+  }
+
+  // MARK: - Progress Callbacks
+
+  func testApproveAndSubmit_progressSequence() async throws {
+    sut.setSignAndSendTransaction(RecordingSigner().asFn())
+    mockApi.approveReturnValue = .stub(
+      transactions: [.stub(from: "0xfrom0"), .stub(from: "0xfrom1")],
+      encodedTransactions: nil
+    )
+    var events: [DelegationSubmitProgress] = []
+
+    _ = try await sut.approveAndSubmit(
+      request: .stub(),
+      options: DelegationSubmitOptions(onProgress: { events.append($0) })
+    )
+
+    XCTAssertEqual(events.count, 4)
+    XCTAssertEqual(events[0], DelegationSubmitProgress(step: .signing, index: 0, total: 2))
+    XCTAssertEqual(events[1], DelegationSubmitProgress(step: .submitted, index: 0, total: 2, hash: "0xhash0"))
+    XCTAssertEqual(events[2], DelegationSubmitProgress(step: .signing, index: 1, total: 2))
+    XCTAssertEqual(events[3], DelegationSubmitProgress(step: .submitted, index: 1, total: 2, hash: "0xhash1"))
+  }
+
+  // MARK: - Revoke & Transfer Happy Paths
+
+  func testRevokeAndSubmit_evm_success() async throws {
+    let signer = RecordingSigner()
+    sut.setSignAndSendTransaction(signer.asFn())
+    mockApi.revokeReturnValue = .stub()
+
+    let result = try await sut.revokeAndSubmit(request: .stub())
+
+    XCTAssertEqual(result.hashes, ["0xhash0"])
+    XCTAssertEqual(mockApi.revokeCallCount, 1)
+  }
+
+  func testRevokeAndSubmit_noSignerConfigured_throws() async {
+    mockApi.revokeReturnValue = .stub()
+
+    do {
+      _ = try await sut.revokeAndSubmit(request: .stub())
+      XCTFail("Expected error")
+    } catch let error as DelegationsError {
+      XCTAssertEqual(error, .noSignerConfigured)
+      XCTAssertEqual(mockApi.revokeCallCount, 0)
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  func testTransferAndSubmit_evm_success() async throws {
+    let signer = RecordingSigner()
+    sut.setSignAndSendTransaction(signer.asFn())
+    mockApi.transferFromReturnValue = .stub()
+
+    let result = try await sut.transferAndSubmit(request: .stub())
+
+    XCTAssertEqual(result.hashes, ["0xhash0"])
+    XCTAssertEqual(mockApi.transferFromCallCount, 1)
+  }
+
+  func testTransferAndSubmit_solana_usesEncodedTransactions() async throws {
+    let signer = RecordingSigner()
+    sut.setSignAndSendTransaction(signer.asFn())
+    mockApi.transferFromReturnValue = .stub(transactions: nil, encodedTransactions: ["base64tx0"])
+
+    let result = try await sut.transferAndSubmit(
+      request: .stub(chain: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1")
+    )
+
+    XCTAssertEqual(result.hashes, ["0xhash0"])
+    XCTAssertEqual(signer.signedTransactions.compactMap(\.solanaTransaction), ["base64tx0"])
+  }
+}

--- a/Tests/PortalSwiftTests/EvmAccountType/EvmAccountTypeTests.swift
+++ b/Tests/PortalSwiftTests/EvmAccountType/EvmAccountTypeTests.swift
@@ -15,6 +15,7 @@ private final class EvmAccountTypePortalMock: EvmAccountTypePortalDependency {
   var rawSignCallCount = 0
   var rawSignMessage: String?
   var rawSignChainId: String?
+  var rawSignTraceId: String?
 
   var requestReturnValue: PortalProviderResult?
   var requestError: Error?
@@ -23,10 +24,11 @@ private final class EvmAccountTypePortalMock: EvmAccountTypePortalDependency {
   var requestMethod: PortalRequestMethod?
   var requestParams: [Any]?
 
-  func rawSign(message: String, chainId: String, signatureApprovalMemo _: String?) async throws -> PortalProviderResult {
+  func rawSign(message: String, chainId: String, signatureApprovalMemo _: String?, traceId: String? = nil) async throws -> PortalProviderResult {
     rawSignCallCount += 1
     rawSignMessage = message
     rawSignChainId = chainId
+    rawSignTraceId = traceId
     if let error = rawSignError {
       throw error
     }

--- a/Tests/PortalSwiftTests/PortalApi/PortalApiMock.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalApiMock.swift
@@ -17,6 +17,7 @@ class PortalApiMock: PortalApiProtocol {
   var blockaid: PortalSwift.PortalBlockaidApiProtocol
   var delegations: PortalSwift.PortalDelegationsApiProtocol
   var evmAccountType: PortalSwift.PortalEvmAccountTypeApiProtocol
+  var noah: PortalSwift.PortalNoahApiProtocol
 
   var client: PortalSwift.ClientResponse?
 
@@ -28,6 +29,7 @@ class PortalApiMock: PortalApiProtocol {
     blockaid: PortalSwift.PortalBlockaidApiProtocol = PortalBlockaidApiMock(),
     delegations: PortalSwift.PortalDelegationsApiProtocol = PortalDelegationsApiMock(),
     evmAccountType: PortalSwift.PortalEvmAccountTypeApiProtocol = PortalEvmAccountTypeApiMock(),
+    noah: PortalSwift.PortalNoahApiProtocol = PortalNoahApiMock(),
     client: PortalSwift.ClientResponse? = nil
   ) {
     self.yieldxyz = yieldxyz
@@ -37,6 +39,7 @@ class PortalApiMock: PortalApiProtocol {
     self.blockaid = blockaid
     self.delegations = delegations
     self.evmAccountType = evmAccountType
+    self.noah = noah
     self.client = client
   }
 

--- a/Tests/PortalSwiftTests/PortalApi/PortalApiMock.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalApiMock.swift
@@ -114,6 +114,22 @@ class PortalApiMock: PortalApiProtocol {
     refreshClientCallsCount += 1
   }
 
+  var generatePreGeneratedSharesCallsCount = 0
+  var generatePreGeneratedSharesMetadataParam: String?
+  var generatePreGeneratedSharesReturnValue: PortalSwift.GenerateApiResponse?
+  var generatePreGeneratedSharesErrorToThrow: Error?
+  func generatePreGeneratedShares(metadataStr: String) async throws -> PortalSwift.GenerateApiResponse {
+    generatePreGeneratedSharesCallsCount += 1
+    generatePreGeneratedSharesMetadataParam = metadataStr
+    if let error = generatePreGeneratedSharesErrorToThrow {
+      throw error
+    }
+    guard let value = generatePreGeneratedSharesReturnValue else {
+      throw URLError(.badURL)
+    }
+    return value
+  }
+
   var simulateTransactionReturnValue: PortalSwift.SimulatedTransaction?
   func simulateTransaction(_: Any, withChainId _: String) async throws -> PortalSwift.SimulatedTransaction {
     return simulateTransactionReturnValue ?? SimulatedTransaction(changes: [])

--- a/Tests/PortalSwiftTests/PortalApi/PortalApiMock.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalApiMock.swift
@@ -45,8 +45,10 @@ class PortalApiMock: PortalApiProtocol {
 
   var ejectReturnValue: String?
   var ejectCallsCount: Int = 0
-  func eject() async throws -> String {
+  var ejectTraceIdParam: String?
+  func eject(traceId: String?) async throws -> String {
     ejectCallsCount += 1
+    ejectTraceIdParam = traceId
     return ejectReturnValue ?? ""
   }
 
@@ -61,14 +63,18 @@ class PortalApiMock: PortalApiProtocol {
   }
 
   var getClientReturnValue: PortalSwift.ClientResponse?
-  func getClient() async throws -> PortalSwift.ClientResponse {
-    getClientReturnValue ?? ClientResponse.stub()
+  var getClientTraceIdParam: String?
+  func getClient(traceId: String?) async throws -> PortalSwift.ClientResponse {
+    getClientTraceIdParam = traceId
+    return getClientReturnValue ?? ClientResponse.stub()
   }
 
   var getClientCipherTextReturnValue: String?
   var getClientCipherTextCallsCount: Int = 0
-  func getClientCipherText(_: String) async throws -> String {
+  var getClientCipherTextTraceIdParam: String?
+  func getClientCipherText(_: String, traceId: String?) async throws -> String {
     getClientCipherTextCallsCount += 1
+    getClientCipherTextTraceIdParam = traceId
     return getClientCipherTextReturnValue ?? ""
   }
 
@@ -107,23 +113,29 @@ class PortalApiMock: PortalApiProtocol {
 
   var prepareEjectReturnValue: String?
   var prepareEjectCallsCount: Int = 0
-  func prepareEject(_: String, _: PortalSwift.BackupMethods) async throws -> String {
+  var prepareEjectTraceIdParam: String?
+  func prepareEject(_: String, _: PortalSwift.BackupMethods, traceId: String?) async throws -> String {
     prepareEjectCallsCount += 1
+    prepareEjectTraceIdParam = traceId
     return prepareEjectReturnValue ?? ""
   }
 
   var refreshClientCallsCount = 0
-  func refreshClient() async throws {
+  var refreshClientTraceIdParam: String?
+  func refreshClient(traceId: String?) async throws {
     refreshClientCallsCount += 1
+    refreshClientTraceIdParam = traceId
   }
 
   var generatePreGeneratedSharesCallsCount = 0
   var generatePreGeneratedSharesMetadataParam: String?
+  var generatePreGeneratedSharesTraceIdParam: String?
   var generatePreGeneratedSharesReturnValue: PortalSwift.GenerateApiResponse?
   var generatePreGeneratedSharesErrorToThrow: Error?
-  func generatePreGeneratedShares(metadataStr: String) async throws -> PortalSwift.GenerateApiResponse {
+  func generatePreGeneratedShares(metadataStr: String, traceId: String?) async throws -> PortalSwift.GenerateApiResponse {
     generatePreGeneratedSharesCallsCount += 1
     generatePreGeneratedSharesMetadataParam = metadataStr
+    generatePreGeneratedSharesTraceIdParam = traceId
     if let error = generatePreGeneratedSharesErrorToThrow {
       throw error
     }
@@ -141,16 +153,20 @@ class PortalApiMock: PortalApiProtocol {
   var updateShareStatusCallsCount = 0
   var updateShareStatusSharePareTypeParam: PortalSharePairType?
   var updateShareStatusStatusParam: SharePairUpdateStatus?
-  func updateShareStatus(_ type: PortalSwift.PortalSharePairType, status: PortalSwift.SharePairUpdateStatus, sharePairIds _: [String]) async throws {
+  var updateShareStatusTraceIdParam: String?
+  func updateShareStatus(_ type: PortalSwift.PortalSharePairType, status: PortalSwift.SharePairUpdateStatus, sharePairIds _: [String], traceId: String?) async throws {
     updateShareStatusSharePareTypeParam = type
     updateShareStatusStatusParam = status
+    updateShareStatusTraceIdParam = traceId
     updateShareStatusCallsCount += 1
   }
 
   var storeClientCipherTextReturnValue: Bool?
   var storeClientCipherTextCallsCount: Int = 0
-  func storeClientCipherText(_: String, cipherText _: String) async throws -> Bool {
+  var storeClientCipherTextTraceIdParam: String?
+  func storeClientCipherText(_: String, cipherText _: String, traceId: String?) async throws -> Bool {
     storeClientCipherTextCallsCount += 1
+    storeClientCipherTextTraceIdParam = traceId
     return storeClientCipherTextReturnValue ?? false
   }
 
@@ -282,22 +298,22 @@ class PortalApiMock: PortalApiProtocol {
   }
 
   var buildEip115TransactionReturnValue: PortalSwift.BuildEip115TransactionResponse?
-  func buildEip155Transaction(chainId _: String, params _: PortalSwift.BuildTransactionParam) async throws -> PortalSwift.BuildEip115TransactionResponse {
+  func buildEip155Transaction(chainId _: String, params _: PortalSwift.BuildTransactionParam, traceId _: String?) async throws -> PortalSwift.BuildEip115TransactionResponse {
     return buildEip115TransactionReturnValue ?? PortalSwift.BuildEip115TransactionResponse.stub()
   }
 
   var buildSolanaTransactionReturnValue: PortalSwift.BuildSolanaTransactionResponse?
-  func buildSolanaTransaction(chainId _: String, params _: PortalSwift.BuildTransactionParam) async throws -> PortalSwift.BuildSolanaTransactionResponse {
+  func buildSolanaTransaction(chainId _: String, params _: PortalSwift.BuildTransactionParam, traceId _: String?) async throws -> PortalSwift.BuildSolanaTransactionResponse {
     return buildSolanaTransactionReturnValue ?? PortalSwift.BuildSolanaTransactionResponse.stub()
   }
 
   var buildBitcoinP2wpkhTransactionReturnValue: PortalSwift.BuildBitcoinP2wpkhTransactionResponse?
-  func buildBitcoinP2wpkhTransaction(chainId _: String, params _: PortalSwift.BuildTransactionParam) async throws -> PortalSwift.BuildBitcoinP2wpkhTransactionResponse {
+  func buildBitcoinP2wpkhTransaction(chainId _: String, params _: PortalSwift.BuildTransactionParam, traceId _: String?) async throws -> PortalSwift.BuildBitcoinP2wpkhTransactionResponse {
     return buildBitcoinP2wpkhTransactionReturnValue ?? PortalSwift.BuildBitcoinP2wpkhTransactionResponse.stub()
   }
 
   var broadcastBitcoinP2wpkhTransactionReturnValue: PortalSwift.BroadcastBitcoinP2wpkhTransactionResponse?
-  func broadcastBitcoinP2wpkhTransaction(chainId _: String, params _: PortalSwift.BroadcastParam) async throws -> PortalSwift.BroadcastBitcoinP2wpkhTransactionResponse {
+  func broadcastBitcoinP2wpkhTransaction(chainId _: String, params _: PortalSwift.BroadcastParam, traceId _: String?) async throws -> PortalSwift.BroadcastBitcoinP2wpkhTransactionResponse {
     return broadcastBitcoinP2wpkhTransactionReturnValue ?? PortalSwift.BroadcastBitcoinP2wpkhTransactionResponse.stub()
   }
 
@@ -306,7 +322,9 @@ class PortalApiMock: PortalApiProtocol {
     return getAssetsReturnValue ?? PortalSwift.AssetsResponse.stub()
   }
 
-  func getWalletCapabilities() async throws -> PortalSwift.WalletCapabilitiesResponse {
+  var getWalletCapabilitiesTraceIdParam: String?
+  func getWalletCapabilities(traceId: String?) async throws -> PortalSwift.WalletCapabilitiesResponse {
+    getWalletCapabilitiesTraceIdParam = traceId
     return [:]
   }
 }

--- a/Tests/PortalSwiftTests/PortalApi/PortalApiSpy.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalApiSpy.swift
@@ -17,6 +17,7 @@ class PortalApiSpy: PortalApiProtocol {
   var blockaid: any PortalSwift.PortalBlockaidApiProtocol
   var delegations: any PortalSwift.PortalDelegationsApiProtocol
   var evmAccountType: any PortalSwift.PortalEvmAccountTypeApiProtocol
+  var noah: any PortalSwift.PortalNoahApiProtocol
 
   init(
     yieldxyz: any PortalSwift.PortalYieldXyzApiProtocol = PortalYieldXyzApiSpy(),
@@ -25,7 +26,8 @@ class PortalApiSpy: PortalApiProtocol {
     hypernative: any PortalSwift.PortalHypernativeApiProtocol = PortalHypernativeApiMock(),
     blockaid: any PortalSwift.PortalBlockaidApiProtocol = PortalBlockaidApiMock(),
     delegations: any PortalSwift.PortalDelegationsApiProtocol = PortalDelegationsApiMock(),
-    evmAccountType: any PortalSwift.PortalEvmAccountTypeApiProtocol = PortalEvmAccountTypeApiMock()
+    evmAccountType: any PortalSwift.PortalEvmAccountTypeApiProtocol = PortalEvmAccountTypeApiMock(),
+    noah: any PortalSwift.PortalNoahApiProtocol = PortalNoahApiSpy()
   ) {
     self.yieldxyz = yieldxyz
     self.lifi = lifi
@@ -34,6 +36,7 @@ class PortalApiSpy: PortalApiProtocol {
     self.blockaid = blockaid
     self.delegations = delegations
     self.evmAccountType = evmAccountType
+    self.noah = noah
   }
 
   // Property to track client access

--- a/Tests/PortalSwiftTests/PortalApi/PortalApiSpy.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalApiSpy.swift
@@ -202,6 +202,24 @@ class PortalApiSpy: PortalApiProtocol {
     refreshClientCallsCount += 1
   }
 
+  // Generate pre-generated shares method tracking
+  var generatePreGeneratedSharesCallsCount: Int = 0
+  var generatePreGeneratedSharesMetadataParam: String?
+  var generatePreGeneratedSharesReturnValue: GenerateApiResponse?
+  var generatePreGeneratedSharesErrorToThrow: Error?
+
+  public func generatePreGeneratedShares(metadataStr: String) async throws -> GenerateApiResponse {
+    generatePreGeneratedSharesCallsCount += 1
+    generatePreGeneratedSharesMetadataParam = metadataStr
+    if let error = generatePreGeneratedSharesErrorToThrow {
+      throw error
+    }
+    guard let value = generatePreGeneratedSharesReturnValue else {
+      throw URLError(.badURL)
+    }
+    return value
+  }
+
   // Simulate Transaction method tracking
   var simulateTransactionCallsCount: Int = 0
   var simulateTransactionTransactionParam: Any?

--- a/Tests/PortalSwiftTests/PortalApi/PortalApiSpy.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalApiSpy.swift
@@ -53,9 +53,11 @@ class PortalApiSpy: PortalApiProtocol {
 
   // Eject method tracking
   var ejectCallsCount: Int = 0
+  var ejectTraceIdParam: String?
 
-  public func eject() async throws -> String {
+  public func eject(traceId: String?) async throws -> String {
     ejectCallsCount += 1
+    ejectTraceIdParam = traceId
     return ""
   }
 
@@ -71,19 +73,23 @@ class PortalApiSpy: PortalApiProtocol {
 
   // Get Client method tracking
   var getClientCallsCount: Int = 0
+  var getClientTraceIdParam: String?
 
-  public func getClient() async throws -> ClientResponse {
+  public func getClient(traceId: String?) async throws -> ClientResponse {
     getClientCallsCount += 1
+    getClientTraceIdParam = traceId
     return ClientResponse.stub()
   }
 
   // Get Client Cipher Text method tracking
   var getClientCipherTextCallsCount: Int = 0
   var getClientCipherTextBackupSharePairIdParam: String?
+  var getClientCipherTextTraceIdParam: String?
 
-  public func getClientCipherText(_ backupSharePairId: String) async throws -> String {
+  public func getClientCipherText(_ backupSharePairId: String, traceId: String?) async throws -> String {
     getClientCipherTextCallsCount += 1
     getClientCipherTextBackupSharePairIdParam = backupSharePairId
+    getClientCipherTextTraceIdParam = traceId
     return ""
   }
 
@@ -190,30 +196,36 @@ class PortalApiSpy: PortalApiProtocol {
   var prepareEjectCallsCount: Int = 0
   var prepareEjectWalletIdParam: String?
   var prepareEjectBackupMethodParam: BackupMethods?
+  var prepareEjectTraceIdParam: String?
 
-  public func prepareEject(_ walletId: String, _ backupMethod: BackupMethods) async throws -> String {
+  public func prepareEject(_ walletId: String, _ backupMethod: BackupMethods, traceId: String?) async throws -> String {
     prepareEjectCallsCount += 1
     prepareEjectWalletIdParam = walletId
     prepareEjectBackupMethodParam = backupMethod
+    prepareEjectTraceIdParam = traceId
     return ""
   }
 
   // Refresh Client method tracking
   var refreshClientCallsCount: Int = 0
+  var refreshClientTraceIdParam: String?
 
-  public func refreshClient() async throws {
+  public func refreshClient(traceId: String?) async throws {
     refreshClientCallsCount += 1
+    refreshClientTraceIdParam = traceId
   }
 
   // Generate pre-generated shares method tracking
   var generatePreGeneratedSharesCallsCount: Int = 0
   var generatePreGeneratedSharesMetadataParam: String?
+  var generatePreGeneratedSharesTraceIdParam: String?
   var generatePreGeneratedSharesReturnValue: GenerateApiResponse?
   var generatePreGeneratedSharesErrorToThrow: Error?
 
-  public func generatePreGeneratedShares(metadataStr: String) async throws -> GenerateApiResponse {
+  public func generatePreGeneratedShares(metadataStr: String, traceId: String?) async throws -> GenerateApiResponse {
     generatePreGeneratedSharesCallsCount += 1
     generatePreGeneratedSharesMetadataParam = metadataStr
+    generatePreGeneratedSharesTraceIdParam = traceId
     if let error = generatePreGeneratedSharesErrorToThrow {
       throw error
     }
@@ -240,12 +252,14 @@ class PortalApiSpy: PortalApiProtocol {
   var updateShareStatusTypeParam: PortalSharePairType?
   var updateShareStatusStatusParam: SharePairUpdateStatus?
   var updateShareStatusSharePairIdsParam: [String]?
+  var updateShareStatusTraceIdParam: String?
 
-  public func updateShareStatus(_ type: PortalSharePairType, status: SharePairUpdateStatus, sharePairIds: [String]) async throws {
+  public func updateShareStatus(_ type: PortalSharePairType, status: SharePairUpdateStatus, sharePairIds: [String], traceId: String?) async throws {
     updateShareStatusCallsCount += 1
     updateShareStatusTypeParam = type
     updateShareStatusStatusParam = status
     updateShareStatusSharePairIdsParam = sharePairIds
+    updateShareStatusTraceIdParam = traceId
   }
 
   // getClient method with completion tracking
@@ -364,11 +378,13 @@ class PortalApiSpy: PortalApiProtocol {
   var storeClientCipherTextCallsCount: Int = 0
   var storeClientCipherTextBackupSharePairIdParam: String?
   var storeClientCipherTextCipherTextParam: String?
+  var storeClientCipherTextTraceIdParam: String?
 
-  func storeClientCipherText(_ backupSharePairId: String, cipherText: String) async throws -> Bool {
+  func storeClientCipherText(_ backupSharePairId: String, cipherText: String, traceId: String?) async throws -> Bool {
     storeClientCipherTextCallsCount += 1
     storeClientCipherTextBackupSharePairIdParam = backupSharePairId
     storeClientCipherTextCipherTextParam = cipherText
+    storeClientCipherTextTraceIdParam = traceId
 
     return true
   }
@@ -414,11 +430,13 @@ class PortalApiSpy: PortalApiProtocol {
   var buildEip155TransactionCallsCount: Int = 0
   var buildEip155TransactionChainIdParam: String?
   var buildEip155TransactionParams: PortalSwift.BuildTransactionParam?
+  var buildEip155TransactionTraceIdParam: String?
 
-  func buildEip155Transaction(chainId: String, params: PortalSwift.BuildTransactionParam) async throws -> PortalSwift.BuildEip115TransactionResponse {
+  func buildEip155Transaction(chainId: String, params: PortalSwift.BuildTransactionParam, traceId: String?) async throws -> PortalSwift.BuildEip115TransactionResponse {
     buildEip155TransactionCallsCount += 1
     buildEip155TransactionChainIdParam = chainId
     buildEip155TransactionParams = params
+    buildEip155TransactionTraceIdParam = traceId
     return PortalSwift.BuildEip115TransactionResponse.stub()
   }
 
@@ -426,11 +444,13 @@ class PortalApiSpy: PortalApiProtocol {
   var buildSolanaTransactionCallsCount: Int = 0
   var buildSolanaTransactionChainIdParam: String?
   var buildSolanaTransactionParams: PortalSwift.BuildTransactionParam?
+  var buildSolanaTransactionTraceIdParam: String?
 
-  func buildSolanaTransaction(chainId: String, params: PortalSwift.BuildTransactionParam) async throws -> PortalSwift.BuildSolanaTransactionResponse {
+  func buildSolanaTransaction(chainId: String, params: PortalSwift.BuildTransactionParam, traceId: String?) async throws -> PortalSwift.BuildSolanaTransactionResponse {
     buildSolanaTransactionCallsCount += 1
     buildSolanaTransactionChainIdParam = chainId
     buildSolanaTransactionParams = params
+    buildSolanaTransactionTraceIdParam = traceId
     return PortalSwift.BuildSolanaTransactionResponse.stub()
   }
 
@@ -439,15 +459,18 @@ class PortalApiSpy: PortalApiProtocol {
   var buildBitcoinP2wpkhTransactionCallsCount: Int = 0
   var buildBitcoinP2wpkhTransactionChainIdParam: String?
   var buildBitcoinP2wpkhTransactionParams: PortalSwift.BuildTransactionParam?
+  var buildBitcoinP2wpkhTransactionTraceIdParam: String?
   var buildBitcoinP2wpkhTransactionReturnValue: PortalSwift.BuildBitcoinP2wpkhTransactionResponse?
 
   func buildBitcoinP2wpkhTransaction(
     chainId: String,
-    params: PortalSwift.BuildTransactionParam
+    params: PortalSwift.BuildTransactionParam,
+    traceId: String?
   ) async throws -> PortalSwift.BuildBitcoinP2wpkhTransactionResponse {
     buildBitcoinP2wpkhTransactionCallsCount += 1
     buildBitcoinP2wpkhTransactionChainIdParam = chainId
     buildBitcoinP2wpkhTransactionParams = params
+    buildBitcoinP2wpkhTransactionTraceIdParam = traceId
     return buildBitcoinP2wpkhTransactionReturnValue ?? PortalSwift.BuildBitcoinP2wpkhTransactionResponse.stub()
   }
 
@@ -456,14 +479,17 @@ class PortalApiSpy: PortalApiProtocol {
   var broadcastBitcoinP2wpkhTransactionCallsCount: Int = 0
   var broadcastBitcoinP2wpkhTransactionChainIdParam: String?
   var broadcastBitcoinP2wpkhTransactionParams: PortalSwift.BroadcastParam?
+  var broadcastBitcoinP2wpkhTransactionTraceIdParam: String?
 
   func broadcastBitcoinP2wpkhTransaction(
     chainId: String,
-    params: PortalSwift.BroadcastParam
+    params: PortalSwift.BroadcastParam,
+    traceId: String?
   ) async throws -> PortalSwift.BroadcastBitcoinP2wpkhTransactionResponse {
     broadcastBitcoinP2wpkhTransactionCallsCount += 1
     broadcastBitcoinP2wpkhTransactionChainIdParam = chainId
     broadcastBitcoinP2wpkhTransactionParams = params
+    broadcastBitcoinP2wpkhTransactionTraceIdParam = traceId
     return PortalSwift.BroadcastBitcoinP2wpkhTransactionResponse.stub()
   }
 
@@ -479,9 +505,11 @@ class PortalApiSpy: PortalApiProtocol {
 
   // getWalletCapabilities method tracking
   var getWalletCapabilitiesCallsCount: Int = 0
+  var getWalletCapabilitiesTraceIdParam: String?
 
-  func getWalletCapabilities() async throws -> PortalSwift.WalletCapabilitiesResponse {
+  func getWalletCapabilities(traceId: String?) async throws -> PortalSwift.WalletCapabilitiesResponse {
     getWalletCapabilitiesCallsCount += 1
+    getWalletCapabilitiesTraceIdParam = traceId
     return PortalSwift.WalletCapabilitiesResponse.stub()
   }
 }

--- a/Tests/PortalSwiftTests/PortalApi/PortalEvmAccountTypeApiMock.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalEvmAccountTypeApiMock.swift
@@ -15,10 +15,12 @@ final class PortalEvmAccountTypeApiMock: PortalEvmAccountTypeApiProtocol {
   var getStatusError: Error?
   var getStatusCallCount = 0
   var getStatusChainId: String?
+  var getStatusTraceId: String?
 
-  func getStatus(chainId: String) async throws -> EvmAccountTypeResponse {
+  func getStatus(chainId: String, traceId: String? = nil) async throws -> EvmAccountTypeResponse {
     getStatusCallCount += 1
     getStatusChainId = chainId
+    getStatusTraceId = traceId
     if let error = getStatusError {
       throw error
     }
@@ -35,11 +37,13 @@ final class PortalEvmAccountTypeApiMock: PortalEvmAccountTypeApiProtocol {
   var buildAuthorizationListCallCount = 0
   var buildAuthorizationListChainId: String?
   var buildAuthorizationListSubsidize: Bool?
+  var buildAuthorizationListTraceId: String?
 
-  func buildAuthorizationList(chainId: String, subsidize: Bool? = nil) async throws -> BuildAuthorizationListResponse {
+  func buildAuthorizationList(chainId: String, subsidize: Bool? = nil, traceId: String? = nil) async throws -> BuildAuthorizationListResponse {
     buildAuthorizationListCallCount += 1
     buildAuthorizationListChainId = chainId
     buildAuthorizationListSubsidize = subsidize
+    buildAuthorizationListTraceId = traceId
     if let error = buildAuthorizationListError {
       throw error
     }
@@ -60,12 +64,14 @@ final class PortalEvmAccountTypeApiMock: PortalEvmAccountTypeApiProtocol {
   var buildAuthorizationTransactionChainId: String?
   var buildAuthorizationTransactionSignature: String?
   var buildAuthorizationTransactionSubsidize: Bool?
+  var buildAuthorizationTransactionTraceId: String?
 
-  func buildAuthorizationTransaction(chainId: String, signature: String, subsidize: Bool? = nil) async throws -> BuildAuthorizationTransactionResponse {
+  func buildAuthorizationTransaction(chainId: String, signature: String, subsidize: Bool? = nil, traceId: String? = nil) async throws -> BuildAuthorizationTransactionResponse {
     buildAuthorizationTransactionCallCount += 1
     buildAuthorizationTransactionChainId = chainId
     buildAuthorizationTransactionSignature = signature
     buildAuthorizationTransactionSubsidize = subsidize
+    buildAuthorizationTransactionTraceId = traceId
     if let error = buildAuthorizationTransactionError {
       throw error
     }

--- a/Tests/PortalSwiftTests/PortalApi/PortalLifiTradingApiMock.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalLifiTradingApiMock.swift
@@ -21,6 +21,16 @@ final class PortalLifiTradingApiMock: PortalLifiTradingApiProtocol {
   var getStatusError: Error?
   var getRouteStepError: Error?
 
+  /// Optional sequence of `getStatus` outcomes consumed in order (one per call). When non-empty it
+  /// takes precedence over `getStatusError`/`getStatusReturnValue`; when exhausted it falls back to
+  /// them. Enables testing the transient-error-then-recover branch of the polling loop.
+  var getStatusResultSequence: [Swift.Result<LifiStatusResponse, Error>] = []
+
+  /// Optional sequence of `getRouteStep` outcomes consumed in order (one per call). When non-empty
+  /// it takes precedence over `getRouteStepError`/`getRouteStepReturnValue`; when exhausted it falls
+  /// back to them. Enables returning a distinct response per step in multi-step tests.
+  var getRouteStepResultSequence: [Swift.Result<LifiStepTransactionResponse, Error>] = []
+
   // Thread-safe serial queue for synchronizing access to counters and parameters
   private let queue = DispatchQueue(label: "com.portal.PortalLifiTradingApiMock.queue")
 
@@ -91,9 +101,16 @@ final class PortalLifiTradingApiMock: PortalLifiTradingApiProtocol {
   }
 
   func getStatus(request: LifiStatusRequest) async throws -> LifiStatusResponse {
-    queue.sync {
+    let queued: Swift.Result<LifiStatusResponse, Error>? = queue.sync {
       _getStatusCalls += 1
       _getStatusRequestParam = request
+      return getStatusResultSequence.isEmpty ? nil : getStatusResultSequence.removeFirst()
+    }
+    if let queued {
+      switch queued {
+      case let .success(response): return response
+      case let .failure(error): throw error
+      }
     }
     if let error = getStatusError {
       throw error
@@ -102,9 +119,16 @@ final class PortalLifiTradingApiMock: PortalLifiTradingApiProtocol {
   }
 
   func getRouteStep(request: LifiStepTransactionRequest) async throws -> LifiStepTransactionResponse {
-    queue.sync {
+    let queued: Swift.Result<LifiStepTransactionResponse, Error>? = queue.sync {
       _getRouteStepCalls += 1
       _getRouteStepRequestParam = request
+      return getRouteStepResultSequence.isEmpty ? nil : getRouteStepResultSequence.removeFirst()
+    }
+    if let queued {
+      switch queued {
+      case let .success(response): return response
+      case let .failure(error): throw error
+      }
     }
     if let error = getRouteStepError {
       throw error
@@ -135,5 +159,8 @@ final class PortalLifiTradingApiMock: PortalLifiTradingApiProtocol {
     getQuoteError = nil
     getStatusError = nil
     getRouteStepError = nil
+
+    getStatusResultSequence = []
+    getRouteStepResultSequence = []
   }
 }

--- a/Tests/PortalSwiftTests/PortalApi/PortalNoahApiMock.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalNoahApiMock.swift
@@ -1,0 +1,78 @@
+//
+//  PortalNoahApiMock.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+@testable import PortalSwift
+
+final class PortalNoahApiMock: PortalNoahApiProtocol {
+  // Configurable return values
+  var initiateKycReturnValue: NoahInitiateKycResponse?
+  var initiatePayinReturnValue: NoahInitiatePayinResponse?
+  var simulatePayinReturnValue: NoahSimulatePayinResponse?
+  var getPaymentMethodsReturnValue: NoahGetPaymentMethodsResponse?
+  var getPayoutCountriesReturnValue: NoahGetPayoutCountriesResponse?
+  var getPayoutChannelsReturnValue: NoahGetPayoutChannelsResponse?
+  var getPayoutChannelFormReturnValue: NoahGetPayoutChannelFormResponse?
+  var getPayoutQuoteReturnValue: NoahGetPayoutQuoteResponse?
+  var initiatePayoutReturnValue: NoahInitiatePayoutResponse?
+
+  // Call counters
+  var initiateKycCalls = 0
+  var initiatePayinCalls = 0
+  var simulatePayinCalls = 0
+  var getPaymentMethodsCalls = 0
+  var getPayoutCountriesCalls = 0
+  var getPayoutChannelsCalls = 0
+  var getPayoutChannelFormCalls = 0
+  var getPayoutQuoteCalls = 0
+  var initiatePayoutCalls = 0
+
+  func initiateKyc(request _: NoahInitiateKycRequest) async throws -> NoahInitiateKycResponse {
+    initiateKycCalls += 1
+    return initiateKycReturnValue ?? NoahInitiateKycResponse.stub()
+  }
+
+  func initiatePayin(request _: NoahInitiatePayinRequest) async throws -> NoahInitiatePayinResponse {
+    initiatePayinCalls += 1
+    return initiatePayinReturnValue ?? NoahInitiatePayinResponse.stub()
+  }
+
+  func simulatePayin(request _: NoahSimulatePayinRequest) async throws -> NoahSimulatePayinResponse {
+    simulatePayinCalls += 1
+    return simulatePayinReturnValue ?? NoahSimulatePayinResponse.stub()
+  }
+
+  func getPaymentMethods(request _: NoahGetPaymentMethodsRequest) async throws -> NoahGetPaymentMethodsResponse {
+    getPaymentMethodsCalls += 1
+    return getPaymentMethodsReturnValue ?? NoahGetPaymentMethodsResponse.stub()
+  }
+
+  func getPayoutCountries() async throws -> NoahGetPayoutCountriesResponse {
+    getPayoutCountriesCalls += 1
+    return getPayoutCountriesReturnValue ?? NoahGetPayoutCountriesResponse.stub()
+  }
+
+  func getPayoutChannels(request _: NoahGetPayoutChannelsRequest) async throws -> NoahGetPayoutChannelsResponse {
+    getPayoutChannelsCalls += 1
+    return getPayoutChannelsReturnValue ?? NoahGetPayoutChannelsResponse.stub()
+  }
+
+  func getPayoutChannelForm(channelId _: String) async throws -> NoahGetPayoutChannelFormResponse {
+    getPayoutChannelFormCalls += 1
+    return getPayoutChannelFormReturnValue ?? NoahGetPayoutChannelFormResponse.stub()
+  }
+
+  func getPayoutQuote(request _: NoahGetPayoutQuoteRequest) async throws -> NoahGetPayoutQuoteResponse {
+    getPayoutQuoteCalls += 1
+    return getPayoutQuoteReturnValue ?? NoahGetPayoutQuoteResponse.stub()
+  }
+
+  func initiatePayout(request _: NoahInitiatePayoutRequest) async throws -> NoahInitiatePayoutResponse {
+    initiatePayoutCalls += 1
+    return initiatePayoutReturnValue ?? NoahInitiatePayoutResponse.stub()
+  }
+}

--- a/Tests/PortalSwiftTests/PortalApi/PortalNoahApiSpy.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalNoahApiSpy.swift
@@ -1,0 +1,108 @@
+//
+//  PortalNoahApiSpy.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+@testable import PortalSwift
+
+final class PortalNoahApiSpy: PortalNoahApiProtocol {
+  // MARK: - initiateKyc
+
+  var initiateKycCallsCount = 0
+  var initiateKycRequestParam: NoahInitiateKycRequest?
+  var initiateKycReturnValue: NoahInitiateKycResponse = .stub()
+  func initiateKyc(request: NoahInitiateKycRequest) async throws -> NoahInitiateKycResponse {
+    initiateKycCallsCount += 1
+    initiateKycRequestParam = request
+    return initiateKycReturnValue
+  }
+
+  // MARK: - initiatePayin
+
+  var initiatePayinCallsCount = 0
+  var initiatePayinRequestParam: NoahInitiatePayinRequest?
+  var initiatePayinReturnValue: NoahInitiatePayinResponse = .stub()
+  func initiatePayin(request: NoahInitiatePayinRequest) async throws -> NoahInitiatePayinResponse {
+    initiatePayinCallsCount += 1
+    initiatePayinRequestParam = request
+    return initiatePayinReturnValue
+  }
+
+  // MARK: - simulatePayin
+
+  var simulatePayinCallsCount = 0
+  var simulatePayinRequestParam: NoahSimulatePayinRequest?
+  var simulatePayinReturnValue: NoahSimulatePayinResponse = .stub()
+  func simulatePayin(request: NoahSimulatePayinRequest) async throws -> NoahSimulatePayinResponse {
+    simulatePayinCallsCount += 1
+    simulatePayinRequestParam = request
+    return simulatePayinReturnValue
+  }
+
+  // MARK: - getPaymentMethods
+
+  var getPaymentMethodsCallsCount = 0
+  var getPaymentMethodsRequestParam: NoahGetPaymentMethodsRequest?
+  var getPaymentMethodsReturnValue: NoahGetPaymentMethodsResponse = .stub()
+  func getPaymentMethods(request: NoahGetPaymentMethodsRequest) async throws -> NoahGetPaymentMethodsResponse {
+    getPaymentMethodsCallsCount += 1
+    getPaymentMethodsRequestParam = request
+    return getPaymentMethodsReturnValue
+  }
+
+  // MARK: - getPayoutCountries
+
+  var getPayoutCountriesCallsCount = 0
+  var getPayoutCountriesReturnValue: NoahGetPayoutCountriesResponse = .stub()
+  func getPayoutCountries() async throws -> NoahGetPayoutCountriesResponse {
+    getPayoutCountriesCallsCount += 1
+    return getPayoutCountriesReturnValue
+  }
+
+  // MARK: - getPayoutChannels
+
+  var getPayoutChannelsCallsCount = 0
+  var getPayoutChannelsRequestParam: NoahGetPayoutChannelsRequest?
+  var getPayoutChannelsReturnValue: NoahGetPayoutChannelsResponse = .stub()
+  func getPayoutChannels(request: NoahGetPayoutChannelsRequest) async throws -> NoahGetPayoutChannelsResponse {
+    getPayoutChannelsCallsCount += 1
+    getPayoutChannelsRequestParam = request
+    return getPayoutChannelsReturnValue
+  }
+
+  // MARK: - getPayoutChannelForm
+
+  var getPayoutChannelFormCallsCount = 0
+  var getPayoutChannelFormChannelIdParam: String?
+  var getPayoutChannelFormReturnValue: NoahGetPayoutChannelFormResponse = .stub()
+  func getPayoutChannelForm(channelId: String) async throws -> NoahGetPayoutChannelFormResponse {
+    getPayoutChannelFormCallsCount += 1
+    getPayoutChannelFormChannelIdParam = channelId
+    return getPayoutChannelFormReturnValue
+  }
+
+  // MARK: - getPayoutQuote
+
+  var getPayoutQuoteCallsCount = 0
+  var getPayoutQuoteRequestParam: NoahGetPayoutQuoteRequest?
+  var getPayoutQuoteReturnValue: NoahGetPayoutQuoteResponse = .stub()
+  func getPayoutQuote(request: NoahGetPayoutQuoteRequest) async throws -> NoahGetPayoutQuoteResponse {
+    getPayoutQuoteCallsCount += 1
+    getPayoutQuoteRequestParam = request
+    return getPayoutQuoteReturnValue
+  }
+
+  // MARK: - initiatePayout
+
+  var initiatePayoutCallsCount = 0
+  var initiatePayoutRequestParam: NoahInitiatePayoutRequest?
+  var initiatePayoutReturnValue: NoahInitiatePayoutResponse = .stub()
+  func initiatePayout(request: NoahInitiatePayoutRequest) async throws -> NoahInitiatePayoutResponse {
+    initiatePayoutCallsCount += 1
+    initiatePayoutRequestParam = request
+    return initiatePayoutReturnValue
+  }
+}

--- a/Tests/PortalSwiftTests/PortalApi/PortalYieldXyzApiMock.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalYieldXyzApiMock.swift
@@ -18,6 +18,8 @@ final class PortalYieldXyzApiMock: PortalYieldXyzApiProtocol {
   var getHistoricalYieldActionsReturnValue: YieldXyzGetHistoricalActionsResponse?
   var getYieldTransactionReturnValue: YieldXyzGetTransactionResponse?
   var submitTransactionHashReturnValue: YieldXyzTrackTransactionResponse?
+  var getYieldDefaultsReturnValue: YieldXyzGetDefaultsResponse?
+  var getYieldValidatorsReturnValue: YieldXyzGetValidatorsResponse?
 
   // Call counters
   var getYieldsCalls = 0
@@ -28,6 +30,12 @@ final class PortalYieldXyzApiMock: PortalYieldXyzApiProtocol {
   var getHistoricalYieldActionsCalls = 0
   var getYieldTransactionCalls = 0
   var submitTransactionHashCalls = 0
+  var getYieldDefaultsCalls = 0
+  var getYieldValidatorsCalls = 0
+
+  // Call parameters
+  var getYieldDefaultsIncludeOpportunitiesParam: Bool?
+  var getYieldValidatorsYieldIdParam: String?
 
   func getYields(request _: YieldXyzGetYieldsRequest) async throws -> YieldXyzGetYieldsResponse {
     getYieldsCalls += 1
@@ -67,5 +75,17 @@ final class PortalYieldXyzApiMock: PortalYieldXyzApiProtocol {
   func submitTransactionHash(request _: YieldXyzTrackTransactionRequest) async throws -> YieldXyzTrackTransactionResponse {
     submitTransactionHashCalls += 1
     return submitTransactionHashReturnValue ?? YieldXyzTrackTransactionResponse.stub()
+  }
+
+  func getYieldDefaults(includeOpportunities: Bool?) async throws -> YieldXyzGetDefaultsResponse {
+    getYieldDefaultsCalls += 1
+    getYieldDefaultsIncludeOpportunitiesParam = includeOpportunities
+    return getYieldDefaultsReturnValue ?? YieldXyzGetDefaultsResponse.stub()
+  }
+
+  func getYieldValidators(yieldId: String) async throws -> YieldXyzGetValidatorsResponse {
+    getYieldValidatorsCalls += 1
+    getYieldValidatorsYieldIdParam = yieldId
+    return getYieldValidatorsReturnValue ?? YieldXyzGetValidatorsResponse.stub()
   }
 }

--- a/Tests/PortalSwiftTests/PortalApi/PortalYieldXyzApiSpy.swift
+++ b/Tests/PortalSwiftTests/PortalApi/PortalYieldXyzApiSpy.swift
@@ -96,4 +96,26 @@ final class PortalYieldXyzApiSpy: PortalYieldXyzApiProtocol {
     submitTransactionHashRequestParam = request
     return submitTransactionHashReturnValue
   }
+
+  // MARK: - getYieldDefaults
+
+  var getYieldDefaultsCallsCount = 0
+  var getYieldDefaultsIncludeOpportunitiesParam: Bool?
+  var getYieldDefaultsReturnValue: YieldXyzGetDefaultsResponse = .stub()
+  func getYieldDefaults(includeOpportunities: Bool?) async throws -> YieldXyzGetDefaultsResponse {
+    getYieldDefaultsCallsCount += 1
+    getYieldDefaultsIncludeOpportunitiesParam = includeOpportunities
+    return getYieldDefaultsReturnValue
+  }
+
+  // MARK: - getYieldValidators
+
+  var getYieldValidatorsCallsCount = 0
+  var getYieldValidatorsYieldIdParam: String?
+  var getYieldValidatorsReturnValue: YieldXyzGetValidatorsResponse = .stub()
+  func getYieldValidators(yieldId: String) async throws -> YieldXyzGetValidatorsResponse {
+    getYieldValidatorsCallsCount += 1
+    getYieldValidatorsYieldIdParam = yieldId
+    return getYieldValidatorsReturnValue
+  }
 }

--- a/Tests/PortalSwiftTests/PortalMPC/PortalMpcSpy.swift
+++ b/Tests/PortalSwiftTests/PortalMPC/PortalMpcSpy.swift
@@ -101,7 +101,8 @@ class PortalMpcSpy: PortalMpcProtocol {
     backupUsingProgressCallbackParam = usingProgressCallback
     return PortalMpcBackupResponse(
       cipherText: MockConstants.mockCiphertext,
-      shareIds: [MockConstants.mockMpcShareId, MockConstants.mockMpcShareId]
+      shareIds: [MockConstants.mockMpcShareId, MockConstants.mockMpcShareId],
+      traceId: generateTraceId()
     )
   }
 
@@ -142,7 +143,8 @@ class PortalMpcSpy: PortalMpcProtocol {
       "",
       PortalMpcBackupResponse(
         cipherText: MockConstants.mockCiphertext,
-        shareIds: [MockConstants.mockMpcShareId, MockConstants.mockMpcShareId]
+        shareIds: [MockConstants.mockMpcShareId, MockConstants.mockMpcShareId],
+        traceId: generateTraceId()
       )
     )
   }

--- a/Tests/PortalSwiftTests/Ramps/NoahCodableTests.swift
+++ b/Tests/PortalSwiftTests/Ramps/NoahCodableTests.swift
@@ -1,0 +1,351 @@
+//
+//  NoahCodableTests.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import AnyCodable
+import Foundation
+@testable import PortalSwift
+import XCTest
+
+final class NoahCodableTests: XCTestCase {
+  private let encoder = JSONEncoder()
+  private let decoder = JSONDecoder()
+}
+
+// MARK: - Request round-trips
+
+extension NoahCodableTests {
+  func test_initiateKycRequest_roundTrips() throws {
+    let original = NoahInitiateKycRequest.stub()
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahInitiateKycRequest.self, from: data)
+    XCTAssertEqual(decoded.returnUrl, original.returnUrl)
+    XCTAssertEqual(decoded.customerType, original.customerType)
+    XCTAssertEqual(decoded.fiatOptions?.first?.fiatCurrencyCode, "USD")
+    XCTAssertNotNil(decoded.metadata)
+    XCTAssertNotNil(decoded.form)
+  }
+
+  func test_initiatePayinRequest_roundTrips() throws {
+    let original = NoahInitiatePayinRequest.stub()
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahInitiatePayinRequest.self, from: data)
+    XCTAssertEqual(decoded.fiatCurrency, original.fiatCurrency)
+    XCTAssertEqual(decoded.cryptoCurrency, original.cryptoCurrency)
+    XCTAssertEqual(decoded.network, original.network)
+    XCTAssertEqual(decoded.destinationAddress, original.destinationAddress)
+  }
+
+  func test_simulatePayinRequest_roundTrips() throws {
+    let original = NoahSimulatePayinRequest.stub()
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahSimulatePayinRequest.self, from: data)
+    XCTAssertEqual(decoded.paymentMethodId, original.paymentMethodId)
+    XCTAssertEqual(decoded.fiatAmount, original.fiatAmount)
+    XCTAssertEqual(decoded.fiatCurrency, original.fiatCurrency)
+  }
+
+  func test_getPayoutChannelsRequest_roundTrips() throws {
+    let original = NoahGetPayoutChannelsRequest.stub()
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahGetPayoutChannelsRequest.self, from: data)
+    XCTAssertEqual(decoded.country, original.country)
+    XCTAssertEqual(decoded.cryptoCurrency, original.cryptoCurrency)
+    XCTAssertEqual(decoded.fiatCurrency, original.fiatCurrency)
+    XCTAssertEqual(decoded.fiatAmount, original.fiatAmount)
+    XCTAssertEqual(decoded.pageToken, original.pageToken)
+  }
+
+  func test_getPaymentMethodsRequest_roundTrips() throws {
+    let original = NoahGetPaymentMethodsRequest(pageSize: 25, pageToken: "tok-1", capability: .payinTo)
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahGetPaymentMethodsRequest.self, from: data)
+    XCTAssertEqual(decoded.pageSize, 25)
+    XCTAssertEqual(decoded.pageToken, "tok-1")
+    XCTAssertEqual(decoded.capability, .payinTo)
+  }
+
+  func test_getPayoutQuoteRequest_roundTrips() throws {
+    let original = NoahGetPayoutQuoteRequest.stub()
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahGetPayoutQuoteRequest.self, from: data)
+    XCTAssertEqual(decoded.channelId, original.channelId)
+    XCTAssertEqual(decoded.fiatAmount, original.fiatAmount)
+    XCTAssertEqual(decoded.paymentMethodId, original.paymentMethodId)
+    XCTAssertNotNil(decoded.form)
+  }
+
+  func test_initiatePayoutRequest_roundTrips() throws {
+    let original = NoahInitiatePayoutRequest.stub()
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahInitiatePayoutRequest.self, from: data)
+    XCTAssertEqual(decoded.payoutId, original.payoutId)
+    XCTAssertEqual(decoded.sourceAddress, original.sourceAddress)
+    XCTAssertEqual(decoded.expiry, original.expiry)
+    XCTAssertEqual(decoded.nonce, original.nonce)
+    XCTAssertEqual(decoded.network, original.network)
+    guard case let .single(single)? = decoded.trigger else {
+      return XCTFail("Expected a single trigger variant")
+    }
+    XCTAssertEqual(single.type, "SingleOnchainDepositSourceTriggerInput")
+  }
+
+  func test_initiatePayoutRequest_quotedTrigger_roundTrips() throws {
+    let original = NoahInitiatePayoutRequest.stub(
+      trigger: .quoted(.stub()),
+      businessFee: .stub()
+    )
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahInitiatePayoutRequest.self, from: data)
+    guard case let .quoted(quoted)? = decoded.trigger else {
+      return XCTFail("Expected a quoted trigger variant")
+    }
+    XCTAssertEqual(quoted.type, "QuotedOnchainDepositSourceTriggerInput")
+    XCTAssertEqual(quoted.signedQuote, "signed-quote-1")
+    XCTAssertEqual(decoded.businessFee?.feePct, "1.5")
+  }
+
+  func test_initiatePayoutRequest_permanentTrigger_usesPascalCaseKeys() throws {
+    let original = NoahInitiatePayoutRequest.stub(trigger: .permanent(.stub(networkAgnostic: true)))
+    let data = try encoder.encode(original)
+    let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let trigger = try XCTUnwrap(json["trigger"] as? [String: Any])
+
+    XCTAssertEqual(trigger["Type"] as? String, "PermanentOnchainDepositSourceTriggerInput")
+    XCTAssertEqual(trigger["NetworkAgnostic"] as? Bool, true)
+    let conditions = try XCTUnwrap(trigger["Conditions"] as? [[String: Any]])
+    XCTAssertNotNil(conditions.first?["Network"])
+    // Permanent triggers must not carry amount conditions.
+    XCTAssertNil(conditions.first?["AmountConditions"])
+  }
+
+  func test_getPayoutQuoteRequest_cryptoAmountAndBusinessFee_roundTrips() throws {
+    let original = NoahGetPayoutQuoteRequest(
+      channelId: "ch-1",
+      cryptoCurrency: "USDC",
+      cryptoAmount: "50",
+      quoted: true,
+      businessFee: .stub()
+    )
+    XCTAssertNil(original.fiatAmount)
+    XCTAssertEqual(original.cryptoAmount, "50")
+
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahGetPayoutQuoteRequest.self, from: data)
+    XCTAssertNil(decoded.fiatAmount)
+    XCTAssertEqual(decoded.cryptoAmount, "50")
+    XCTAssertEqual(decoded.quoted, true)
+    XCTAssertEqual(decoded.businessFee?.fiatCurrency, "USD")
+
+    let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    XCTAssertNil(json["fiatAmount"])
+    let businessFee = try XCTUnwrap(json["businessFee"] as? [String: Any])
+    XCTAssertEqual(businessFee["FeePct"] as? String, "1.5")
+  }
+
+  func test_getPayoutQuoteRequest_fiatAmountInitializer_excludesCryptoAmount() throws {
+    let request = NoahGetPayoutQuoteRequest(
+      channelId: "ch-1",
+      cryptoCurrency: "USDC",
+      fiatAmount: "100.00"
+    )
+    XCTAssertEqual(request.fiatAmount, "100.00")
+    XCTAssertNil(request.cryptoAmount)
+
+    let data = try encoder.encode(request)
+    let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    XCTAssertEqual(json["fiatAmount"] as? String, "100.00")
+    XCTAssertNil(json["cryptoAmount"])
+  }
+
+  func test_getPayoutQuoteResponse_disclosureFields_roundTrip() throws {
+    let original = NoahGetPayoutQuoteResponse.stub(
+      data: .stub(cryptoCurrency: "USDC", fiatCurrency: "USD", fiatAmount: "100.00")
+    )
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahGetPayoutQuoteResponse.self, from: data)
+    XCTAssertEqual(decoded.data.cryptoCurrency, "USDC")
+    XCTAssertEqual(decoded.data.fiatCurrency, "USD")
+    XCTAssertEqual(decoded.data.fiatAmount, "100.00")
+  }
+
+  func test_initiatePayinRequest_businessFees_roundTrips() throws {
+    let original = NoahInitiatePayinRequest.stub(businessFees: ["BankAch": .stub()])
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahInitiatePayinRequest.self, from: data)
+    XCTAssertEqual(decoded.businessFees?["BankAch"]?.feeBase, "0.50")
+
+    let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let fees = try XCTUnwrap(json["businessFees"] as? [String: Any])
+    let ach = try XCTUnwrap(fees["BankAch"] as? [String: Any])
+    XCTAssertEqual(ach["FeeBase"] as? String, "0.50")
+  }
+
+  func test_initiatePayoutRequest_triggerUsesPascalCaseKeys() throws {
+    let original = NoahInitiatePayoutRequest.stub()
+    let data = try encoder.encode(original)
+    let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let trigger = try XCTUnwrap(json["trigger"] as? [String: Any])
+
+    XCTAssertEqual(trigger["Type"] as? String, "SingleOnchainDepositSourceTriggerInput")
+    XCTAssertNotNil(trigger["Conditions"])
+    XCTAssertNotNil(trigger["SourceAddress"])
+    XCTAssertNotNil(trigger["Expiry"])
+    XCTAssertNotNil(trigger["Nonce"])
+
+    let conditions = try XCTUnwrap(trigger["Conditions"] as? [[String: Any]])
+    let firstCondition = try XCTUnwrap(conditions.first)
+    XCTAssertNotNil(firstCondition["Network"])
+    let amountConditions = try XCTUnwrap(firstCondition["AmountConditions"] as? [[String: Any]])
+    let firstAmount = try XCTUnwrap(amountConditions.first)
+    XCTAssertEqual(firstAmount["ComparisonOperator"] as? String, "GTEQ")
+    XCTAssertNotNil(firstAmount["Value"])
+  }
+}
+
+// MARK: - Response round-trips
+
+extension NoahCodableTests {
+  func test_initiateKycResponse_roundTrips() throws {
+    let original = NoahInitiateKycResponse.stub()
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahInitiateKycResponse.self, from: data)
+    XCTAssertEqual(decoded.data.hostedUrl, original.data.hostedUrl)
+    XCTAssertNil(decoded.metadata)
+  }
+
+  func test_initiatePayinResponse_roundTrips() throws {
+    let original = NoahInitiatePayinResponse.stub()
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahInitiatePayinResponse.self, from: data)
+    XCTAssertEqual(decoded.data.payinId, original.data.payinId)
+    XCTAssertEqual(decoded.data.bankDetails.accountNumber, original.data.bankDetails.accountNumber)
+  }
+
+  func test_simulatePayinResponse_roundTrips() throws {
+    let original = NoahSimulatePayinResponse.stub()
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahSimulatePayinResponse.self, from: data)
+    XCTAssertEqual(decoded.data.fiatDepositId, original.data.fiatDepositId)
+  }
+
+  func test_getPaymentMethodsResponse_roundTrips() throws {
+    let original = NoahGetPaymentMethodsResponse.stub()
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahGetPaymentMethodsResponse.self, from: data)
+    XCTAssertEqual(decoded.data.paymentMethods.count, original.data.paymentMethods.count)
+    XCTAssertEqual(decoded.data.paymentMethods.first?.paymentMethodCategory, "Bank")
+    XCTAssertEqual(decoded.data.paymentMethods.first?.country, "US")
+    XCTAssertEqual(decoded.data.paymentMethods.first?.displayDetails.type, "BankAccount")
+  }
+
+  func test_getPayoutCountriesResponse_roundTrips() throws {
+    let original = NoahGetPayoutCountriesResponse.stub()
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahGetPayoutCountriesResponse.self, from: data)
+    XCTAssertEqual(decoded.data.countries["US"], original.data.countries["US"])
+    XCTAssertEqual(decoded.data.countries["GB"], original.data.countries["GB"])
+  }
+
+  func test_getPayoutChannelsResponse_roundTrips() throws {
+    let original = NoahGetPayoutChannelsResponse.stub()
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahGetPayoutChannelsResponse.self, from: data)
+    XCTAssertEqual(decoded.data.items.first?.id, original.data.items.first?.id)
+    XCTAssertEqual(decoded.data.items.first?.limits.minLimit, original.data.items.first?.limits.minLimit)
+    XCTAssertEqual(decoded.data.items.first?.paymentMethodCategory, "Bank")
+  }
+
+  func test_getPayoutChannelFormResponse_roundTrips() throws {
+    let original = NoahGetPayoutChannelFormResponse.stub()
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahGetPayoutChannelFormResponse.self, from: data)
+    XCTAssertEqual(decoded.data.formMetadata?.contentHash, original.data.formMetadata?.contentHash)
+    XCTAssertNotNil(decoded.data.formSchema)
+  }
+
+  func test_getPayoutQuoteResponse_roundTrips() throws {
+    let original = NoahGetPayoutQuoteResponse.stub(data: .stub(nextStep: .stub()))
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahGetPayoutQuoteResponse.self, from: data)
+    XCTAssertEqual(decoded.data.payoutId, original.data.payoutId)
+    XCTAssertEqual(decoded.data.nextStep?.stepId, "step-1")
+    XCTAssertEqual(decoded.data.nextStep?.stepType, .dataEntry)
+  }
+
+  func test_initiatePayoutResponse_roundTrips() throws {
+    let original = NoahInitiatePayoutResponse.stub()
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(NoahInitiatePayoutResponse.self, from: data)
+    XCTAssertEqual(decoded.data.destinationAddress, original.data.destinationAddress)
+    XCTAssertEqual(decoded.data.conditions?.count, original.data.conditions?.count)
+  }
+}
+
+// MARK: - Envelope behaviour
+
+extension NoahCodableTests {
+  func test_response_decodes_dataOnly_envelope() throws {
+    let json = """
+    { "data": { "hostedUrl": "https://noah.example.com/kyc/xyz" } }
+    """.data(using: .utf8)!
+
+    let decoded = try decoder.decode(NoahInitiateKycResponse.self, from: json)
+    XCTAssertEqual(decoded.data.hostedUrl, "https://noah.example.com/kyc/xyz")
+    XCTAssertNil(decoded.metadata)
+  }
+
+  func test_response_decodes_dataWithMetadata_envelope() throws {
+    let json = """
+    {
+      "data": { "hostedUrl": "https://x" },
+      "metadata": { "anything": "goes" }
+    }
+    """.data(using: .utf8)!
+
+    let decoded = try decoder.decode(NoahInitiateKycResponse.self, from: json)
+    XCTAssertEqual(decoded.data.hostedUrl, "https://x")
+    XCTAssertEqual(decoded.metadata?["anything"]?.value as? String, "goes")
+  }
+}
+
+// MARK: - AnyCodable fields
+
+extension NoahCodableTests {
+  func test_kycRequest_encodesAnyCodableMetadataAsJsonObject() throws {
+    let request = NoahInitiateKycRequest(
+      returnUrl: "https://example.com",
+      metadata: [
+        "userId": AnyCodable("user-1"),
+        "count": AnyCodable(42)
+      ]
+    )
+
+    let data = try encoder.encode(request)
+    let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let metadata = try XCTUnwrap(json["metadata"] as? [String: Any])
+    XCTAssertEqual(metadata["userId"] as? String, "user-1")
+    XCTAssertEqual(metadata["count"] as? Int, 42)
+  }
+
+  func test_payoutQuoteRequest_encodesAnyCodableFormAsJsonObject() throws {
+    let request = NoahGetPayoutQuoteRequest(
+      channelId: "ch-1",
+      cryptoCurrency: "USDC",
+      fiatAmount: "1",
+      form: [
+        "accountNumber": AnyCodable("1234"),
+        "country": AnyCodable("US")
+      ]
+    )
+
+    let data = try encoder.encode(request)
+    let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let form = try XCTUnwrap(json["form"] as? [String: Any])
+    XCTAssertEqual(form["accountNumber"] as? String, "1234")
+    XCTAssertEqual(form["country"] as? String, "US")
+  }
+}

--- a/Tests/PortalSwiftTests/Ramps/NoahMock.swift
+++ b/Tests/PortalSwiftTests/Ramps/NoahMock.swift
@@ -1,0 +1,97 @@
+//
+//  NoahMock.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+@testable import PortalSwift
+
+/// Mock implementation of `NoahProtocol` for testing purposes.
+final class NoahMock: NoahProtocol {
+  // Configurable return values
+  var initiateKycReturnValue: NoahInitiateKycResponse?
+  var initiatePayinReturnValue: NoahInitiatePayinResponse?
+  var simulatePayinReturnValue: NoahSimulatePayinResponse?
+  var getPaymentMethodsReturnValue: NoahGetPaymentMethodsResponse?
+  var getPayoutCountriesReturnValue: NoahGetPayoutCountriesResponse?
+  var getPayoutChannelsReturnValue: NoahGetPayoutChannelsResponse?
+  var getPayoutChannelFormReturnValue: NoahGetPayoutChannelFormResponse?
+  var getPayoutQuoteReturnValue: NoahGetPayoutQuoteResponse?
+  var initiatePayoutReturnValue: NoahInitiatePayoutResponse?
+
+  // Call counters
+  var initiateKycCalls = 0
+  var initiatePayinCalls = 0
+  var simulatePayinCalls = 0
+  var getPaymentMethodsCalls = 0
+  var getPayoutCountriesCalls = 0
+  var getPayoutChannelsCalls = 0
+  var getPayoutChannelFormCalls = 0
+  var getPayoutQuoteCalls = 0
+  var initiatePayoutCalls = 0
+
+  // Call parameters
+  var initiateKycRequestParam: NoahInitiateKycRequest?
+  var initiatePayinRequestParam: NoahInitiatePayinRequest?
+  var simulatePayinRequestParam: NoahSimulatePayinRequest?
+  var getPaymentMethodsRequestParam: NoahGetPaymentMethodsRequest?
+  var getPayoutChannelsRequestParam: NoahGetPayoutChannelsRequest?
+  var getPayoutChannelFormChannelIdParam: String?
+  var getPayoutQuoteRequestParam: NoahGetPayoutQuoteRequest?
+  var initiatePayoutRequestParam: NoahInitiatePayoutRequest?
+
+  func initiateKyc(request: NoahInitiateKycRequest) async throws -> NoahInitiateKycResponse {
+    initiateKycCalls += 1
+    initiateKycRequestParam = request
+    return initiateKycReturnValue ?? NoahInitiateKycResponse.stub()
+  }
+
+  func initiatePayin(request: NoahInitiatePayinRequest) async throws -> NoahInitiatePayinResponse {
+    initiatePayinCalls += 1
+    initiatePayinRequestParam = request
+    return initiatePayinReturnValue ?? NoahInitiatePayinResponse.stub()
+  }
+
+  func simulatePayin(request: NoahSimulatePayinRequest) async throws -> NoahSimulatePayinResponse {
+    simulatePayinCalls += 1
+    simulatePayinRequestParam = request
+    return simulatePayinReturnValue ?? NoahSimulatePayinResponse.stub()
+  }
+
+  func getPaymentMethods(request: NoahGetPaymentMethodsRequest) async throws -> NoahGetPaymentMethodsResponse {
+    getPaymentMethodsCalls += 1
+    getPaymentMethodsRequestParam = request
+    return getPaymentMethodsReturnValue ?? NoahGetPaymentMethodsResponse.stub()
+  }
+
+  func getPayoutCountries() async throws -> NoahGetPayoutCountriesResponse {
+    getPayoutCountriesCalls += 1
+    return getPayoutCountriesReturnValue ?? NoahGetPayoutCountriesResponse.stub()
+  }
+
+  func getPayoutChannels(request: NoahGetPayoutChannelsRequest) async throws -> NoahGetPayoutChannelsResponse {
+    getPayoutChannelsCalls += 1
+    getPayoutChannelsRequestParam = request
+    return getPayoutChannelsReturnValue ?? NoahGetPayoutChannelsResponse.stub()
+  }
+
+  func getPayoutChannelForm(channelId: String) async throws -> NoahGetPayoutChannelFormResponse {
+    getPayoutChannelFormCalls += 1
+    getPayoutChannelFormChannelIdParam = channelId
+    return getPayoutChannelFormReturnValue ?? NoahGetPayoutChannelFormResponse.stub()
+  }
+
+  func getPayoutQuote(request: NoahGetPayoutQuoteRequest) async throws -> NoahGetPayoutQuoteResponse {
+    getPayoutQuoteCalls += 1
+    getPayoutQuoteRequestParam = request
+    return getPayoutQuoteReturnValue ?? NoahGetPayoutQuoteResponse.stub()
+  }
+
+  func initiatePayout(request: NoahInitiatePayoutRequest) async throws -> NoahInitiatePayoutResponse {
+    initiatePayoutCalls += 1
+    initiatePayoutRequestParam = request
+    return initiatePayoutReturnValue ?? NoahInitiatePayoutResponse.stub()
+  }
+}

--- a/Tests/PortalSwiftTests/RampsTests.swift
+++ b/Tests/PortalSwiftTests/RampsTests.swift
@@ -1,0 +1,177 @@
+//
+//  RampsTests.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import Foundation
+@testable import PortalSwift
+import XCTest
+
+final class RampsTests: XCTestCase {
+  var api: PortalApi!
+  var rampsInstance: Ramps!
+
+  override func setUpWithError() throws {
+    api = PortalApi(apiKey: MockConstants.mockApiKey, requests: PortalRequestsMock())
+    rampsInstance = Ramps(api: api)
+  }
+
+  override func tearDownWithError() throws {
+    api = nil
+    rampsInstance = nil
+  }
+}
+
+// MARK: - Initialization Tests
+
+extension RampsTests {
+  func test_init_createsInstanceSuccessfully() {
+    let portalApi = PortalApi(apiKey: MockConstants.mockApiKey, requests: PortalRequestsMock())
+    let ramps = Ramps(api: portalApi)
+    XCTAssertNotNil(ramps)
+  }
+
+  func test_init_initializesNoahProperty() {
+    let portalApi = PortalApi(apiKey: MockConstants.mockApiKey, requests: PortalRequestsMock())
+    let ramps = Ramps(api: portalApi)
+    XCTAssertNotNil(ramps.noah)
+  }
+
+  func test_init_noahIsOfCorrectType() {
+    let portalApi = PortalApi(apiKey: MockConstants.mockApiKey, requests: PortalRequestsMock())
+    let ramps = Ramps(api: portalApi)
+    XCTAssertTrue(ramps.noah is NoahProtocol)
+  }
+
+  func test_init_withMockApi() {
+    let mockApi = PortalApiMock()
+    let ramps = Ramps(api: mockApi)
+    XCTAssertNotNil(ramps)
+    XCTAssertNotNil(ramps.noah)
+  }
+}
+
+// MARK: - Forwarding Success Tests
+
+extension RampsTests {
+  func test_noah_initiateKyc_forwardsToApi() async throws {
+    let noahApiMock = PortalNoahApiMock()
+    noahApiMock.initiateKycReturnValue = NoahInitiateKycResponse.stub()
+    let mockApi = PortalApiMock(noah: noahApiMock)
+    let ramps = Ramps(api: mockApi)
+
+    let response = try await ramps.noah.initiateKyc(request: .stub())
+
+    XCTAssertNotNil(response.data)
+    XCTAssertEqual(noahApiMock.initiateKycCalls, 1)
+  }
+
+  func test_noah_initiatePayin_forwardsToApi() async throws {
+    let noahApiMock = PortalNoahApiMock()
+    noahApiMock.initiatePayinReturnValue = NoahInitiatePayinResponse.stub()
+    let ramps = Ramps(api: PortalApiMock(noah: noahApiMock))
+
+    let response = try await ramps.noah.initiatePayin(request: .stub())
+
+    XCTAssertNotNil(response.data)
+    XCTAssertEqual(noahApiMock.initiatePayinCalls, 1)
+  }
+
+  func test_noah_simulatePayin_forwardsToApi() async throws {
+    let noahApiMock = PortalNoahApiMock()
+    noahApiMock.simulatePayinReturnValue = NoahSimulatePayinResponse.stub()
+    let ramps = Ramps(api: PortalApiMock(noah: noahApiMock))
+
+    let response = try await ramps.noah.simulatePayin(request: .stub())
+
+    XCTAssertNotNil(response.data)
+    XCTAssertEqual(noahApiMock.simulatePayinCalls, 1)
+  }
+
+  func test_noah_getPaymentMethods_forwardsToApi() async throws {
+    let noahApiMock = PortalNoahApiMock()
+    noahApiMock.getPaymentMethodsReturnValue = NoahGetPaymentMethodsResponse.stub()
+    let ramps = Ramps(api: PortalApiMock(noah: noahApiMock))
+
+    let response = try await ramps.noah.getPaymentMethods()
+
+    XCTAssertNotNil(response.data)
+    XCTAssertEqual(noahApiMock.getPaymentMethodsCalls, 1)
+  }
+
+  func test_noah_getPayoutCountries_forwardsToApi() async throws {
+    let noahApiMock = PortalNoahApiMock()
+    noahApiMock.getPayoutCountriesReturnValue = NoahGetPayoutCountriesResponse.stub()
+    let ramps = Ramps(api: PortalApiMock(noah: noahApiMock))
+
+    let response = try await ramps.noah.getPayoutCountries()
+
+    XCTAssertNotNil(response.data)
+    XCTAssertEqual(noahApiMock.getPayoutCountriesCalls, 1)
+  }
+
+  func test_noah_getPayoutChannels_forwardsToApi() async throws {
+    let noahApiMock = PortalNoahApiMock()
+    noahApiMock.getPayoutChannelsReturnValue = NoahGetPayoutChannelsResponse.stub()
+    let ramps = Ramps(api: PortalApiMock(noah: noahApiMock))
+
+    let response = try await ramps.noah.getPayoutChannels(request: .stub())
+
+    XCTAssertNotNil(response.data)
+    XCTAssertEqual(noahApiMock.getPayoutChannelsCalls, 1)
+  }
+
+  func test_noah_getPayoutChannelForm_forwardsToApi() async throws {
+    let noahApiMock = PortalNoahApiMock()
+    noahApiMock.getPayoutChannelFormReturnValue = NoahGetPayoutChannelFormResponse.stub()
+    let ramps = Ramps(api: PortalApiMock(noah: noahApiMock))
+
+    let response = try await ramps.noah.getPayoutChannelForm(channelId: "channel-1")
+
+    XCTAssertNotNil(response.data)
+    XCTAssertEqual(noahApiMock.getPayoutChannelFormCalls, 1)
+  }
+
+  func test_noah_getPayoutQuote_forwardsToApi() async throws {
+    let noahApiMock = PortalNoahApiMock()
+    noahApiMock.getPayoutQuoteReturnValue = NoahGetPayoutQuoteResponse.stub()
+    let ramps = Ramps(api: PortalApiMock(noah: noahApiMock))
+
+    let response = try await ramps.noah.getPayoutQuote(request: .stub())
+
+    XCTAssertNotNil(response.data)
+    XCTAssertEqual(noahApiMock.getPayoutQuoteCalls, 1)
+  }
+
+  func test_noah_initiatePayout_forwardsToApi() async throws {
+    let noahApiMock = PortalNoahApiMock()
+    noahApiMock.initiatePayoutReturnValue = NoahInitiatePayoutResponse.stub()
+    let ramps = Ramps(api: PortalApiMock(noah: noahApiMock))
+
+    let response = try await ramps.noah.initiatePayout(request: .stub())
+
+    XCTAssertNotNil(response.data)
+    XCTAssertEqual(noahApiMock.initiatePayoutCalls, 1)
+  }
+}
+
+// MARK: - Dependency Injection Tests
+
+extension RampsTests {
+  func test_noah_supportsCustomMockInjection() async throws {
+    let noahMock = NoahMock()
+    rampsInstance.noah = noahMock
+
+    _ = try await rampsInstance.noah.getPayoutCountries()
+
+    XCTAssertEqual(noahMock.getPayoutCountriesCalls, 1)
+  }
+
+  func test_noah_propertyIsStable() {
+    let first = rampsInstance.noah
+    let second = rampsInstance.noah
+    XCTAssertTrue(first as AnyObject === second as AnyObject)
+  }
+}

--- a/Tests/PortalSwiftTests/Stubs/Lifi.swift
+++ b/Tests/PortalSwiftTests/Stubs/Lifi.swift
@@ -599,3 +599,41 @@ extension LifiStatusRequest {
     )
   }
 }
+
+// MARK: - Trade Asset
+
+extension LifiTradeAssetResult {
+  static func stub(
+    hashes: [String] = ["0xabc123def456"],
+    steps: [LifiStep] = [.stub()],
+    route: LifiRoute = .stub()
+  ) -> Self {
+    LifiTradeAssetResult(hashes: hashes, steps: steps, route: route)
+  }
+}
+
+extension LifiTradeAssetParams {
+  static func stub(
+    fromChain: String = "8453",
+    toChain: String = "137",
+    fromToken: String = "0x0000000000000000000000000000000000000000",
+    toToken: String = "0x0000000000000000000000000000000000001010",
+    amount: String = "1000000000000000000",
+    fromAddress: String? = "0x1234567890abcdef1234567890abcdef12345678",
+    toAddress: String? = nil,
+    routeIndex: Int? = nil,
+    onProgress: LifiProgressHandler? = nil
+  ) -> Self {
+    LifiTradeAssetParams(
+      fromChain: fromChain,
+      toChain: toChain,
+      fromToken: fromToken,
+      toToken: toToken,
+      amount: amount,
+      fromAddress: fromAddress,
+      toAddress: toAddress,
+      routeIndex: routeIndex,
+      onProgress: onProgress
+    )
+  }
+}

--- a/Tests/PortalSwiftTests/Stubs/Noah.swift
+++ b/Tests/PortalSwiftTests/Stubs/Noah.swift
@@ -1,0 +1,636 @@
+//
+//  Noah.swift
+//  PortalSwift
+//
+//  Created by Ahmed Ragab
+//
+
+import AnyCodable
+import Foundation
+@testable import PortalSwift
+
+// MARK: - Common Types
+
+extension NoahBankAddress {
+  static func stub(
+    street: String? = "1 Market Street",
+    street2: String? = nil,
+    city: String? = "San Francisco",
+    postCode: String? = "94105",
+    state: String? = "CA",
+    country: String? = "US"
+  ) -> Self {
+    NoahBankAddress(
+      street: street,
+      street2: street2,
+      city: city,
+      postCode: postCode,
+      state: state,
+      country: country
+    )
+  }
+}
+
+extension NoahFeeDetails {
+  static func stub(
+    fiatCurrencyCode: String = "USD",
+    totalFeePct: String = "0.5",
+    totalFeeBase: String = "0.25",
+    totalFeeMin: String = "1.00"
+  ) -> Self {
+    NoahFeeDetails(
+      fiatCurrencyCode: fiatCurrencyCode,
+      totalFeePct: totalFeePct,
+      totalFeeBase: totalFeeBase,
+      totalFeeMin: totalFeeMin
+    )
+  }
+}
+
+extension NoahPersonName {
+  static func stub(
+    firstName: String = "John",
+    lastName: String = "Doe",
+    middleName: String? = nil
+  ) -> Self {
+    NoahPersonName(
+      firstName: firstName,
+      lastName: lastName,
+      middleName: middleName
+    )
+  }
+}
+
+extension NoahBankToAddressRelatedPaymentMethodDetails {
+  static func stub(accountNumber: String? = "1234567890", bankCode: String? = "BANKUS33") -> Self {
+    NoahBankToAddressRelatedPaymentMethodDetails(accountNumber: accountNumber, bankCode: bankCode)
+  }
+}
+
+extension NoahBankToAddressRelatedPaymentMethod {
+  static func stub(
+    paymentMethodId: String = "pm-related-1",
+    paymentMethodType: String = "BankAch",
+    fee: NoahFeeDetails = .stub(),
+    details: NoahBankToAddressRelatedPaymentMethodDetails? = .stub()
+  ) -> Self {
+    NoahBankToAddressRelatedPaymentMethod(
+      paymentMethodId: paymentMethodId,
+      paymentMethodType: paymentMethodType,
+      fee: fee,
+      details: details
+    )
+  }
+}
+
+extension NoahBankDetails {
+  static func stub(
+    paymentMethodId: String = "pm-1",
+    paymentMethodType: String = "BankAch",
+    accountNumber: String = "1111222233",
+    cryptoCurrency: String = "USDC",
+    network: String = "ACH",
+    fee: NoahFeeDetails = .stub(),
+    accountHolderName: String? = "John Doe",
+    bankCode: String? = "BANKUS33",
+    bankName: String? = "Test Bank",
+    bankAddress: NoahBankAddress? = .stub(),
+    reference: String? = "REF-1",
+    relatedPaymentMethods: [NoahBankToAddressRelatedPaymentMethod]? = [.stub()]
+  ) -> Self {
+    NoahBankDetails(
+      paymentMethodId: paymentMethodId,
+      paymentMethodType: paymentMethodType,
+      accountNumber: accountNumber,
+      cryptoCurrency: cryptoCurrency,
+      network: network,
+      fee: fee,
+      accountHolderName: accountHolderName,
+      bankCode: bankCode,
+      bankName: bankName,
+      bankAddress: bankAddress,
+      reference: reference,
+      relatedPaymentMethods: relatedPaymentMethods
+    )
+  }
+}
+
+extension NoahChannelLimits {
+  static func stub(minLimit: String = "10.00", maxLimit: String? = "1000.00") -> Self {
+    NoahChannelLimits(minLimit: minLimit, maxLimit: maxLimit)
+  }
+}
+
+extension NoahChannelCalculated {
+  static func stub(totalFee: String = "1.25") -> Self {
+    NoahChannelCalculated(totalFee: totalFee)
+  }
+}
+
+extension NoahChannel {
+  static func stub(
+    id: String = "channel-1",
+    paymentMethodCategory: String = "Bank",
+    paymentMethodType: String = "BankAch",
+    fiatCurrency: String = "USD",
+    country: String = "US",
+    limits: NoahChannelLimits = .stub(),
+    rate: String = "1.00",
+    processingSeconds: Int = 3600,
+    calculated: NoahChannelCalculated? = .stub(),
+    paymentMethods: [NoahChannelPaymentMethodDisplay]? = nil,
+    processingTier: String? = nil,
+    formSchema: [String: AnyCodable]? = nil,
+    formMetadata: NoahFormMetadata? = nil,
+    issuer: String? = nil
+  ) -> Self {
+    NoahChannel(
+      id: id,
+      paymentMethodCategory: paymentMethodCategory,
+      paymentMethodType: paymentMethodType,
+      fiatCurrency: fiatCurrency,
+      country: country,
+      limits: limits,
+      rate: rate,
+      processingSeconds: processingSeconds,
+      calculated: calculated,
+      paymentMethods: paymentMethods,
+      processingTier: processingTier,
+      formSchema: formSchema,
+      formMetadata: formMetadata,
+      issuer: issuer
+    )
+  }
+}
+
+extension NoahPaymentMethodDisplayDetails {
+  static func stub(
+    type: String = "BankAccount",
+    accountNumber: String? = "1111222233",
+    bankCode: String? = "BANKUS33",
+    last4: String? = "2233",
+    scheme: String? = "ACH",
+    identifierType: String? = "IBAN",
+    identifier: String? = "US00BANKUS3300001111222233"
+  ) -> Self {
+    NoahPaymentMethodDisplayDetails(
+      type: type,
+      accountNumber: accountNumber,
+      bankCode: bankCode,
+      last4: last4,
+      scheme: scheme,
+      identifierType: identifierType,
+      identifier: identifier
+    )
+  }
+}
+
+extension NoahPaymentMethodCapabilities {
+  static func stub(payoutFrom: Bool = false, payinTo: Bool = true, payoutTo: Bool = true) -> Self {
+    NoahPaymentMethodCapabilities(payoutFrom: payoutFrom, payinTo: payinTo, payoutTo: payoutTo)
+  }
+}
+
+extension NoahAccountHolderDetails {
+  static func stub(name: NoahPersonName? = .stub()) -> Self {
+    NoahAccountHolderDetails(name: name)
+  }
+}
+
+extension NoahIssuerDetails {
+  static func stub(name: String? = "Issuer Name") -> Self {
+    NoahIssuerDetails(name: name)
+  }
+}
+
+extension NoahPaymentMethod {
+  static func stub(
+    id: String = "pm-1",
+    paymentMethodCategory: String = "Bank",
+    country: String = "US",
+    displayDetails: NoahPaymentMethodDisplayDetails = .stub(),
+    customerId: String? = "customer-1",
+    capabilities: NoahPaymentMethodCapabilities? = .stub(),
+    accountHolderDetails: NoahAccountHolderDetails? = .stub(),
+    issuerDetails: NoahIssuerDetails? = .stub()
+  ) -> Self {
+    NoahPaymentMethod(
+      id: id,
+      paymentMethodCategory: paymentMethodCategory,
+      country: country,
+      displayDetails: displayDetails,
+      customerId: customerId,
+      capabilities: capabilities,
+      accountHolderDetails: accountHolderDetails,
+      issuerDetails: issuerDetails
+    )
+  }
+}
+
+extension NoahFormNextStep {
+  static func stub(
+    stepId: String = "step-1",
+    stepType: NoahFormNextStepType = .dataEntry,
+    schema: [String: AnyCodable]? = ["field": AnyCodable("value")]
+  ) -> Self {
+    NoahFormNextStep(stepId: stepId, stepType: stepType, schema: schema)
+  }
+}
+
+extension NoahAmountCondition {
+  static func stub(comparisonOperator: NoahComparisonOperator = .gteq, value: String = "0") -> Self {
+    NoahAmountCondition(comparisonOperator: comparisonOperator, value: value)
+  }
+}
+
+extension NoahDepositSourceTriggerCondition {
+  static func stub(
+    amountConditions: [NoahAmountCondition] = [.stub()],
+    cryptoCurrency: String = "USDC",
+    network: String = "Ethereum",
+    destinationAddress: String = "0x0000000000000000000000000000000000000000"
+  ) -> Self {
+    NoahDepositSourceTriggerCondition(
+      amountConditions: amountConditions,
+      cryptoCurrency: cryptoCurrency,
+      network: network,
+      destinationAddress: destinationAddress
+    )
+  }
+}
+
+extension NoahSingleOnchainDepositSourceTriggerAmountCondition {
+  static func stub(comparisonOperator: NoahComparisonOperator = .gteq, value: String = "1") -> Self {
+    NoahSingleOnchainDepositSourceTriggerAmountCondition(comparisonOperator: comparisonOperator, value: value)
+  }
+}
+
+extension NoahSingleOnchainDepositSourceTriggerCondition {
+  static func stub(
+    amountConditions: [NoahSingleOnchainDepositSourceTriggerAmountCondition] = [.stub()],
+    network: String = NoahNetwork.ethereum
+  ) -> Self {
+    NoahSingleOnchainDepositSourceTriggerCondition(amountConditions: amountConditions, network: network)
+  }
+}
+
+extension NoahSingleOnchainDepositSourceTriggerInput {
+  static func stub(
+    type: String = "SingleOnchainDepositSourceTriggerInput",
+    conditions: [NoahSingleOnchainDepositSourceTriggerCondition] = [.stub()],
+    sourceAddress: String = "0x1111111111111111111111111111111111111111",
+    expiry: String = "2099-01-01T00:00:00Z",
+    nonce: String = "nonce-1"
+  ) -> Self {
+    NoahSingleOnchainDepositSourceTriggerInput(
+      type: type,
+      conditions: conditions,
+      sourceAddress: sourceAddress,
+      expiry: expiry,
+      nonce: nonce
+    )
+  }
+}
+
+extension NoahNetworkOnlyOnchainDepositSourceTriggerCondition {
+  static func stub(network: String = NoahNetwork.ethereum) -> Self {
+    NoahNetworkOnlyOnchainDepositSourceTriggerCondition(network: network)
+  }
+}
+
+extension NoahPermanentOnchainDepositSourceTriggerInput {
+  static func stub(
+    conditions: [NoahNetworkOnlyOnchainDepositSourceTriggerCondition] = [.stub()],
+    sourceAddress: String = "0x1111111111111111111111111111111111111111",
+    expiry: String = "2099-01-01T00:00:00Z",
+    nonce: String = "nonce-1",
+    networkAgnostic: Bool? = nil
+  ) -> Self {
+    NoahPermanentOnchainDepositSourceTriggerInput(
+      conditions: conditions,
+      sourceAddress: sourceAddress,
+      expiry: expiry,
+      nonce: nonce,
+      networkAgnostic: networkAgnostic
+    )
+  }
+}
+
+extension NoahQuotedOnchainDepositSourceTriggerInput {
+  static func stub(
+    signedQuote: String = "signed-quote-1",
+    conditions: [NoahNetworkOnlyOnchainDepositSourceTriggerCondition] = [.stub()],
+    sourceAddress: String = "0x1111111111111111111111111111111111111111",
+    nonce: String = "nonce-1",
+    expiry: String? = "2099-01-01T00:00:00Z"
+  ) -> Self {
+    NoahQuotedOnchainDepositSourceTriggerInput(
+      signedQuote: signedQuote,
+      conditions: conditions,
+      sourceAddress: sourceAddress,
+      nonce: nonce,
+      expiry: expiry
+    )
+  }
+}
+
+extension NoahBusinessFee {
+  static func stub(
+    feeBase: String? = "0.50",
+    feePct: String? = "1.5",
+    fiatCurrency: String? = "USD"
+  ) -> Self {
+    NoahBusinessFee(feeBase: feeBase, feePct: feePct, fiatCurrency: fiatCurrency)
+  }
+}
+
+// MARK: - InitiateKyc
+
+extension NoahFiatOption {
+  static func stub(fiatCurrencyCode: String = "USD") -> Self {
+    NoahFiatOption(fiatCurrencyCode: fiatCurrencyCode)
+  }
+}
+
+extension NoahInitiateKycRequest {
+  static func stub(
+    returnUrl: String = "https://example.com/return",
+    fiatOptions: [NoahFiatOption]? = [.stub()],
+    customerType: NoahCustomerType? = .individual,
+    metadata: [String: AnyCodable]? = ["userId": AnyCodable("user-1")],
+    form: [String: AnyCodable]? = ["firstName": AnyCodable("John")]
+  ) -> Self {
+    NoahInitiateKycRequest(
+      returnUrl: returnUrl,
+      fiatOptions: fiatOptions,
+      customerType: customerType,
+      metadata: metadata,
+      form: form
+    )
+  }
+}
+
+extension NoahInitiateKycData {
+  static func stub(hostedUrl: String = "https://noah.example.com/kyc/abc") -> Self {
+    NoahInitiateKycData(hostedUrl: hostedUrl)
+  }
+}
+
+extension NoahInitiateKycResponse {
+  static func stub(data: NoahInitiateKycData = .stub(), metadata: NoahResponseMetadata? = nil) -> Self {
+    NoahInitiateKycResponse(data: data, metadata: metadata)
+  }
+}
+
+// MARK: - InitiatePayin
+
+extension NoahInitiatePayinRequest {
+  static func stub(
+    fiatCurrency: String = "USD",
+    cryptoCurrency: String = "USDC",
+    network: String = NoahNetwork.ethereum,
+    destinationAddress: String = "0x0000000000000000000000000000000000000000",
+    businessFees: [String: NoahBusinessFee]? = nil
+  ) -> Self {
+    NoahInitiatePayinRequest(
+      fiatCurrency: fiatCurrency,
+      cryptoCurrency: cryptoCurrency,
+      network: network,
+      destinationAddress: destinationAddress,
+      businessFees: businessFees
+    )
+  }
+}
+
+extension NoahInitiatePayinData {
+  static func stub(payinId: String = "payin-1", bankDetails: NoahBankDetails = .stub()) -> Self {
+    NoahInitiatePayinData(payinId: payinId, bankDetails: bankDetails)
+  }
+}
+
+extension NoahInitiatePayinResponse {
+  static func stub(data: NoahInitiatePayinData = .stub(), metadata: NoahResponseMetadata? = nil) -> Self {
+    NoahInitiatePayinResponse(data: data, metadata: metadata)
+  }
+}
+
+// MARK: - SimulatePayin
+
+extension NoahSimulatePayinRequest {
+  static func stub(
+    paymentMethodId: String = "pm-1",
+    fiatAmount: String = "100.00",
+    fiatCurrency: String = "USD"
+  ) -> Self {
+    NoahSimulatePayinRequest(
+      paymentMethodId: paymentMethodId,
+      fiatAmount: fiatAmount,
+      fiatCurrency: fiatCurrency
+    )
+  }
+}
+
+extension NoahSimulatePayinData {
+  static func stub(fiatDepositId: String = "fiat-deposit-1", reference: String? = nil) -> Self {
+    NoahSimulatePayinData(fiatDepositId: fiatDepositId, reference: reference)
+  }
+}
+
+extension NoahSimulatePayinResponse {
+  static func stub(data: NoahSimulatePayinData = .stub(), metadata: NoahResponseMetadata? = nil) -> Self {
+    NoahSimulatePayinResponse(data: data, metadata: metadata)
+  }
+}
+
+// MARK: - GetPayoutCountries
+
+extension NoahGetPayoutCountriesData {
+  static func stub(countries: [String: [String]] = ["US": ["USD"], "GB": ["GBP", "EUR"]]) -> Self {
+    NoahGetPayoutCountriesData(countries: countries)
+  }
+}
+
+extension NoahGetPayoutCountriesResponse {
+  static func stub(data: NoahGetPayoutCountriesData = .stub(), metadata: NoahResponseMetadata? = nil) -> Self {
+    NoahGetPayoutCountriesResponse(data: data, metadata: metadata)
+  }
+}
+
+// MARK: - GetPayoutChannels
+
+extension NoahGetPayoutChannelsRequest {
+  static func stub(
+    country: String = "US",
+    cryptoCurrency: String = "USDC",
+    fiatCurrency: String = "USD",
+    fiatAmount: String? = "100.00",
+    pageToken: String? = nil
+  ) -> Self {
+    NoahGetPayoutChannelsRequest(
+      cryptoCurrency: cryptoCurrency,
+      country: country,
+      fiatCurrency: fiatCurrency,
+      fiatAmount: fiatAmount,
+      pageToken: pageToken
+    )
+  }
+}
+
+extension NoahGetPayoutChannelsData {
+  static func stub(items: [NoahChannel] = [.stub()], pageToken: String? = nil) -> Self {
+    NoahGetPayoutChannelsData(items: items, pageToken: pageToken)
+  }
+}
+
+extension NoahGetPayoutChannelsResponse {
+  static func stub(data: NoahGetPayoutChannelsData = .stub(), metadata: NoahResponseMetadata? = nil) -> Self {
+    NoahGetPayoutChannelsResponse(data: data, metadata: metadata)
+  }
+}
+
+// MARK: - GetPayoutChannelForm
+
+extension NoahFormMetadata {
+  static func stub(contentHash: String = "sha256:abc") -> Self {
+    NoahFormMetadata(contentHash: contentHash)
+  }
+}
+
+extension NoahGetPayoutChannelFormData {
+  static func stub(
+    formSchema: [String: AnyCodable]? = ["type": AnyCodable("object")],
+    formMetadata: NoahFormMetadata? = .stub()
+  ) -> Self {
+    NoahGetPayoutChannelFormData(formSchema: formSchema, formMetadata: formMetadata)
+  }
+}
+
+extension NoahGetPayoutChannelFormResponse {
+  static func stub(data: NoahGetPayoutChannelFormData = .stub(), metadata: NoahResponseMetadata? = nil) -> Self {
+    NoahGetPayoutChannelFormResponse(data: data, metadata: metadata)
+  }
+}
+
+// MARK: - GetPaymentMethods
+
+extension NoahGetPaymentMethodsRequest {
+  static func stub(
+    pageSize: Int? = nil,
+    pageToken: String? = nil,
+    capability: NoahPaymentMethodCapability? = nil
+  ) -> Self {
+    NoahGetPaymentMethodsRequest(pageSize: pageSize, pageToken: pageToken, capability: capability)
+  }
+}
+
+extension NoahGetPaymentMethodsData {
+  static func stub(paymentMethods: [NoahPaymentMethod] = [.stub()], pageToken: String? = nil) -> Self {
+    NoahGetPaymentMethodsData(paymentMethods: paymentMethods, pageToken: pageToken)
+  }
+}
+
+extension NoahGetPaymentMethodsResponse {
+  static func stub(data: NoahGetPaymentMethodsData = .stub(), metadata: NoahResponseMetadata? = nil) -> Self {
+    NoahGetPaymentMethodsResponse(data: data, metadata: metadata)
+  }
+}
+
+// MARK: - GetPayoutQuote
+
+extension NoahGetPayoutQuoteRequest {
+  static func stub(
+    channelId: String = "channel-1",
+    cryptoCurrency: String = "USDC",
+    fiatAmount: String = "100.00",
+    form: [String: AnyCodable]? = ["accountNumber": AnyCodable("1111222233")],
+    fiatCurrency: String? = "USD",
+    paymentMethodId: String? = "pm-1"
+  ) -> Self {
+    NoahGetPayoutQuoteRequest(
+      channelId: channelId,
+      cryptoCurrency: cryptoCurrency,
+      fiatAmount: fiatAmount,
+      form: form,
+      fiatCurrency: fiatCurrency,
+      paymentMethodId: paymentMethodId
+    )
+  }
+}
+
+extension NoahGetPayoutQuoteData {
+  static func stub(
+    payoutId: String = "payout-1",
+    totalFee: String = "1.25",
+    cryptoAmountEstimate: String = "101.25",
+    cryptoAuthorizedAmount: String = "101.25",
+    formSessionId: String = "session-1",
+    cryptoCurrency: String? = nil,
+    fiatCurrency: String? = nil,
+    fiatAmount: String? = nil,
+    rate: String? = nil,
+    breakdown: [NoahTransactionBreakdownItem]? = nil,
+    quote: NoahSellQuote? = nil,
+    nextStep: NoahFormNextStep? = nil
+  ) -> Self {
+    NoahGetPayoutQuoteData(
+      payoutId: payoutId,
+      totalFee: totalFee,
+      cryptoAmountEstimate: cryptoAmountEstimate,
+      cryptoAuthorizedAmount: cryptoAuthorizedAmount,
+      formSessionId: formSessionId,
+      cryptoCurrency: cryptoCurrency,
+      fiatCurrency: fiatCurrency,
+      fiatAmount: fiatAmount,
+      rate: rate,
+      breakdown: breakdown,
+      quote: quote,
+      nextStep: nextStep
+    )
+  }
+}
+
+extension NoahGetPayoutQuoteResponse {
+  static func stub(data: NoahGetPayoutQuoteData = .stub(), metadata: NoahResponseMetadata? = nil) -> Self {
+    NoahGetPayoutQuoteResponse(data: data, metadata: metadata)
+  }
+}
+
+// MARK: - InitiatePayout
+
+extension NoahInitiatePayoutRequest {
+  static func stub(
+    payoutId: String = "payout-1",
+    sourceAddress: String = "0x1111111111111111111111111111111111111111",
+    expiry: String = "2099-01-01T00:00:00Z",
+    nonce: String = "nonce-1",
+    network: String = NoahNetwork.ethereum,
+    trigger: NoahOnchainDepositSourceTrigger? = .single(.stub()),
+    businessFee: NoahBusinessFee? = nil
+  ) -> Self {
+    NoahInitiatePayoutRequest(
+      payoutId: payoutId,
+      sourceAddress: sourceAddress,
+      expiry: expiry,
+      nonce: nonce,
+      network: network,
+      trigger: trigger,
+      businessFee: businessFee
+    )
+  }
+}
+
+extension NoahInitiatePayoutData {
+  static func stub(
+    destinationAddress: String? = "0x2222222222222222222222222222222222222222",
+    conditions: [NoahDepositSourceTriggerCondition]? = [.stub()],
+    ruleId: String? = nil
+  ) -> Self {
+    NoahInitiatePayoutData(destinationAddress: destinationAddress, conditions: conditions, ruleId: ruleId)
+  }
+}
+
+extension NoahInitiatePayoutResponse {
+  static func stub(data: NoahInitiatePayoutData = .stub(), metadata: NoahResponseMetadata? = nil) -> Self {
+    NoahInitiatePayoutResponse(data: data, metadata: metadata)
+  }
+}

--- a/Tests/PortalSwiftTests/Stubs/YieldXyz.swift
+++ b/Tests/PortalSwiftTests/Stubs/YieldXyz.swift
@@ -565,3 +565,118 @@ extension YieldXyzTrackTransactionResponse {
     YieldXyzTrackTransactionResponse(data: data, error: error)
   }
 }
+
+// MARK: - Defaults
+
+extension YieldXyzDefaultYieldEntry {
+  static func stub(yieldId: String? = "yield-1", opportunity: YieldXyzOpportunity? = nil) -> Self {
+    YieldXyzDefaultYieldEntry(yieldId: yieldId, opportunity: opportunity)
+  }
+}
+
+extension YieldXyzGetDefaultsResponse {
+  static func stub(
+    data: [String: YieldXyzDefaultYieldEntry]? = ["eip155:11155111:ETH": .stub()],
+    error: String? = nil
+  ) -> Self {
+    YieldXyzGetDefaultsResponse(data: data, error: error)
+  }
+}
+
+// MARK: - Validators
+
+extension YieldXyzProvider {
+  static func stub(
+    name: String? = "Provider",
+    uniqueId: String? = "provider-1",
+    website: String? = "https://example.com",
+    rank: Int? = 1,
+    preferred: Bool? = true
+  ) -> Self {
+    YieldXyzProvider(name: name, uniqueId: uniqueId, website: website, rank: rank, preferred: preferred)
+  }
+}
+
+extension YieldXyzValidator {
+  static func stub(
+    address: String = "0xvalidator",
+    name: String? = "Validator One",
+    rewardRate: YieldXyzRewardRate? = .stub(),
+    provider: YieldXyzProvider? = .stub(),
+    commission: Double? = 0.05,
+    preferred: Bool? = true,
+    status: String? = "active"
+  ) -> Self {
+    YieldXyzValidator(
+      address: address,
+      name: name,
+      rewardRate: rewardRate,
+      provider: provider,
+      commission: commission,
+      preferred: preferred,
+      status: status
+    )
+  }
+}
+
+extension YieldXyzGetValidatorsRawResponse {
+  static func stub(items: [YieldXyzValidator]? = [.stub()], limit: Int? = 10, offset: Int? = 0, total: Int? = 1) -> Self {
+    YieldXyzGetValidatorsRawResponse(items: items, validators: nil, limit: limit, offset: offset, total: total)
+  }
+}
+
+extension YieldXyzGetValidatorsData {
+  static func stub(validators: [YieldXyzValidator]? = nil, rawResponse: YieldXyzGetValidatorsRawResponse? = .stub()) -> Self {
+    YieldXyzGetValidatorsData(validators: validators, rawResponse: rawResponse)
+  }
+}
+
+extension YieldXyzGetValidatorsResponse {
+  static func stub(data: YieldXyzGetValidatorsData? = .stub(), error: String? = nil) -> Self {
+    YieldXyzGetValidatorsResponse(data: data, error: error)
+  }
+}
+
+// MARK: - High-level deposit/withdraw
+
+extension YieldOpportunityDetails {
+  static func stub(
+    yieldId: String = "yield-1",
+    intent: YieldXyzActionIntent? = .enter,
+    type: YieldXyzActionType? = .STAKE,
+    executionPattern: YieldXyzActionExecutionPattern? = .synchronous,
+    status: YieldXyzActionStatus? = .CREATED,
+    amount: String? = "1.0",
+    amountUsd: String? = "3000"
+  ) -> Self {
+    YieldOpportunityDetails(
+      yieldId: yieldId,
+      intent: intent,
+      type: type,
+      executionPattern: executionPattern,
+      status: status,
+      amount: amount,
+      amountUsd: amountUsd
+    )
+  }
+}
+
+extension YieldDepositResult {
+  static func stub(
+    hashes: [String] = ["0xhash"],
+    yieldId: String = "yield-1",
+    status: YieldSubmitResultStatus = .success,
+    chain: String? = nil,
+    token: String? = nil,
+    yieldOpportunityDetails: YieldOpportunityDetails = .stub()
+  ) -> Self {
+    YieldDepositResult(
+      hashes: hashes,
+      yieldId: yieldId,
+      status: status,
+      chain: chain,
+      token: token,
+      yieldOpportunityDetails: yieldOpportunityDetails
+    )
+  }
+}

--- a/Tests/PortalSwiftTests/Tracing/PortalSendAssetTraceIdTests.swift
+++ b/Tests/PortalSwiftTests/Tracing/PortalSendAssetTraceIdTests.swift
@@ -1,0 +1,44 @@
+//
+//  PortalSendAssetTraceIdTests.swift
+//  PortalSwiftTests
+//
+//  Verifies sendAsset shares a single trace ID across the build and sign/broadcast steps.
+//
+
+@testable import PortalSwift
+import XCTest
+
+extension PortalTests {
+  func test_sendAsset_eip155_usesSingleTraceIdForBuildAndSign() async throws {
+    let apiSpy = PortalApiSpy()
+    try initPortalWithSpy(api: apiSpy)
+
+    let providerSpy = PortalProviderSpy()
+    setToPortal(portalProvider: providerSpy)
+
+    _ = try await portal.sendAsset(
+      chainId: "eip155:11155111",
+      params: SendAssetParams(to: "0xto", amount: "1.0", token: "NATIVE")
+    )
+
+    let buildTraceId = try XCTUnwrap(apiSpy.buildEip155TransactionTraceIdParam, "build should receive a trace ID")
+    let sendTraceId = try XCTUnwrap(providerSpy.requestOptionsOptionsParam?.traceId, "request options should carry a trace ID")
+    XCTAssertEqual(buildTraceId, sendTraceId, "sendAsset should reuse one trace ID for build and sign")
+  }
+
+  func test_sendAsset_honorsCallerProvidedTraceId() async throws {
+    let apiSpy = PortalApiSpy()
+    try initPortalWithSpy(api: apiSpy)
+
+    let providerSpy = PortalProviderSpy()
+    setToPortal(portalProvider: providerSpy)
+
+    _ = try await portal.sendAsset(
+      chainId: "eip155:11155111",
+      params: SendAssetParams(to: "0xto", amount: "1.0", token: "NATIVE", traceId: "caller-trace-id")
+    )
+
+    XCTAssertEqual(apiSpy.buildEip155TransactionTraceIdParam, "caller-trace-id")
+    XCTAssertEqual(providerSpy.requestOptionsOptionsParam?.traceId, "caller-trace-id")
+  }
+}

--- a/Tests/PortalSwiftTests/Tracing/TraceIdTests.swift
+++ b/Tests/PortalSwiftTests/Tracing/TraceIdTests.swift
@@ -1,0 +1,378 @@
+//
+//  TraceIdTests.swift
+//  PortalSwiftTests
+//
+//  Tests for the X-Portal-Trace-Id header and MPC reqId propagation.
+//
+
+@testable import PortalSwift
+import XCTest
+
+final class TraceIdTests: XCTestCase {
+  // MARK: - generateTraceId
+
+  func test_generateTraceId_returnsLowercasedUUID() {
+    let traceId = generateTraceId()
+    XCTAssertNotNil(UUID(uuidString: traceId), "Trace ID should be a valid UUID")
+    XCTAssertEqual(traceId, traceId.lowercased(), "Trace ID should be lowercased")
+  }
+
+  func test_generateTraceId_isUnique() {
+    let first = generateTraceId()
+    let second = generateTraceId()
+    XCTAssertNotEqual(first, second)
+  }
+
+  // MARK: - PortalAPIRequest header injection
+
+  func test_portalAPIRequest_autoGeneratesTraceIdHeader() throws {
+    let url = try XCTUnwrap(URL(string: "https://api.portalhq.io/api/v3/clients/me"))
+    let request = PortalAPIRequest(url: url, bearerToken: "test-key")
+
+    let header = try XCTUnwrap(request.headers[PORTAL_TRACE_ID_HEADER])
+    XCTAssertNotNil(UUID(uuidString: header), "Auto-generated trace ID should be a valid UUID")
+  }
+
+  func test_portalAPIRequest_honorsExplicitTraceId() throws {
+    let url = try XCTUnwrap(URL(string: "https://api.portalhq.io/api/v3/clients/me"))
+    let request = PortalAPIRequest(url: url, bearerToken: "test-key", traceId: "explicit-trace-id")
+
+    XCTAssertEqual(request.headers[PORTAL_TRACE_ID_HEADER], "explicit-trace-id")
+  }
+
+  // MARK: - PortalApi forwards the header
+
+  func test_portalApi_buildEip155Transaction_forwardsExplicitTraceIdHeader() async throws {
+    let spy = PortalRequestsSpy()
+    spy.returnData = try JSONEncoder().encode(BuildEip115TransactionResponse.stub())
+    let api = PortalApi(apiKey: MockConstants.mockApiKey, requests: spy)
+
+    _ = try await api.buildEip155Transaction(
+      chainId: "eip155:11155111",
+      params: BuildTransactionParam(to: "0xto", token: "NATIVE", amount: "1.0"),
+      traceId: "trace-build-123"
+    )
+
+    let executedRequest = try XCTUnwrap(spy.executeRequestParam)
+    XCTAssertEqual(executedRequest.headers[PORTAL_TRACE_ID_HEADER], "trace-build-123")
+  }
+
+  func test_portalApi_getClient_includesTraceIdHeader() async throws {
+    let spy = PortalRequestsSpy()
+    spy.returnData = try JSONEncoder().encode(ClientResponse.stub())
+    let api = PortalApi(apiKey: MockConstants.mockApiKey, requests: spy)
+
+    _ = try await api.getClient()
+
+    let executedRequest = try XCTUnwrap(spy.executeRequestParam)
+    let header = try XCTUnwrap(executedRequest.headers[PORTAL_TRACE_ID_HEADER])
+    XCTAssertNotNil(UUID(uuidString: header), "getClient should attach a valid trace ID header")
+  }
+
+  func test_portalApi_getWalletCapabilities_forwardsExplicitTraceIdHeader() async throws {
+    let spy = PortalRequestsSpy()
+    spy.returnData = try JSONEncoder().encode(WalletCapabilitiesResponse.stub())
+    let api = PortalApi(apiKey: MockConstants.mockApiKey, requests: spy)
+
+    _ = try await api.getWalletCapabilities(traceId: "trace-capabilities-789")
+
+    let executedRequest = try XCTUnwrap(spy.executeRequestParam)
+    XCTAssertEqual(executedRequest.headers[PORTAL_TRACE_ID_HEADER], "trace-capabilities-789")
+  }
+
+  // MARK: - MPC reqId mapping
+
+  func test_portalMpcSigner_mapsReqIdIntoMpcMetadata() async throws {
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileSignReturnValue = MockConstants.mockSignatureResponse
+    let signer = PortalMpcSigner(
+      apiKey: MockConstants.mockApiKey,
+      keychain: MockPortalKeychain(),
+      binary: mobileSpy
+    )
+    let blockchain = try PortalBlockchain(fromChainId: "eip155:11155111")
+    let signRequest = PortalSignRequest(method: .eth_sign, params: "test-message")
+
+    _ = try await signer.sign(
+      "eip155:11155111",
+      withPayload: signRequest,
+      andRpcUrl: MockConstants.mockHost,
+      usingBlockchain: blockchain,
+      signatureApprovalMemo: nil,
+      sponsorGas: nil,
+      reqId: "trace-sign-456"
+    )
+
+    let metadata = try XCTUnwrap(mobileSpy.mobileSignMetadataParam)
+    XCTAssertTrue(metadata.contains("trace-sign-456"), "MPC metadata should contain the reqId. Got: \(metadata)")
+  }
+
+  // MARK: - MPC lifecycle operation-scoped trace ID
+
+  func test_portalMpc_generate_sharesTraceIdAcrossMpcMetadataAndApiCalls() async throws {
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateSecp256k1ReturnValue = UnitTestMockConstants.validSecp256k1ShareRotatedResultJSON
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    let apiSpy = PortalApiSpy()
+    let mpc = PortalMpc(
+      apiKey: MockConstants.mockApiKey,
+      api: apiSpy,
+      keychain: MockPortalKeychain(),
+      mobile: mobileSpy
+    )
+
+    _ = try await mpc.generate()
+
+    assertSharedTraceId(
+      try reqId(fromMetadata: mobileSpy.mobileGenerateEd25519MetadataParam),
+      try reqId(fromMetadata: mobileSpy.mobileGenerateSecp256k1MetadataParam),
+      try XCTUnwrap(apiSpy.updateShareStatusTraceIdParam),
+      try XCTUnwrap(apiSpy.refreshClientTraceIdParam)
+    )
+  }
+
+  func test_portalMpc_generate_preGeneratedWallet_sharesTraceIdAcrossApiCalls() async throws {
+    let mobileSpy = MobileSpy()
+    let apiSpy = PortalApiSpy()
+    let share = try MockConstants.mockBase64EncodedMpcShare
+    apiSpy.generatePreGeneratedSharesReturnValue = GenerateApiResponse(
+      secp256k1: GenerateApiCurveShare(share: share, id: MockConstants.mockMpcShareId),
+      ed25519: GenerateApiCurveShare(share: share, id: MockConstants.mockMpcShareId)
+    )
+    let mpc = PortalMpc(
+      apiKey: MockConstants.mockApiKey,
+      api: apiSpy,
+      keychain: MockPortalKeychain(),
+      mobile: mobileSpy,
+      featureFlags: FeatureFlags(usePreGeneratedWallet: true)
+    )
+
+    _ = try await mpc.generate()
+
+    XCTAssertEqual(apiSpy.generatePreGeneratedSharesCallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileGenerateEd25519CallsCount, 0)
+    XCTAssertEqual(mobileSpy.mobileGenerateSecp256k1CallsCount, 0)
+
+    assertSharedTraceId(
+      try reqId(fromMetadata: apiSpy.generatePreGeneratedSharesMetadataParam),
+      try XCTUnwrap(apiSpy.generatePreGeneratedSharesTraceIdParam),
+      try XCTUnwrap(apiSpy.updateShareStatusTraceIdParam),
+      try XCTUnwrap(apiSpy.refreshClientTraceIdParam)
+    )
+  }
+
+  func test_portalMpc_backup_sharesTraceIdAcrossMpcMetadataAndApiCalls() async throws {
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileBackupSecp256k1ReturnValue = try MockConstants.mockRotateResult
+    mobileSpy.mobileBackupEd25519ReturnValue = try MockConstants.mockRotateResult
+    let apiSpy = PortalApiSpy()
+    apiSpy.mockClient = ClientResponse.stub(
+      environment: ClientResponseEnvironment.stub(backupWithPortalEnabled: true)
+    )
+    let keychainSpy = PortalKeychainSpy()
+    keychainSpy.getSharesReturnValue = try MockConstants.mockGenerateResponse
+    let storageSpy = PortalStorageSpy()
+    storageSpy.encryptReturnValue = EncryptData(key: "encryption-key", cipherText: MockConstants.mockCiphertext)
+    let mpc = PortalMpc(
+      apiKey: MockConstants.mockApiKey,
+      api: apiSpy,
+      keychain: keychainSpy,
+      mobile: mobileSpy
+    )
+    mpc.registerBackupMethod(.iCloud, withStorage: storageSpy)
+
+    let response = try await mpc.backup(.iCloud)
+
+    XCTAssertEqual(mobileSpy.mobileBackupEd25519CallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileBackupSecp256k1CallsCount, 1)
+
+    assertSharedTraceId(
+      response.traceId,
+      try reqId(fromMetadata: mobileSpy.mobileBackupEd25519MetadataParam),
+      try reqId(fromMetadata: mobileSpy.mobileBackupSecp256k1MetadataParam),
+      try XCTUnwrap(apiSpy.updateShareStatusTraceIdParam),
+      try XCTUnwrap(apiSpy.storeClientCipherTextTraceIdParam),
+      try XCTUnwrap(apiSpy.refreshClientTraceIdParam)
+    )
+  }
+
+  func test_portalMpc_recover_sharesTraceIdAcrossMpcMetadataAndApiCalls() async throws {
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileRecoverSigningSecp256k1ReturnValue = try MockConstants.mockRotateResult
+    mobileSpy.mobileRecoverSigningEd25519ReturnValue = try MockConstants.mockRotateResult
+    let apiSpy = PortalApiSpy()
+    apiSpy.mockClient = ClientResponse.stub(
+      environment: ClientResponseEnvironment.stub(backupWithPortalEnabled: true)
+    )
+    let storageSpy = PortalStorageSpy()
+    storageSpy.decryptReturnValue = try UnitTestMockConstants.mockGenerateResponseString
+    let mpc = PortalMpc(
+      apiKey: MockConstants.mockApiKey,
+      api: apiSpy,
+      keychain: MockPortalKeychain(),
+      mobile: mobileSpy
+    )
+    mpc.registerBackupMethod(.iCloud, withStorage: storageSpy)
+
+    _ = try await mpc.recover(.iCloud, withCipherText: MockConstants.mockCiphertext)
+
+    XCTAssertEqual(mobileSpy.mobileRecoverSigningEd25519CallsCount, 1)
+    XCTAssertEqual(mobileSpy.mobileRecoverSigningSecp256k1CallsCount, 1)
+
+    assertSharedTraceId(
+      try reqId(fromMetadata: mobileSpy.mobileRecoverSigningEd25519MetadataParam),
+      try reqId(fromMetadata: mobileSpy.mobileRecoverSigningSecp256k1MetadataParam),
+      try XCTUnwrap(apiSpy.getClientCipherTextTraceIdParam),
+      try XCTUnwrap(apiSpy.updateShareStatusTraceIdParam),
+      try XCTUnwrap(apiSpy.refreshClientTraceIdParam)
+    )
+  }
+
+  func test_portalMpc_eject_sharesTraceIdAcrossApiCalls() async throws {
+    let apiSpy = PortalApiSpy()
+    apiSpy.mockClient = ClientResponse.stub(
+      environment: ClientResponseEnvironment.stub(backupWithPortalEnabled: true)
+    )
+    let storageSpy = PortalStorageSpy()
+    storageSpy.decryptReturnValue = UnitTestMockConstants.decodedShare
+    let mpc = PortalMpc(
+      apiKey: MockConstants.mockApiKey,
+      api: apiSpy,
+      keychain: MockPortalKeychain(),
+      mobile: MobileSpy()
+    )
+    mpc.registerBackupMethod(.iCloud, withStorage: storageSpy)
+
+    _ = try await mpc.eject(.iCloud)
+
+    assertSharedTraceId(
+      try XCTUnwrap(apiSpy.getClientCipherTextTraceIdParam),
+      try XCTUnwrap(apiSpy.prepareEjectTraceIdParam),
+      try XCTUnwrap(apiSpy.ejectTraceIdParam)
+    )
+  }
+
+  func test_portalMpc_generateSolanaWallet_sharesTraceIdAcrossMpcMetadataAndApiCalls() async throws {
+    let mobileSpy = MobileSpy()
+    mobileSpy.mobileGenerateEd25519ReturnValue = UnitTestMockConstants.validED25519ShareRotatedResultJSON
+    let apiSpy = PortalApiSpy()
+    let keychainSpy = PortalKeychainSpy()
+    keychainSpy.getAddressesReturnValue = [
+      .eip155: MockConstants.mockEip155Address
+    ]
+    keychainSpy.getSharesReturnValue = try MockConstants.mockGenerateResponse
+    let mpc = PortalMpc(
+      apiKey: MockConstants.mockApiKey,
+      api: apiSpy,
+      keychain: keychainSpy,
+      mobile: mobileSpy
+    )
+
+    // Public wrapper may fail looking up the new Solana address from the spy keychain;
+    // the shared operation trace ID is set before that point.
+    _ = try? await mpc.generateSolanaWallet()
+
+    assertSharedTraceId(
+      try reqId(fromMetadata: mobileSpy.mobileGenerateEd25519MetadataParam),
+      try XCTUnwrap(apiSpy.updateShareStatusTraceIdParam),
+      try XCTUnwrap(apiSpy.refreshClientTraceIdParam)
+    )
+  }
+
+  // MARK: - upgradeTo7702 operation-scoped trace ID
+
+  func test_upgradeTo7702_sharesTraceIdAcrossApiAndRawSignCalls() async throws {
+    let apiMock = PortalEvmAccountTypeApiMock()
+    apiMock.getStatusReturnValue = EvmAccountTypeResponse.stub(
+      data: EvmAccountTypeData.stub(status: "EIP_155_EOA")
+    )
+    apiMock.buildAuthorizationListReturnValue = BuildAuthorizationListResponse.stub()
+    apiMock.buildAuthorizationTransactionReturnValue = BuildAuthorizationTransactionResponse.stub()
+
+    let portalMock = TraceIdEvmAccountTypePortalMock()
+    portalMock.rawSignReturnValue = PortalProviderResult(id: "1", result: "sig")
+    let sut = EvmAccountType(api: apiMock, portal: portalMock)
+
+    _ = try await sut.upgradeTo7702(chainId: "eip155:11155111")
+
+    assertSharedTraceId(
+      try XCTUnwrap(apiMock.getStatusTraceId),
+      try XCTUnwrap(apiMock.buildAuthorizationListTraceId),
+      try XCTUnwrap(portalMock.rawSignTraceId),
+      try XCTUnwrap(apiMock.buildAuthorizationTransactionTraceId)
+    )
+  }
+
+  // MARK: - wallet_getCapabilities request trace ID
+
+  func test_portalProvider_walletGetCapabilities_forwardsRequestTraceId() async throws {
+    let apiSpy = PortalApiSpy()
+    let provider = try PortalProvider(
+      apiKey: MockConstants.mockApiKey,
+      rpcConfig: ["eip155:11155111": "https://\(MockConstants.mockHost)/test-rpc"],
+      keychain: MockPortalKeychain(),
+      autoApprove: true,
+      requests: MockPortalRequests(),
+      signer: MockPortalMpcSigner(apiKey: MockConstants.mockApiKey, keychain: MockPortalKeychain())
+    )
+    provider.api = apiSpy
+
+    _ = try await provider.request(
+      chainId: "eip155:11155111",
+      method: .wallet_getCapabilities,
+      params: nil,
+      options: RequestOptions(traceId: "capabilities-trace-123")
+    )
+
+    XCTAssertEqual(apiSpy.getWalletCapabilitiesTraceIdParam, "capabilities-trace-123")
+  }
+
+  // MARK: - Helpers
+
+  private func reqId(fromMetadata metadata: String?) throws -> String {
+    let metadata = try XCTUnwrap(metadata)
+    let data = try XCTUnwrap(metadata.data(using: .utf8))
+    let decoded = try JSONDecoder().decode(MpcMetadata.self, from: data)
+    return try XCTUnwrap(decoded.reqId, "MPC metadata should include reqId. Got: \(metadata)")
+  }
+
+  private func assertSharedTraceId(
+    _ ids: String...,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    guard let first = ids.first else {
+      XCTFail("Expected at least one trace ID", file: file, line: line)
+      return
+    }
+    for id in ids {
+      XCTAssertEqual(id, first, "Expected a single shared operation trace ID", file: file, line: line)
+    }
+    XCTAssertNotNil(UUID(uuidString: first), "Operation trace ID should be a valid UUID", file: file, line: line)
+  }
+}
+
+/// Minimal portal dependency mock for upgradeTo7702 trace ID assertions.
+private final class TraceIdEvmAccountTypePortalMock: EvmAccountTypePortalDependency {
+  var rawSignReturnValue: PortalProviderResult?
+  var rawSignTraceId: String?
+
+  func rawSign(
+    message _: String,
+    chainId _: String,
+    signatureApprovalMemo _: String?,
+    traceId: String?
+  ) async throws -> PortalProviderResult {
+    rawSignTraceId = traceId
+    return rawSignReturnValue ?? PortalProviderResult(id: "1", result: "sig")
+  }
+
+  func request(
+    chainId _: String,
+    method _: PortalRequestMethod,
+    params _: [Any],
+    options _: RequestOptions?
+  ) async throws -> PortalProviderResult {
+    PortalProviderResult(id: "1", result: "0xtxhash")
+  }
+}

--- a/Tests/PortalSwiftTests/Trading/LifiMock.swift
+++ b/Tests/PortalSwiftTests/Trading/LifiMock.swift
@@ -16,6 +16,8 @@ final class LifiMock: LifiProtocol {
   var getQuoteReturnValue: LifiQuoteResponse?
   var getStatusReturnValue: LifiStatusResponse?
   var getRouteStepReturnValue: LifiStepTransactionResponse?
+  var tradeAssetReturnValue: LifiTradeAssetResult?
+  var pollStatusReturnValue: LifiStatusRawResponse?
 
   // MARK: - Error simulation
 
@@ -23,6 +25,8 @@ final class LifiMock: LifiProtocol {
   var getQuoteError: Error?
   var getStatusError: Error?
   var getRouteStepError: Error?
+  var tradeAssetError: Error?
+  var pollStatusError: Error?
 
   // MARK: - Call counters
 
@@ -30,6 +34,8 @@ final class LifiMock: LifiProtocol {
   var getQuoteCalls = 0
   var getStatusCalls = 0
   var getRouteStepCalls = 0
+  var tradeAssetCalls = 0
+  var pollStatusCalls = 0
 
   // MARK: - Call parameters
 
@@ -37,6 +43,8 @@ final class LifiMock: LifiProtocol {
   var getQuoteRequestParam: LifiQuoteRequest?
   var getStatusRequestParam: LifiStatusRequest?
   var getRouteStepRequestParam: LifiStepTransactionRequest?
+  var tradeAssetParamsParam: LifiTradeAssetParams?
+  var pollStatusRequestParam: LifiStatusRequest?
 
   // MARK: - Protocol Implementation
 
@@ -76,6 +84,40 @@ final class LifiMock: LifiProtocol {
     return getRouteStepReturnValue ?? LifiStepTransactionResponse.stub()
   }
 
+  func tradeAsset(params: LifiTradeAssetParams) async throws -> LifiTradeAssetResult {
+    tradeAssetCalls += 1
+    tradeAssetParamsParam = params
+    if let error = tradeAssetError {
+      throw error
+    }
+    return tradeAssetReturnValue ?? LifiTradeAssetResult.stub()
+  }
+
+  func pollStatus(
+    request: LifiStatusRequest,
+    onUpdate: ((LifiStatusRawResponse) -> Bool)?,
+    options _: LifiPollStatusOptions
+  ) async throws -> LifiStatusRawResponse {
+    pollStatusCalls += 1
+    pollStatusRequestParam = request
+    if let error = pollStatusError {
+      throw error
+    }
+    let result = pollStatusReturnValue ?? LifiStatusRawResponse.stub()
+    // Mirror the real Lifi.pollStatus contract: only invoke onUpdate for non-terminal statuses,
+    // and throw on a FAILED terminal state instead of returning it.
+    switch result.status {
+    case .done:
+      return result
+    case .failed:
+      let detail = result.substatusMessage ?? result.substatus?.rawValue ?? "LiFi transfer FAILED"
+      throw LifiTradeAssetError.lifiTransferFailed(detail)
+    default:
+      _ = onUpdate?(result)
+      return result
+    }
+  }
+
   // MARK: - Helper Methods
 
   /// Resets all call counters and captured parameters
@@ -84,20 +126,28 @@ final class LifiMock: LifiProtocol {
     getQuoteCalls = 0
     getStatusCalls = 0
     getRouteStepCalls = 0
+    tradeAssetCalls = 0
+    pollStatusCalls = 0
 
     getRoutesRequestParam = nil
     getQuoteRequestParam = nil
     getStatusRequestParam = nil
     getRouteStepRequestParam = nil
+    tradeAssetParamsParam = nil
+    pollStatusRequestParam = nil
 
     getRoutesReturnValue = nil
     getQuoteReturnValue = nil
     getStatusReturnValue = nil
     getRouteStepReturnValue = nil
+    tradeAssetReturnValue = nil
+    pollStatusReturnValue = nil
 
     getRoutesError = nil
     getQuoteError = nil
     getStatusError = nil
     getRouteStepError = nil
+    tradeAssetError = nil
+    pollStatusError = nil
   }
 }

--- a/Tests/PortalSwiftTests/Trading/LifiTradeAssetTests.swift
+++ b/Tests/PortalSwiftTests/Trading/LifiTradeAssetTests.swift
@@ -1,0 +1,704 @@
+//
+//  LifiTradeAssetTests.swift
+//  PortalSwift
+//
+//  Created by Portal Labs
+//
+
+import AnyCodable
+import Foundation
+@testable import PortalSwift
+import XCTest
+
+final class LifiTradeAssetTests: XCTestCase {
+  var apiMock: PortalLifiTradingApiMock!
+
+  // Fast poll options so the per-step LiFi status poll doesn't add real delays in tests.
+  private let fastPollOptions = LifiPollStatusOptions(everyMs: 1, initialDelayMs: 0, timeoutMs: 5000)
+
+  override func setUpWithError() throws {
+    apiMock = PortalLifiTradingApiMock()
+  }
+
+  override func tearDownWithError() throws {
+    apiMock = nil
+  }
+
+  // MARK: - Helpers
+
+  private func makeStepWithTransactionRequest(
+    from: String = "0x1234567890abcdef1234567890abcdef12345678",
+    to: String = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+    value: String = "0x0",
+    data: String = "0xdeadbeef",
+    tool: String = "relay",
+    fromChainId: String = "8453",
+    toChainId: String = "137"
+  ) -> LifiStep {
+    let action = LifiAction.stub(fromChainId: fromChainId, toChainId: toChainId)
+    let transactionRequest = AnyCodable([
+      "from": from,
+      "to": to,
+      "value": value,
+      "data": data,
+      "chainId": fromChainId,
+    ])
+    return LifiStep.stub(tool: tool, action: action, transactionRequest: transactionRequest)
+  }
+
+  private func makeLifi(
+    signAndSend: @escaping LifiSignAndSendTransaction,
+    waitForConfirmation: @escaping LifiWaitForConfirmation
+  ) -> Lifi {
+    Lifi(
+      api: apiMock,
+      signAndSendTransaction: signAndSend,
+      waitForConfirmation: waitForConfirmation,
+      stepPollOptions: fastPollOptions
+    )
+  }
+
+  /// Builds a step whose transactionRequest carries a raw (non-String) `value` and/or `chainId` so
+  /// the Int/Double parsing and CAIP-2 normalization branches can be exercised. Passing
+  /// `chainId: nil` omits the key entirely (forcing the `action.fromChainId` fallback).
+  private func makeStepWithRawTransaction(
+    value: Any = "0x0",
+    chainId: Any? = "8453",
+    fromChainId: String = "8453",
+    toChainId: String = "137",
+    from: String = "0x1234567890abcdef1234567890abcdef12345678",
+    to: String = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+    data: String = "0xdeadbeef",
+    tool: String = "relay"
+  ) -> LifiStep {
+    var dict: [String: Any] = ["from": from, "to": to, "value": value, "data": data]
+    if let chainId {
+      dict["chainId"] = chainId
+    }
+    let action = LifiAction.stub(fromChainId: fromChainId, toChainId: toChainId)
+    return LifiStep.stub(tool: tool, action: action, transactionRequest: AnyCodable(dict))
+  }
+
+  /// Runs a single-step, single-route `tradeAsset` where `getRouteStep` returns `step`, capturing
+  /// the `ETHTransactionParam` and CAIP-2 chainId passed to the signer. Resets the api mock first.
+  private func runTradeAsset(
+    returningStep step: LifiStep
+  ) async throws -> (transaction: ETHTransactionParam?, chainId: String) {
+    apiMock.reset()
+    let route = LifiRoute.stub(steps: [step])
+    apiMock.getRoutesReturnValue = LifiRoutesResponse.stub(
+      data: LifiRoutesData(rawResponse: LifiRoutesRawResponse(routes: [route]))
+    )
+    apiMock.getRouteStepReturnValue = LifiStepTransactionResponse(
+      data: LifiStepTransactionData(rawResponse: step), error: nil
+    )
+    apiMock.getStatusReturnValue = LifiStatusResponse.stub(
+      data: LifiStatusData(rawResponse: LifiStatusRawResponse.stub(status: .done))
+    )
+    var capturedTx: ETHTransactionParam?
+    var capturedChainId = ""
+    let lifi = makeLifi(
+      signAndSend: { tx, chainId in
+        capturedTx = tx
+        capturedChainId = chainId
+        return "0xhash1"
+      },
+      waitForConfirmation: { _, _ in .confirmed }
+    )
+    _ = try await lifi.tradeAsset(params: LifiTradeAssetParams.stub())
+    return (capturedTx, capturedChainId)
+  }
+}
+
+// MARK: - tradeAsset success
+
+extension LifiTradeAssetTests {
+  func test_tradeAsset_singleStep_succeeds() async throws {
+    // given
+    let step = makeStepWithTransactionRequest()
+    let route = LifiRoute.stub(steps: [step])
+    apiMock.getRoutesReturnValue = LifiRoutesResponse.stub(
+      data: LifiRoutesData(rawResponse: LifiRoutesRawResponse(routes: [route]))
+    )
+    apiMock.getRouteStepReturnValue = LifiStepTransactionResponse(
+      data: LifiStepTransactionData(rawResponse: step), error: nil
+    )
+    apiMock.getStatusReturnValue = LifiStatusResponse.stub(
+      data: LifiStatusData(rawResponse: LifiStatusRawResponse.stub(status: .done))
+    )
+
+    var signedChainIds: [String] = []
+    let lifi = makeLifi(
+      signAndSend: { _, chainId in
+        signedChainIds.append(chainId)
+        return "0xhash1"
+      },
+      waitForConfirmation: { _, _ in .confirmed }
+    )
+
+    // when
+    let result = try await lifi.tradeAsset(params: LifiTradeAssetParams.stub())
+
+    // then
+    XCTAssertEqual(result.hashes, ["0xhash1"])
+    XCTAssertEqual(result.steps.count, 1)
+    XCTAssertEqual(apiMock.getRoutesCalls, 1)
+    XCTAssertEqual(apiMock.getRouteStepCalls, 1)
+    XCTAssertGreaterThanOrEqual(apiMock.getStatusCalls, 1)
+    XCTAssertEqual(signedChainIds, ["eip155:8453"])
+  }
+
+  func test_tradeAsset_multipleSteps_executesSequentially() async throws {
+    // given
+    let step1 = makeStepWithTransactionRequest(data: "0x01", fromChainId: "8453")
+    let step2 = makeStepWithTransactionRequest(data: "0x02", fromChainId: "137")
+    let route = LifiRoute.stub(steps: [step1, step2])
+    apiMock.getRoutesReturnValue = LifiRoutesResponse.stub(
+      data: LifiRoutesData(rawResponse: LifiRoutesRawResponse(routes: [route]))
+    )
+    // Return a DISTINCT response per step (step1 then step2) so per-step transaction parsing and
+    // CAIP-2 chainId resolution are actually exercised rather than reusing step1 for both.
+    apiMock.getRouteStepResultSequence = [
+      Swift.Result<LifiStepTransactionResponse, Error>.success(
+        LifiStepTransactionResponse(data: LifiStepTransactionData(rawResponse: step1), error: nil)
+      ),
+      Swift.Result<LifiStepTransactionResponse, Error>.success(
+        LifiStepTransactionResponse(data: LifiStepTransactionData(rawResponse: step2), error: nil)
+      ),
+    ]
+    apiMock.getStatusReturnValue = LifiStatusResponse.stub(
+      data: LifiStatusData(rawResponse: LifiStatusRawResponse.stub(status: .done))
+    )
+
+    var signCount = 0
+    var signedChainIds: [String] = []
+    let lifi = makeLifi(
+      signAndSend: { _, chainId in
+        signCount += 1
+        signedChainIds.append(chainId)
+        return "0xhash\(signCount)"
+      },
+      waitForConfirmation: { _, _ in .confirmed }
+    )
+
+    // when
+    let result = try await lifi.tradeAsset(params: LifiTradeAssetParams.stub())
+
+    // then
+    XCTAssertEqual(result.hashes, ["0xhash1", "0xhash2"])
+    XCTAssertEqual(result.steps.count, 2)
+    XCTAssertEqual(apiMock.getRouteStepCalls, 2)
+    // The last getRouteStep request must correspond to step2 (not a reused step1), so the steps
+    // are fetched in order. step1/step2 are distinguished by their action.fromChainId.
+    XCTAssertEqual(apiMock.getRouteStepRequestParam?.action.fromChainId, "137")
+    // Each step's own chainId is resolved independently (step1 -> 8453, step2 -> 137).
+    XCTAssertEqual(signedChainIds, ["eip155:8453", "eip155:137"])
+  }
+
+  func test_tradeAsset_emitsProgressStatuses() async throws {
+    // given
+    let step = makeStepWithTransactionRequest()
+    let route = LifiRoute.stub(steps: [step])
+    apiMock.getRoutesReturnValue = LifiRoutesResponse.stub(
+      data: LifiRoutesData(rawResponse: LifiRoutesRawResponse(routes: [route]))
+    )
+    apiMock.getRouteStepReturnValue = LifiStepTransactionResponse(
+      data: LifiStepTransactionData(rawResponse: step), error: nil
+    )
+    apiMock.getStatusReturnValue = LifiStatusResponse.stub(
+      data: LifiStatusData(rawResponse: LifiStatusRawResponse.stub(status: .done))
+    )
+
+    var statuses: [LifiTradeAssetProgressStatus] = []
+    let params = LifiTradeAssetParams.stub(onProgress: { status, _ in
+      statuses.append(status)
+    })
+
+    let lifi = makeLifi(
+      signAndSend: { _, _ in "0xhash1" },
+      waitForConfirmation: { _, _ in .confirmed }
+    )
+
+    // when
+    _ = try await lifi.tradeAsset(params: params)
+
+    // then
+    XCTAssertEqual(statuses.first, .fetchingRoutes)
+    XCTAssertTrue(statuses.contains(.routeSelected))
+    XCTAssertTrue(statuses.contains(.preparingStep))
+    XCTAssertTrue(statuses.contains(.signing))
+    XCTAssertTrue(statuses.contains(.submitted))
+    XCTAssertTrue(statuses.contains(.confirming))
+    XCTAssertTrue(statuses.contains(.lifiPending))
+    XCTAssertTrue(statuses.contains(.stepDone))
+    XCTAssertEqual(statuses.last, .complete)
+  }
+}
+
+// MARK: - tradeAsset failures
+
+extension LifiTradeAssetTests {
+  func test_tradeAsset_withoutSigner_throwsMissingSigner() async {
+    // given
+    let lifi = Lifi(api: apiMock)
+
+    // when / then
+    do {
+      _ = try await lifi.tradeAsset(params: LifiTradeAssetParams.stub())
+      XCTFail("Expected error to be thrown")
+    } catch {
+      XCTAssertEqual(error as? LifiTradeAssetError, .missingSigner)
+    }
+  }
+
+  func test_tradeAsset_withoutConfirmation_throwsMissingConfirmation() async {
+    // given
+    let lifi = Lifi(
+      api: apiMock,
+      signAndSendTransaction: { _, _ in "0xhash" },
+      waitForConfirmation: nil
+    )
+
+    // when / then
+    do {
+      _ = try await lifi.tradeAsset(params: LifiTradeAssetParams.stub())
+      XCTFail("Expected error to be thrown")
+    } catch {
+      XCTAssertEqual(error as? LifiTradeAssetError, .missingConfirmation)
+    }
+  }
+
+  func test_tradeAsset_withNoRoutes_throwsNoRoutesFound() async {
+    // given
+    apiMock.getRoutesReturnValue = LifiRoutesResponse.stub(
+      data: LifiRoutesData(rawResponse: LifiRoutesRawResponse(routes: []))
+    )
+    let lifi = makeLifi(
+      signAndSend: { _, _ in "0xhash" },
+      waitForConfirmation: { _, _ in .confirmed }
+    )
+
+    // when / then
+    do {
+      _ = try await lifi.tradeAsset(params: LifiTradeAssetParams.stub())
+      XCTFail("Expected error to be thrown")
+    } catch {
+      XCTAssertEqual(error as? LifiTradeAssetError, .noRoutesFound)
+    }
+  }
+
+  func test_tradeAsset_confirmationFails_throwsAndReportsFailed() async {
+    // given
+    let step = makeStepWithTransactionRequest()
+    let route = LifiRoute.stub(steps: [step])
+    apiMock.getRoutesReturnValue = LifiRoutesResponse.stub(
+      data: LifiRoutesData(rawResponse: LifiRoutesRawResponse(routes: [route]))
+    )
+    apiMock.getRouteStepReturnValue = LifiStepTransactionResponse(
+      data: LifiStepTransactionData(rawResponse: step), error: nil
+    )
+
+    var failedReported = false
+    let params = LifiTradeAssetParams.stub(onProgress: { status, _ in
+      if status == .failed { failedReported = true }
+    })
+
+    let lifi = makeLifi(
+      signAndSend: { _, _ in "0xhash1" },
+      waitForConfirmation: { _, _ in .reverted }
+    )
+
+    // when / then
+    do {
+      _ = try await lifi.tradeAsset(params: params)
+      XCTFail("Expected error to be thrown")
+    } catch {
+      XCTAssertEqual(error as? LifiTradeAssetError, .transactionConfirmationFailed("0xhash1"))
+      XCTAssertTrue(failedReported)
+    }
+  }
+
+  func test_tradeAsset_confirmationTimedOut_throwsTimedOutAndReportsFailed() async {
+    // given
+    let step = makeStepWithTransactionRequest()
+    let route = LifiRoute.stub(steps: [step])
+    apiMock.getRoutesReturnValue = LifiRoutesResponse.stub(
+      data: LifiRoutesData(rawResponse: LifiRoutesRawResponse(routes: [route]))
+    )
+    apiMock.getRouteStepReturnValue = LifiStepTransactionResponse(
+      data: LifiStepTransactionData(rawResponse: step), error: nil
+    )
+
+    var failedReported = false
+    let params = LifiTradeAssetParams.stub(onProgress: { status, _ in
+      if status == .failed { failedReported = true }
+    })
+
+    let lifi = makeLifi(
+      signAndSend: { _, _ in "0xhash1" },
+      waitForConfirmation: { _, _ in .timedOut }
+    )
+
+    // when / then
+    do {
+      _ = try await lifi.tradeAsset(params: params)
+      XCTFail("Expected error to be thrown")
+    } catch {
+      XCTAssertEqual(error as? LifiTradeAssetError, .transactionConfirmationTimedOut("0xhash1"))
+      XCTAssertTrue(failedReported)
+    }
+  }
+
+  func test_tradeAsset_lifiStatusFailed_throwsLifiTransferFailed() async {
+    // given
+    let step = makeStepWithTransactionRequest()
+    let route = LifiRoute.stub(steps: [step])
+    apiMock.getRoutesReturnValue = LifiRoutesResponse.stub(
+      data: LifiRoutesData(rawResponse: LifiRoutesRawResponse(routes: [route]))
+    )
+    apiMock.getRouteStepReturnValue = LifiStepTransactionResponse(
+      data: LifiStepTransactionData(rawResponse: step), error: nil
+    )
+    apiMock.getStatusReturnValue = LifiStatusResponse.stub(
+      data: LifiStatusData(rawResponse: LifiStatusRawResponse.stub(
+        status: .failed,
+        substatus: .unknownError,
+        substatusMessage: "Bridge reverted"
+      ))
+    )
+
+    let lifi = makeLifi(
+      signAndSend: { _, _ in "0xhash1" },
+      waitForConfirmation: { _, _ in .confirmed }
+    )
+
+    // when / then
+    do {
+      _ = try await lifi.tradeAsset(params: LifiTradeAssetParams.stub())
+      XCTFail("Expected error to be thrown")
+    } catch {
+      XCTAssertEqual(error as? LifiTradeAssetError, .lifiTransferFailed("Bridge reverted"))
+    }
+  }
+
+  func test_tradeAsset_routeIndexOutOfBounds_throws() async {
+    // given
+    let step = makeStepWithTransactionRequest()
+    let route = LifiRoute.stub(steps: [step])
+    apiMock.getRoutesReturnValue = LifiRoutesResponse.stub(
+      data: LifiRoutesData(rawResponse: LifiRoutesRawResponse(routes: [route]))
+    )
+    let lifi = makeLifi(
+      signAndSend: { _, _ in "0xhash1" },
+      waitForConfirmation: { _, _ in .confirmed }
+    )
+
+    // when / then
+    do {
+      _ = try await lifi.tradeAsset(params: LifiTradeAssetParams.stub(routeIndex: 5))
+      XCTFail("Expected error to be thrown")
+    } catch {
+      XCTAssertEqual(error as? LifiTradeAssetError, .routeIndexOutOfBounds)
+    }
+  }
+}
+
+// MARK: - transaction value parsing
+
+extension LifiTradeAssetTests {
+  func test_tradeAsset_parsesIntValue_usesLlxFormatWithoutTruncation() async throws {
+    // A wei amount larger than UInt32.max would be truncated by %x; %llx must be used.
+    let bigWei = 12_345_678_901_234
+    let result = try await runTradeAsset(returningStep: makeStepWithRawTransaction(value: bigWei))
+    XCTAssertEqual(result.transaction?.value, String(format: "0x%llx", UInt64(bigWei)))
+  }
+
+  func test_tradeAsset_parsesIntegralDoubleValue() async throws {
+    let result = try await runTradeAsset(returningStep: makeStepWithRawTransaction(value: 1_000_000.0))
+    XCTAssertEqual(result.transaction?.value, "0xf4240") // 1_000_000
+  }
+
+  func test_tradeAsset_rejectsFractionalDoubleValue_throwsInvalidTransactionRequest() async {
+    do {
+      _ = try await runTradeAsset(returningStep: makeStepWithRawTransaction(value: 1.5))
+      XCTFail("Expected error to be thrown")
+    } catch {
+      XCTAssertEqual(error as? LifiTradeAssetError, .invalidTransactionRequest)
+    }
+  }
+
+  func test_tradeAsset_rejectsUnsafeIntegerDoubleValue_throwsInvalidTransactionRequest() async {
+    // Beyond 2^53 a Double can't represent every integer, so it must be rejected.
+    let unsafe = Double(UInt64(1) << 60)
+    do {
+      _ = try await runTradeAsset(returningStep: makeStepWithRawTransaction(value: unsafe))
+      XCTFail("Expected error to be thrown")
+    } catch {
+      XCTAssertEqual(error as? LifiTradeAssetError, .invalidTransactionRequest)
+    }
+  }
+
+  func test_tradeAsset_rejectsNegativeIntValue_throwsInvalidTransactionRequest() async {
+    // A negative Int value must fail fast rather than silently signing 0x0.
+    do {
+      _ = try await runTradeAsset(returningStep: makeStepWithRawTransaction(value: -1))
+      XCTFail("Expected error to be thrown")
+    } catch {
+      XCTAssertEqual(error as? LifiTradeAssetError, .invalidTransactionRequest)
+    }
+  }
+
+  func test_tradeAsset_rejectsUnexpectedValueType_throwsInvalidTransactionRequest() async {
+    // A value present but of an unexpected type (e.g. Bool) must fail fast, not default to 0x0.
+    do {
+      _ = try await runTradeAsset(returningStep: makeStepWithRawTransaction(value: true))
+      XCTFail("Expected error to be thrown")
+    } catch {
+      XCTAssertEqual(error as? LifiTradeAssetError, .invalidTransactionRequest)
+    }
+  }
+}
+
+// MARK: - JSON-decoded transactionRequest (production decode path)
+
+extension LifiTradeAssetTests {
+  func test_tradeAsset_decodesTransactionRequestFromJSON_parsesCorrectly() async throws {
+    // Production decodes `transactionRequest` from the API JSON via AnyCodable, not from a native
+    // Swift dict. Decode it exactly that way here to prove `transactionRequest.value as? [String:
+    // Any]` holds (Flight-School AnyCodable unwraps nested objects to [String: Any]) and that the
+    // value/chainId are parsed from the decoded payload.
+    let json = """
+    {
+      "from": "0x1234567890abcdef1234567890abcdef12345678",
+      "to": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+      "value": "0x16345785d8a0000",
+      "data": "0xdeadbeef",
+      "chainId": 8453
+    }
+    """.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(AnyCodable.self, from: json)
+    // Sanity: the decoded object is [String: Any], so the cast in parseLifiTransactionRequest works.
+    XCTAssertNotNil(decoded.value as? [String: Any])
+
+    let step = LifiStep.stub(
+      action: LifiAction.stub(fromChainId: "8453", toChainId: "137"),
+      transactionRequest: decoded
+    )
+    let result = try await runTradeAsset(returningStep: step)
+
+    XCTAssertEqual(result.transaction?.value, "0x16345785d8a0000")
+    XCTAssertEqual(result.transaction?.to, "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd")
+    XCTAssertEqual(result.transaction?.from, "0x1234567890abcdef1234567890abcdef12345678")
+    // chainId arrives as a JSON number (Int) and normalizes to CAIP-2.
+    XCTAssertEqual(result.chainId, "eip155:8453")
+  }
+}
+
+// MARK: - CAIP-2 normalization
+
+extension LifiTradeAssetTests {
+  func test_tradeAsset_caip2Normalization_variants() async throws {
+    // decimal string
+    var r = try await runTradeAsset(returningStep: makeStepWithRawTransaction(chainId: "8453"))
+    XCTAssertEqual(r.chainId, "eip155:8453")
+    // hex string
+    r = try await runTradeAsset(returningStep: makeStepWithRawTransaction(chainId: "0x2105"))
+    XCTAssertEqual(r.chainId, "eip155:8453")
+    // already-prefixed eip155 (no double prefix)
+    r = try await runTradeAsset(returningStep: makeStepWithRawTransaction(chainId: "eip155:8453"))
+    XCTAssertEqual(r.chainId, "eip155:8453")
+    // Int
+    r = try await runTradeAsset(returningStep: makeStepWithRawTransaction(chainId: 8453))
+    XCTAssertEqual(r.chainId, "eip155:8453")
+    // integral Double
+    r = try await runTradeAsset(returningStep: makeStepWithRawTransaction(chainId: 8453.0))
+    XCTAssertEqual(r.chainId, "eip155:8453")
+    // missing chainId -> falls back to action.fromChainId
+    r = try await runTradeAsset(returningStep: makeStepWithRawTransaction(chainId: nil, fromChainId: "42161"))
+    XCTAssertEqual(r.chainId, "eip155:42161")
+  }
+
+  func test_tradeAsset_caip2Normalization_rejectsNonPositiveChainId_fallsBack() async throws {
+    // Negative / zero numeric chainIds must not become invalid ids like "eip155:-1"; they fall
+    // back to the step's action.fromChainId instead.
+    var r = try await runTradeAsset(returningStep: makeStepWithRawTransaction(chainId: -1, fromChainId: "42161"))
+    XCTAssertEqual(r.chainId, "eip155:42161")
+    r = try await runTradeAsset(returningStep: makeStepWithRawTransaction(chainId: -1.0, fromChainId: "42161"))
+    XCTAssertEqual(r.chainId, "eip155:42161")
+    r = try await runTradeAsset(returningStep: makeStepWithRawTransaction(chainId: 0, fromChainId: "42161"))
+    XCTAssertEqual(r.chainId, "eip155:42161")
+  }
+}
+
+// MARK: - tradeAsset error cases
+
+extension LifiTradeAssetTests {
+  func test_tradeAsset_routeHasNoSteps_throws() async {
+    apiMock.getRoutesReturnValue = LifiRoutesResponse.stub(
+      data: LifiRoutesData(rawResponse: LifiRoutesRawResponse(routes: [LifiRoute.stub(steps: [])]))
+    )
+    let lifi = makeLifi(signAndSend: { _, _ in "0xhash" }, waitForConfirmation: { _, _ in .confirmed })
+
+    do {
+      _ = try await lifi.tradeAsset(params: LifiTradeAssetParams.stub())
+      XCTFail("Expected error to be thrown")
+    } catch {
+      XCTAssertEqual(error as? LifiTradeAssetError, .routeHasNoSteps)
+    }
+  }
+
+  func test_tradeAsset_missingTransactionRequest_throws() async {
+    let route = LifiRoute.stub(steps: [makeStepWithTransactionRequest()])
+    apiMock.getRoutesReturnValue = LifiRoutesResponse.stub(
+      data: LifiRoutesData(rawResponse: LifiRoutesRawResponse(routes: [route]))
+    )
+    // getRouteStep returns a step with no transactionRequest at all.
+    apiMock.getRouteStepReturnValue = LifiStepTransactionResponse(
+      data: LifiStepTransactionData(rawResponse: LifiStep.stub(transactionRequest: nil)), error: nil
+    )
+    let lifi = makeLifi(signAndSend: { _, _ in "0xhash" }, waitForConfirmation: { _, _ in .confirmed })
+
+    do {
+      _ = try await lifi.tradeAsset(params: LifiTradeAssetParams.stub())
+      XCTFail("Expected error to be thrown")
+    } catch {
+      XCTAssertEqual(error as? LifiTradeAssetError, .missingTransactionRequest)
+    }
+  }
+
+  func test_tradeAsset_invalidTransactionRequest_throws() async {
+    let route = LifiRoute.stub(steps: [makeStepWithTransactionRequest()])
+    apiMock.getRoutesReturnValue = LifiRoutesResponse.stub(
+      data: LifiRoutesData(rawResponse: LifiRoutesRawResponse(routes: [route]))
+    )
+    // transactionRequest present but not an object — malformed, not missing.
+    apiMock.getRouteStepReturnValue = LifiStepTransactionResponse(
+      data: LifiStepTransactionData(rawResponse: LifiStep.stub(transactionRequest: AnyCodable("not-an-object"))),
+      error: nil
+    )
+    let lifi = makeLifi(signAndSend: { _, _ in "0xhash" }, waitForConfirmation: { _, _ in .confirmed })
+
+    do {
+      _ = try await lifi.tradeAsset(params: LifiTradeAssetParams.stub())
+      XCTFail("Expected error to be thrown")
+    } catch {
+      XCTAssertEqual(error as? LifiTradeAssetError, .invalidTransactionRequest)
+    }
+  }
+}
+
+// MARK: - pollStatus
+
+extension LifiTradeAssetTests {
+  func test_pollStatus_done_returnsTerminal() async throws {
+    // given
+    apiMock.getStatusReturnValue = LifiStatusResponse.stub(
+      data: LifiStatusData(rawResponse: LifiStatusRawResponse.stub(status: .done))
+    )
+    let lifi = Lifi(api: apiMock)
+
+    // when
+    let terminal = try await lifi.pollStatus(request: LifiStatusRequest.stub(), options: fastPollOptions)
+
+    // then
+    XCTAssertEqual(terminal.status, .done)
+    XCTAssertGreaterThanOrEqual(apiMock.getStatusCalls, 1)
+  }
+
+  func test_pollStatus_failed_throws() async {
+    // given
+    apiMock.getStatusReturnValue = LifiStatusResponse.stub(
+      data: LifiStatusData(rawResponse: LifiStatusRawResponse.stub(
+        status: .failed,
+        substatusMessage: "Failed transfer"
+      ))
+    )
+    let lifi = Lifi(api: apiMock)
+
+    // when / then
+    do {
+      _ = try await lifi.pollStatus(request: LifiStatusRequest.stub(), options: fastPollOptions)
+      XCTFail("Expected error to be thrown")
+    } catch {
+      XCTAssertEqual(error as? LifiTradeAssetError, .lifiTransferFailed("Failed transfer"))
+    }
+  }
+
+  func test_pollStatus_onUpdateReturningFalse_stops() async throws {
+    // given a pending status that never resolves
+    apiMock.getStatusReturnValue = LifiStatusResponse.stub(
+      data: LifiStatusData(rawResponse: LifiStatusRawResponse.stub(status: .pending))
+    )
+    let lifi = Lifi(api: apiMock)
+
+    // when - onUpdate returns false to stop after the first poll
+    let result = try await lifi.pollStatus(
+      request: LifiStatusRequest.stub(),
+      onUpdate: { _ in false }
+    )
+
+    // then
+    XCTAssertEqual(result.status, .pending)
+  }
+
+  func test_pollStatus_timesOut_throwsPollTimeout() async {
+    // given a status that never reaches a terminal state and a tiny timeout
+    apiMock.getStatusReturnValue = LifiStatusResponse.stub(
+      data: LifiStatusData(rawResponse: LifiStatusRawResponse.stub(status: .pending))
+    )
+    let lifi = Lifi(api: apiMock)
+    let options = LifiPollStatusOptions(everyMs: 1, initialDelayMs: 0, timeoutMs: 1)
+
+    // when / then
+    do {
+      _ = try await lifi.pollStatus(request: LifiStatusRequest.stub(), options: options)
+      XCTFail("Expected error to be thrown")
+    } catch {
+      XCTAssertEqual(error as? LifiTradeAssetError, .pollTimeout)
+    }
+  }
+
+  func test_pollStatus_transientErrorThenRecovers_returnsTerminal() async throws {
+    // given a transient network error on the first poll, then a DONE status
+    struct TransientError: Error {}
+    apiMock.getStatusResultSequence = [
+      Swift.Result<LifiStatusResponse, Error>.failure(TransientError()),
+      Swift.Result<LifiStatusResponse, Error>.success(LifiStatusResponse.stub(
+        data: LifiStatusData(rawResponse: LifiStatusRawResponse.stub(status: .done))
+      )),
+    ]
+    let lifi = Lifi(api: apiMock)
+
+    // when
+    let terminal = try await lifi.pollStatus(request: LifiStatusRequest.stub(), options: fastPollOptions)
+
+    // then - the transient error was retried, not surfaced
+    XCTAssertEqual(terminal.status, .done)
+    XCTAssertEqual(apiMock.getStatusCalls, 2)
+  }
+
+  func test_pollStatus_cancellation_throwsCancellationError() async {
+    // given a status that never resolves and a long poll interval so the task parks in sleep
+    apiMock.getStatusReturnValue = LifiStatusResponse.stub(
+      data: LifiStatusData(rawResponse: LifiStatusRawResponse.stub(status: .pending))
+    )
+    let lifi = Lifi(api: apiMock)
+    let options = LifiPollStatusOptions(everyMs: 10_000, initialDelayMs: 0, timeoutMs: 600_000)
+
+    let task = Task { () -> LifiStatusRawResponse in
+      try await lifi.pollStatus(request: LifiStatusRequest.stub(), options: options)
+    }
+
+    // let it enter the polling loop, then cancel
+    try? await Task.sleep(nanoseconds: 150_000_000) // 150ms
+    task.cancel()
+
+    // then
+    do {
+      _ = try await task.value
+      XCTFail("Expected cancellation to propagate")
+    } catch {
+      XCTAssertTrue(error is CancellationError, "Expected CancellationError, got \(error)")
+    }
+  }
+}

--- a/Tests/PortalSwiftTests/Yield/YieldXyzCodableTests.swift
+++ b/Tests/PortalSwiftTests/Yield/YieldXyzCodableTests.swift
@@ -1,0 +1,122 @@
+//
+//  YieldXyzCodableTests.swift
+//  PortalSwiftTests
+//
+
+@testable import PortalSwift
+import XCTest
+
+final class YieldXyzCodableTests: XCTestCase {
+  let decoder = JSONDecoder()
+
+  func test_getYieldsResponse_decodesLendingYieldSource() throws {
+    let json = """
+    {
+      "data": {
+        "rawResponse": {
+          "items": [
+            {
+              "id": "ethereum-sepolia-link-aave-v3-lending",
+              "network": "eip155:11155111",
+              "inputTokens": [
+                {
+                  "symbol": "LINK",
+                  "name": "LINK",
+                  "decimals": 18,
+                  "network": "eip155:11155111",
+                  "address": "0xf8Fb3713D459D7C1018BD0A49D19b4C44290EBE5",
+                  "isPoints": false
+                }
+              ],
+              "outputToken": {
+                "symbol": "aEthLINK",
+                "name": "Aave Ethereum LINK",
+                "decimals": 18,
+                "network": "eip155:11155111",
+                "address": "0x3FfAf50D4F4E96eB78f2407c090b72e86eCaed24",
+                "isPoints": false
+              },
+              "token": {
+                "symbol": "LINK",
+                "name": "LINK",
+                "decimals": 18,
+                "network": "eip155:11155111",
+                "address": "0xf8Fb3713D459D7C1018BD0A49D19b4C44290EBE5",
+                "isPoints": false
+              },
+              "rewardRate": {
+                "total": 6.478416940285867,
+                "rateType": "APY",
+                "components": [
+                  {
+                    "rate": 6.478416940285867,
+                    "rateType": "APY",
+                    "token": {
+                      "symbol": "LINK",
+                      "name": "LINK",
+                      "decimals": 18,
+                      "network": "eip155:11155111",
+                      "address": "0xf8Fb3713D459D7C1018BD0A49D19b4C44290EBE5",
+                      "isPoints": false
+                    },
+                    "yieldSource": "lending",
+                    "description": "Earn lending rewards by supplying LINK"
+                  }
+                ]
+              },
+              "status": { "enter": true, "exit": true },
+              "metadata": {
+                "name": "Aave v3 LINK Lending",
+                "logoURI": "https://assets.stakek.it/tokens/link.svg",
+                "description": "Lend your LINK with Aave v3",
+                "documentation": "https://docs.yield.xyz/docs/aave-lending",
+                "underMaintenance": false,
+                "deprecated": false,
+                "supportedStandards": []
+              },
+              "mechanics": {
+                "type": "lending",
+                "requiresValidatorSelection": false,
+                "rewardSchedule": "block",
+                "rewardClaiming": "auto",
+                "gasFeeToken": {
+                  "symbol": "ETH",
+                  "name": "Ethereum",
+                  "decimals": 18,
+                  "network": "eip155:11155111",
+                  "isPoints": false
+                },
+                "entryLimits": { "minimum": "0", "maximum": null },
+                "supportsLedgerWalletApi": true,
+                "arguments": {
+                  "enter": { "fields": [] },
+                  "exit": { "fields": [] }
+                },
+                "possibleFeeTakingMechanisms": {
+                  "depositFee": true,
+                  "managementFee": true,
+                  "performanceFee": true,
+                  "validatorRebates": false
+                }
+              },
+              "providerId": "aave",
+              "tags": ["lending"]
+            }
+          ],
+          "limit": 10,
+          "offset": 0,
+          "total": 1
+        }
+      }
+    }
+    """.data(using: .utf8)!
+
+    let decoded = try decoder.decode(YieldXyzGetYieldsResponse.self, from: json)
+
+    XCTAssertEqual(decoded.data?.rawResponse.items.count, 1)
+    XCTAssertEqual(
+      decoded.data?.rawResponse.items.first?.rewardRate.components.first?.yieldSource,
+      .lending
+    )
+  }
+}

--- a/Tests/PortalSwiftTests/Yield/YieldXyzDepositWithdrawTests.swift
+++ b/Tests/PortalSwiftTests/Yield/YieldXyzDepositWithdrawTests.swift
@@ -1,0 +1,387 @@
+//
+//  YieldXyzDepositWithdrawTests.swift
+//  PortalSwift
+//
+//  Created by Portal Labs
+//
+
+import Foundation
+@testable import PortalSwift
+import XCTest
+
+final class YieldXyzDepositWithdrawTests: XCTestCase {
+  private var apiMock: PortalYieldXyzApiMock!
+  private var portalMock: YieldXyzPortalDependencyMock!
+  private var yieldXyz: YieldXyz!
+
+  // Fast confirmation polling for tests.
+  private let fastOptions = YieldSubmitOptions(pollIntervalSeconds: 1, timeoutSeconds: 1)
+
+  override func setUpWithError() throws {
+    apiMock = PortalYieldXyzApiMock()
+    portalMock = YieldXyzPortalDependencyMock()
+    yieldXyz = YieldXyz(api: apiMock, portal: portalMock)
+  }
+
+  override func tearDownWithError() throws {
+    apiMock = nil
+    portalMock = nil
+    yieldXyz = nil
+  }
+
+  // MARK: - Helpers
+
+  private func evmUnsignedTransaction(to: String = "0xcontract") -> String {
+    """
+    {"from":"0xwalletaddress","to":"\(to)","data":"0xabcdef","value":"0x0","gasLimit":"0x5208","maxFeePerGas":"0x3b9aca00","maxPriorityFeePerGas":"0x3b9aca00","nonce":"0x5"}
+    """
+  }
+
+  private func makeEnterResponse(
+    transactions: [YieldXyzActionTransaction],
+    yieldId: String = "yield-1",
+    intent: YieldXyzActionIntent = .enter
+  ) -> YieldXyzEnterYieldResponse {
+    YieldXyzEnterYieldResponse(
+      data: .stub(rawResponse: .stub(intent: intent, yieldId: yieldId, transactions: transactions))
+    )
+  }
+
+  private func makeExitResponse(
+    transactions: [YieldXyzActionTransaction],
+    yieldId: String = "yield-1"
+  ) -> YieldXyzExitResponse {
+    YieldXyzExitResponse(
+      data: .stub(rawResponse: .stub(intent: .exit, yieldId: yieldId, transactions: transactions))
+    )
+  }
+}
+
+// MARK: - Deposit (yieldId mode)
+
+extension YieldXyzDepositWithdrawTests {
+  func test_deposit_byYieldId_singleEvmTx_succeeds() async throws {
+    let tx = YieldXyzActionTransaction.stub(unsignedTransaction: evmUnsignedTransaction(), stepIndex: 0)
+    apiMock.enterYieldReturnValue = makeEnterResponse(transactions: [tx])
+
+    let result = try await yieldXyz.deposit(
+      params: YieldDepositParams(target: .yieldId("yield-1"), amount: "0.1"),
+      options: fastOptions
+    )
+
+    XCTAssertEqual(result.status, .success)
+    XCTAssertEqual(result.hashes, ["0xhash1"])
+    XCTAssertEqual(result.yieldId, "yield-1")
+    XCTAssertNil(result.chain)
+    XCTAssertNil(result.token)
+    // yieldId mode resolves the chain via getYields, then enters.
+    XCTAssertEqual(apiMock.getYieldsCalls, 1)
+    XCTAssertEqual(apiMock.enterYieldCalls, 1)
+    XCTAssertEqual(apiMock.submitTransactionHashCalls, 1)
+    XCTAssertEqual(portalMock.sendCalls, 1)
+  }
+
+  func test_deposit_mergesAmountIntoArguments() async throws {
+    let tx = YieldXyzActionTransaction.stub(unsignedTransaction: evmUnsignedTransaction(), stepIndex: 0)
+    apiMock.enterYieldReturnValue = makeEnterResponse(transactions: [tx])
+
+    _ = try await yieldXyz.deposit(
+      params: YieldDepositParams(
+        target: .yieldId("yield-1"),
+        amount: "0.42",
+        arguments: YieldXyzEnterArguments(validatorAddress: "0xvalidator")
+      ),
+      options: fastOptions
+    )
+    // The amount should be merged into arguments while preserving validatorAddress (verified
+    // indirectly by a successful enter call; request payload assertion lives in API tests).
+    XCTAssertEqual(apiMock.enterYieldCalls, 1)
+  }
+
+  func test_deposit_multipleEvmTxs_succeeds() async throws {
+    let tx0 = YieldXyzActionTransaction.stub(id: "tx-0", type: .APPROVAL, unsignedTransaction: evmUnsignedTransaction(), stepIndex: 0)
+    let tx1 = YieldXyzActionTransaction.stub(id: "tx-1", type: .STAKE, unsignedTransaction: evmUnsignedTransaction(), stepIndex: 1)
+    apiMock.enterYieldReturnValue = makeEnterResponse(transactions: [tx0, tx1])
+
+    let result = try await yieldXyz.deposit(
+      params: YieldDepositParams(target: .yieldId("yield-1"), amount: "1.0"),
+      options: fastOptions
+    )
+
+    XCTAssertEqual(result.status, .success)
+    XCTAssertEqual(result.hashes, ["0xhash1", "0xhash2"])
+    XCTAssertEqual(apiMock.submitTransactionHashCalls, 2)
+    XCTAssertEqual(portalMock.sendCalls, 2)
+  }
+
+  func test_deposit_onChainFailure_returnsFailedAndStops() async throws {
+    portalMock.receiptStatus = "0x0"
+    let tx0 = YieldXyzActionTransaction.stub(id: "tx-0", unsignedTransaction: evmUnsignedTransaction(), stepIndex: 0)
+    let tx1 = YieldXyzActionTransaction.stub(id: "tx-1", unsignedTransaction: evmUnsignedTransaction(), stepIndex: 1)
+    apiMock.enterYieldReturnValue = makeEnterResponse(transactions: [tx0, tx1])
+
+    let result = try await yieldXyz.deposit(
+      params: YieldDepositParams(target: .yieldId("yield-1"), amount: "1.0"),
+      options: fastOptions
+    )
+
+    XCTAssertEqual(result.status, .failed)
+    XCTAssertEqual(result.hashes, ["0xhash1"]) // stopped after first failure
+    XCTAssertEqual(portalMock.sendCalls, 1)
+    XCTAssertEqual(apiMock.submitTransactionHashCalls, 1)
+  }
+
+  func test_deposit_uncertainConfirmation_returnsPartialSuccess() async throws {
+    portalMock.receiptAvailable = false // never mined within timeout
+    let tx0 = YieldXyzActionTransaction.stub(id: "tx-0", unsignedTransaction: evmUnsignedTransaction(), stepIndex: 0)
+    let tx1 = YieldXyzActionTransaction.stub(id: "tx-1", unsignedTransaction: evmUnsignedTransaction(), stepIndex: 1)
+    apiMock.enterYieldReturnValue = makeEnterResponse(transactions: [tx0, tx1])
+
+    let result = try await yieldXyz.deposit(
+      params: YieldDepositParams(target: .yieldId("yield-1"), amount: "1.0"),
+      options: fastOptions
+    )
+
+    XCTAssertEqual(result.status, .partialSuccess)
+    XCTAssertEqual(result.hashes, ["0xhash1"]) // stopped after uncertain
+  }
+
+  func test_deposit_emitsProgressSteps() async throws {
+    let tx = YieldXyzActionTransaction.stub(unsignedTransaction: evmUnsignedTransaction(), stepIndex: 0)
+    apiMock.enterYieldReturnValue = makeEnterResponse(transactions: [tx])
+
+    var steps: [YieldSubmitStep] = []
+    let options = YieldSubmitOptions(
+      onProgress: { steps.append($0.step) },
+      pollIntervalSeconds: 1,
+      timeoutSeconds: 1
+    )
+
+    _ = try await yieldXyz.deposit(params: YieldDepositParams(target: .yieldId("yield-1"), amount: "0.1"), options: options)
+
+    XCTAssertEqual(steps, [.signing, .submitted, .confirming, .confirmed])
+  }
+}
+
+// MARK: - Deposit (chain + token mode)
+
+extension YieldXyzDepositWithdrawTests {
+  func test_deposit_byChainAndToken_resolvesYieldIdAndEchoesChainToken() async throws {
+    apiMock.getYieldDefaultsReturnValue = YieldXyzGetDefaultsResponse(
+      data: ["eip155:11155111:ETH": .stub(yieldId: "resolved-yield")]
+    )
+    let tx = YieldXyzActionTransaction.stub(network: "eip155:11155111", unsignedTransaction: evmUnsignedTransaction(), stepIndex: 0)
+    apiMock.enterYieldReturnValue = makeEnterResponse(transactions: [tx], yieldId: "resolved-yield")
+
+    let result = try await yieldXyz.deposit(
+      params: YieldDepositParams(target: .chainAndToken(chain: "eip155:11155111", token: "ETH"), amount: "0.1"),
+      options: fastOptions
+    )
+
+    XCTAssertEqual(result.status, .success)
+    XCTAssertEqual(result.chain, "eip155:11155111")
+    XCTAssertEqual(result.token, "ETH")
+    XCTAssertEqual(apiMock.getYieldDefaultsCalls, 1)
+    XCTAssertEqual(apiMock.getYieldDefaultsIncludeOpportunitiesParam, false)
+    XCTAssertEqual(apiMock.getYieldsCalls, 0) // chain+token mode does not need discover
+  }
+
+  func test_deposit_byChainAndToken_noDefault_throws() async throws {
+    apiMock.getYieldDefaultsReturnValue = YieldXyzGetDefaultsResponse(data: [:])
+
+    do {
+      _ = try await yieldXyz.deposit(
+        params: YieldDepositParams(target: .chainAndToken(chain: "eip155:1", token: "DOGE"), amount: "1"),
+        options: fastOptions
+      )
+      XCTFail("Expected noYieldForChainToken error")
+    } catch let error as YieldXyzError {
+      XCTAssertEqual(error, .noYieldForChainToken("eip155:1:DOGE"))
+    }
+  }
+
+  func test_deposit_invalidChainId_throws() async throws {
+    do {
+      _ = try await yieldXyz.deposit(
+        params: YieldDepositParams(target: .chainAndToken(chain: "ethereum", token: "ETH"), amount: "1"),
+        options: fastOptions
+      )
+      XCTFail("Expected invalidChainId error")
+    } catch let error as YieldXyzError {
+      XCTAssertEqual(error, .invalidChainId("ethereum"))
+    }
+  }
+}
+
+// MARK: - Withdraw
+
+extension YieldXyzDepositWithdrawTests {
+  func test_withdraw_byYieldId_succeeds() async throws {
+    let tx = YieldXyzActionTransaction.stub(type: .UNSTAKE, unsignedTransaction: evmUnsignedTransaction(), stepIndex: 0)
+    apiMock.exitYieldReturnValue = makeExitResponse(transactions: [tx])
+
+    let result = try await yieldXyz.withdraw(
+      params: YieldWithdrawParams(target: .yieldId("yield-1"), amount: "0.1"),
+      options: fastOptions
+    )
+
+    XCTAssertEqual(result.status, .success)
+    XCTAssertEqual(apiMock.exitYieldCalls, 1)
+    XCTAssertEqual(result.yieldOpportunityDetails.intent, .exit)
+  }
+}
+
+// MARK: - Solana
+
+extension YieldXyzDepositWithdrawTests {
+  func test_deposit_solana_succeeds() async throws {
+    portalMock.solanaStatus = "confirmed"
+    let tx = YieldXyzActionTransaction.stub(network: "solana:mainnet", type: .STAKE, unsignedTransaction: "c29sYW5hLXR4", stepIndex: 0)
+    // yieldId mode: discover must report a solana network for address resolution.
+    apiMock.getYieldsReturnValue = YieldXyzGetYieldsResponse(
+      data: .stub(rawResponse: .stub(items: [.stub(network: "solana:mainnet")]))
+    )
+    apiMock.enterYieldReturnValue = makeEnterResponse(transactions: [tx])
+
+    let result = try await yieldXyz.deposit(
+      params: YieldDepositParams(target: .yieldId("solana-yield"), amount: "0.1"),
+      options: fastOptions
+    )
+
+    XCTAssertEqual(result.status, .success)
+    XCTAssertTrue(portalMock.requestedMethods.contains(.sol_signAndSendTransaction))
+    XCTAssertEqual(portalMock.getTransactionDetailsCalls, 1)
+  }
+
+  func test_deposit_solanaError_returnsFailed() async throws {
+    portalMock.solanaError = "blockhash expired"
+    let tx = YieldXyzActionTransaction.stub(network: "solana:mainnet", unsignedTransaction: "c29sYW5hLXR4", stepIndex: 0)
+    apiMock.getYieldsReturnValue = YieldXyzGetYieldsResponse(
+      data: .stub(rawResponse: .stub(items: [.stub(network: "solana:mainnet")]))
+    )
+    apiMock.enterYieldReturnValue = makeEnterResponse(transactions: [tx])
+
+    let result = try await yieldXyz.deposit(
+      params: YieldDepositParams(target: .yieldId("solana-yield"), amount: "0.1"),
+      options: fastOptions
+    )
+
+    XCTAssertEqual(result.status, .failed)
+  }
+}
+
+// MARK: - getValidators & errors
+
+extension YieldXyzDepositWithdrawTests {
+  func test_getValidators_returnsValidators() async throws {
+    apiMock.getYieldValidatorsReturnValue = YieldXyzGetValidatorsResponse(
+      data: .stub(rawResponse: .stub(items: [.stub(address: "0xv1"), .stub(address: "0xv2")]))
+    )
+
+    let validators = try await yieldXyz.getValidators(yieldId: "monad-testnet-mon-native-staking")
+
+    XCTAssertEqual(validators.count, 2)
+    XCTAssertEqual(apiMock.getYieldValidatorsCalls, 1)
+    XCTAssertEqual(apiMock.getYieldValidatorsYieldIdParam, "monad-testnet-mon-native-staking")
+  }
+
+  func test_getValidators_normalizesFromDataValidators() async throws {
+    apiMock.getYieldValidatorsReturnValue = YieldXyzGetValidatorsResponse(
+      data: YieldXyzGetValidatorsData(validators: [.stub(address: "0xtop")], rawResponse: nil)
+    )
+
+    let validators = try await yieldXyz.getValidators(yieldId: "y")
+
+    XCTAssertEqual(validators.first?.address, "0xtop")
+  }
+
+  func test_getValidators_emptyArray_throwsNoValidators() async throws {
+    apiMock.getYieldValidatorsReturnValue = YieldXyzGetValidatorsResponse(
+      data: YieldXyzGetValidatorsData(validators: [], rawResponse: nil)
+    )
+
+    do {
+      _ = try await yieldXyz.getValidators(yieldId: "y")
+      XCTFail("Expected noValidators error")
+    } catch let error as YieldXyzError {
+      XCTAssertEqual(error, .noValidators("y"))
+    }
+  }
+
+  func test_getValidators_backendError_throwsApiError() async throws {
+    apiMock.getYieldValidatorsReturnValue = YieldXyzGetValidatorsResponse(
+      data: nil,
+      error: "validators unavailable"
+    )
+
+    do {
+      _ = try await yieldXyz.getValidators(yieldId: "y")
+      XCTFail("Expected apiError")
+    } catch let error as YieldXyzError {
+      XCTAssertEqual(error, .apiError("validators unavailable"))
+    }
+  }
+
+  func test_deposit_byYieldId_normalizesFriendlyNetworkToCaip2() async throws {
+    apiMock.getYieldsReturnValue = YieldXyzGetYieldsResponse(
+      data: .stub(rawResponse: .stub(items: [.stub(network: "ethereum")]))
+    )
+    let tx = YieldXyzActionTransaction.stub(network: "eip155:1", unsignedTransaction: evmUnsignedTransaction(), stepIndex: 0)
+    apiMock.enterYieldReturnValue = makeEnterResponse(transactions: [tx])
+
+    _ = try await yieldXyz.deposit(
+      params: YieldDepositParams(target: .yieldId("yield-1"), amount: "0.1"),
+      options: fastOptions
+    )
+
+    XCTAssertEqual(portalMock.getAddressChainIdParam, "eip155:1")
+  }
+
+  func test_deposit_chainAndToken_defaultsError_throwsApiError() async throws {
+    apiMock.getYieldDefaultsReturnValue = YieldXyzGetDefaultsResponse(
+      data: nil,
+      error: "defaults service down"
+    )
+
+    do {
+      _ = try await yieldXyz.deposit(
+        params: YieldDepositParams(target: .chainAndToken(chain: "eip155:1", token: "ETH"), amount: "0.1"),
+        options: fastOptions
+      )
+      XCTFail("Expected apiError")
+    } catch let error as YieldXyzError {
+      XCTAssertEqual(error, .apiError("defaults service down"))
+    }
+  }
+
+  func test_deposit_byYieldId_getYieldsError_throwsApiError() async throws {
+    apiMock.getYieldsReturnValue = YieldXyzGetYieldsResponse(
+      data: nil,
+      error: "yields service down"
+    )
+
+    do {
+      _ = try await yieldXyz.deposit(
+        params: YieldDepositParams(target: .yieldId("yield-1"), amount: "0.1"),
+        options: fastOptions
+      )
+      XCTFail("Expected apiError")
+    } catch let error as YieldXyzError {
+      XCTAssertEqual(error, .apiError("yields service down"))
+    }
+  }
+
+  func test_deposit_withoutPortal_throwsPortalNotInitialized() async throws {
+    let detached = YieldXyz(api: apiMock) // no portal
+    apiMock.enterYieldReturnValue = makeEnterResponse(
+      transactions: [.stub(unsignedTransaction: evmUnsignedTransaction(), stepIndex: 0)]
+    )
+
+    do {
+      _ = try await detached.deposit(params: YieldDepositParams(target: .yieldId("yield-1"), amount: "1"), options: fastOptions)
+      XCTFail("Expected portalNotInitialized error")
+    } catch let error as YieldXyzError {
+      XCTAssertEqual(error, .portalNotInitialized)
+    }
+  }
+}

--- a/Tests/PortalSwiftTests/Yield/YieldXyzMock.swift
+++ b/Tests/PortalSwiftTests/Yield/YieldXyzMock.swift
@@ -19,6 +19,9 @@ final class YieldXyzMock: YieldXyzProtocol {
   var getHistoricalActionsReturnValue: YieldXyzGetHistoricalActionsResponse?
   var manageReturnValue: YieldXyzManageYieldResponse?
   var exitReturnValue: YieldXyzExitResponse?
+  var depositReturnValue: YieldDepositResult?
+  var withdrawReturnValue: YieldWithdrawResult?
+  var getValidatorsReturnValue: [YieldXyzValidator]?
 
   // Call counters
   var discoverCalls = 0
@@ -29,6 +32,9 @@ final class YieldXyzMock: YieldXyzProtocol {
   var getHistoricalActionsCalls = 0
   var manageCalls = 0
   var exitCalls = 0
+  var depositCalls = 0
+  var withdrawCalls = 0
+  var getValidatorsCalls = 0
 
   // Call parameters
   var discoverRequestParam: YieldXyzGetYieldsRequest?
@@ -40,6 +46,9 @@ final class YieldXyzMock: YieldXyzProtocol {
   var getHistoricalActionsRequestParam: YieldXyzGetHistoricalActionsRequest?
   var manageRequestParam: YieldXyzManageYieldRequest?
   var exitRequestParam: YieldXyzExitRequest?
+  var depositParamsParam: YieldDepositParams?
+  var withdrawParamsParam: YieldWithdrawParams?
+  var getValidatorsYieldIdParam: String?
 
   func discover(request: YieldXyzGetYieldsRequest?) async throws -> YieldXyzGetYieldsResponse {
     discoverCalls += 1
@@ -88,5 +97,23 @@ final class YieldXyzMock: YieldXyzProtocol {
     exitCalls += 1
     exitRequestParam = request
     return exitReturnValue ?? YieldXyzExitResponse.stub()
+  }
+
+  func deposit(params: YieldDepositParams, options _: YieldSubmitOptions?) async throws -> YieldDepositResult {
+    depositCalls += 1
+    depositParamsParam = params
+    return depositReturnValue ?? YieldDepositResult.stub()
+  }
+
+  func withdraw(params: YieldWithdrawParams, options _: YieldSubmitOptions?) async throws -> YieldWithdrawResult {
+    withdrawCalls += 1
+    withdrawParamsParam = params
+    return withdrawReturnValue ?? YieldWithdrawResult.stub()
+  }
+
+  func getValidators(yieldId: String) async throws -> [YieldXyzValidator] {
+    getValidatorsCalls += 1
+    getValidatorsYieldIdParam = yieldId
+    return getValidatorsReturnValue ?? [YieldXyzValidator.stub()]
   }
 }

--- a/Tests/PortalSwiftTests/Yield/YieldXyzPortalDependencyMock.swift
+++ b/Tests/PortalSwiftTests/Yield/YieldXyzPortalDependencyMock.swift
@@ -1,0 +1,105 @@
+//
+//  YieldXyzPortalDependencyMock.swift
+//  PortalSwift
+//
+//  Created by Portal Labs
+//
+
+import Foundation
+@testable import PortalSwift
+
+/// Mock of `YieldXyzPortalDependency` for testing the high-level deposit/withdraw flow.
+final class YieldXyzPortalDependencyMock: YieldXyzPortalDependency {
+  // Configurable behavior
+  var defaultAddress: String? = "0xwalletaddress"
+  var addressByChain: [String: String] = [:]
+  /// Hashes returned for successive send calls (eth_sendTransaction / sol_signAndSendTransaction).
+  var sendHashes: [String] = ["0xhash1", "0xhash2", "0xhash3"]
+  /// EVM receipt status returned by eth_getTransactionReceipt ("0x1" success, "0x0" failure).
+  var receiptStatus: String? = "0x1"
+  /// When false, eth_getTransactionReceipt returns a response with a nil result (not mined yet).
+  var receiptAvailable = true
+  /// Solana confirmation status returned by getTransactionDetails.
+  var solanaStatus = "confirmed"
+  var solanaError: String?
+  var solanaAvailable = true
+
+  // Captured calls
+  private(set) var sendCalls = 0
+  private(set) var receiptCalls = 0
+  private(set) var getAddressCalls = 0
+  private(set) var getAddressChainIdParam: String?
+  private(set) var getTransactionDetailsCalls = 0
+  private(set) var requestedMethods: [PortalRequestMethod] = []
+  private(set) var requestedChainIds: [String] = []
+  private(set) var lastEthParam: ETHTransactionParam?
+
+  func request(chainId: String, method: PortalRequestMethod, params: [Any], options _: RequestOptions?) async throws -> PortalProviderResult {
+    requestedMethods.append(method)
+    requestedChainIds.append(chainId)
+
+    switch method {
+    case .eth_sendTransaction:
+      if let param = params.first as? ETHTransactionParam {
+        lastEthParam = param
+      }
+      let hash = sendCalls < sendHashes.count ? sendHashes[sendCalls] : "0xhash\(sendCalls)"
+      sendCalls += 1
+      return PortalProviderResult(id: "1", result: hash)
+    case .sol_signAndSendTransaction:
+      let hash = sendCalls < sendHashes.count ? sendHashes[sendCalls] : "solhash\(sendCalls)"
+      sendCalls += 1
+      return PortalProviderResult(id: "1", result: hash)
+    case .eth_getTransactionReceipt:
+      receiptCalls += 1
+      return PortalProviderResult(id: "1", result: makeReceiptResponse())
+    default:
+      return PortalProviderResult(id: "1", result: "")
+    }
+  }
+
+  func getAddress(_ forChainId: String) async -> String? {
+    getAddressCalls += 1
+    getAddressChainIdParam = forChainId
+    return addressByChain[forChainId] ?? defaultAddress
+  }
+
+  func getTransactionDetails(chain _: String, signature _: String) async throws -> GetTransactionDetailsResponse {
+    getTransactionDetailsCalls += 1
+    return makeSolanaDetailsResponse()
+  }
+
+  // MARK: - Helpers
+
+  private func makeReceiptResponse() -> EthTransactionResponse {
+    guard receiptAvailable else {
+      let json = "{\"jsonrpc\":\"2.0\",\"id\":1}"
+      return decode(EthTransactionResponse.self, from: json)
+    }
+    let statusField = receiptStatus.map { ",\"status\":\"\($0)\"" } ?? ""
+    let json = """
+    {"jsonrpc":"2.0","id":1,"result":{"blockHash":"0xblock","blockNumber":"0x1","from":"0xwalletaddress","transactionIndex":"0x0","type":"0x2"\(statusField)}}
+    """
+    return decode(EthTransactionResponse.self, from: json)
+  }
+
+  private func makeSolanaDetailsResponse() -> GetTransactionDetailsResponse {
+    let solanaField: String
+    if solanaAvailable {
+      let errorField = solanaError.map { ",\"error\":\"\($0)\"" } ?? ""
+      solanaField = "\"solanaTransaction\":{\"signature\":\"sig\",\"status\":\"\(solanaStatus)\"\(errorField)}"
+    } else {
+      solanaField = "\"solanaTransaction\":null"
+    }
+    let json = """
+    {"data":{\(solanaField)},"metadata":{"chainId":"solana:mainnet","signature":"sig"}}
+    """
+    return decode(GetTransactionDetailsResponse.self, from: json)
+  }
+
+  private func decode<T: Decodable>(_ type: T.Type, from json: String) -> T {
+    // Force-unwrap is acceptable in a test mock with controlled JSON.
+    // swiftlint:disable:next force_try
+    try! JSONDecoder().decode(type, from: json.data(using: .utf8)!)
+  }
+}


### PR DESCRIPTION
## Release `7.3.0` - 2026-07-21
- Added Noah on/off-ramp integration for fiat payins, payouts, and KYC via the new `portal.ramps` namespace.
    - Added `portal.ramps.noah.initiateKyc`
    - Added `portal.ramps.noah.initiatePayin` and `portal.ramps.noah.simulatePayin`
    - Added `portal.ramps.noah.getPaymentMethods`
    - Added `portal.ramps.noah.getPayoutCountries`, `portal.ramps.noah.getPayoutChannels`, and `portal.ramps.noah.getPayoutChannelForm`
    - Added `portal.ramps.noah.getPayoutQuote` and `portal.ramps.noah.initiatePayout`
- Added high-level Li.Fi swap methods for one-call cross-chain bridging.
    - Added `portal.trading.lifi.tradeAsset` — fetches routes and, for each step, signs, submits, waits for on-chain confirmation, and polls Li.Fi status until the transfer completes.
    - Added `portal.trading.lifi.pollStatus` to poll a transfer's status until it is done, with an optional progress callback and polling controlled by `LifiPollStatusOptions`.
- Added high-level Yield.xyz deposit and withdraw methods.
    - Added `portal.yield.yieldxyz.deposit` and `portal.yield.yieldxyz.withdraw`, which resolve the yield, build the transactions, then sign, submit, and confirm each step for you.
    - Added `portal.yield.yieldxyz.getValidators` (and the convenience `portal.yield.getValidators`) for native-staking validators.
    - Target a yield by explicit `yieldId` or by chain and token, and track progress and tune polling via `YieldSubmitOptions`.
    - Added the `lending` case to `YieldXyzSource`.
- Added high-level delegation methods that construct and broadcast a transaction in a single call.
    - Added `portal.delegations.approveAndSubmit`, `portal.delegations.revokeAndSubmit`, and `portal.delegations.transferAndSubmit`.
    - Added `portal.delegations.setSignAndSendTransaction` to override the default signer, or supply a per-call override and progress callback via `DelegationSubmitOptions`.
- Added pre-generated wallet support via the `FeatureFlags.usePreGeneratedWallet` flag.
    - When enabled, wallet generation draws from the pre-generated wallet pool, with automatic fallback to on-device generation on transient server errors.
- Added request tracing via an `X-Portal-Trace-Id` header attached to all client API requests for end-to-end request correlation.
    - Multi-step flows (such as `sendAsset`, MPC generate/backup/recover, and `upgradeTo7702`) share a single trace ID across their underlying calls.
    - Added an optional `traceId` parameter to `SendAssetParams` and `RequestOptions`; if omitted, one is generated automatically.


> **Copilot Review:** GitHub Copilot will automatically post a review below. Check its comments for additional context and suggestions.
