### PR TITLE
Send `x-api-key` header on SPM Example custodian requests

### DIFF
--- a/SPM Example/PortalSwift/Info.plist
+++ b/SPM Example/PortalSwift/Info.plist
@@ -8,6 +8,14 @@
 	<string>$(SWAPS_API_KEY)</string>
 	<key>BACKUP_WITH_PORTAL</key>
 	<string>$(BACKUP_WITH_PORTAL)</string>
+	<key>PORTAL_EX_PROD_API_KEY</key>
+	<string>$(PORTAL_EX_PROD_API_KEY)</string>
+	<key>PORTAL_EX_STAGING_API_KEY</key>
+	<string>$(PORTAL_EX_STAGING_API_KEY)</string>
+	<key>PORTAL_EX_BACKUP_WITH_PORTAL_PROD_API_KEY</key>
+	<string>$(PORTAL_EX_BACKUP_WITH_PORTAL_PROD_API_KEY)</string>
+	<key>PORTAL_EX_BACKUP_WITH_PORTAL_STAGING_API_KEY</key>
+	<string>$(PORTAL_EX_BACKUP_WITH_PORTAL_STAGING_API_KEY)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/SPM Example/PortalSwift/MainViewController/FirebaseAuthViewController.swift
+++ b/SPM Example/PortalSwift/MainViewController/FirebaseAuthViewController.swift
@@ -349,7 +349,7 @@ class FirebaseAuthViewController: UIViewController {
             let message: String?
           }
 
-          let request = PortalAPIRequest(url: url, method: .post, payload: payload)
+          let request = PortalAPIRequest.custodian(url: url, method: .post, payload: payload)
           _ = try await requests.execute(request: request, mappingInResponse: ResponseType.self)
         }
 
@@ -400,7 +400,7 @@ class FirebaseAuthViewController: UIViewController {
           guard let url = URL(string: "\(config.custodianServerUrl)/mobile/\(user.exchangeUserId)/cipher-text/fetch?backupMethod=FIREBASE") else {
             throw URLError(.badURL)
           }
-          let request = PortalAPIRequest(url: url)
+          let request = PortalAPIRequest.custodian(url: url)
           let response = try await requests.execute(request: request, mappingInResponse: CipherTextResult.self)
           cipherText = response.cipherText
         }
@@ -459,7 +459,7 @@ class FirebaseAuthViewController: UIViewController {
           ) else {
             throw URLError(.badURL)
           }
-          let cipherTextRequest = PortalAPIRequest(url: cipherTextUrl)
+          let cipherTextRequest = PortalAPIRequest.custodian(url: cipherTextUrl)
           let cipherTextResponse = try await requests.execute(request: cipherTextRequest, mappingInResponse: CipherTextResult.self)
           cipherText = cipherTextResponse.cipherText
 
@@ -468,7 +468,7 @@ class FirebaseAuthViewController: UIViewController {
           ) else {
             throw URLError(.badURL)
           }
-          let organizationBackupShareRequest = PortalAPIRequest(url: organizationBackupShareUrl)
+          let organizationBackupShareRequest = PortalAPIRequest.custodian(url: organizationBackupShareUrl)
           let organizationBackupShareResponse = try await requests.execute(request: organizationBackupShareRequest, mappingInResponse: OrgShareResult.self)
           organizationShare = organizationBackupShareResponse.orgShare
 
@@ -478,7 +478,7 @@ class FirebaseAuthViewController: UIViewController {
           ) else {
             throw URLError(.badURL)
           }
-          let organizationSolanaBackupShareRequest = PortalAPIRequest(url: organizationSolanaBackupShareUrl)
+          let organizationSolanaBackupShareRequest = PortalAPIRequest.custodian(url: organizationSolanaBackupShareUrl)
           let organizationSolanaBackupShareResponse = try? await requests.execute(request: organizationSolanaBackupShareRequest, mappingInResponse: OrgShareResult.self)
           if let organizationSolanaBackupShareResponse {
             organizationSolanaShare = organizationSolanaBackupShareResponse.orgShare
@@ -514,12 +514,12 @@ class FirebaseAuthViewController: UIViewController {
             throw URLError(.badURL)
           }
 
-          let prepareEjectRequest = PortalAPIRequest(url: prepareEjectUrl, method: .post, payload: ["walletId": walletId])
+          let prepareEjectRequest = PortalAPIRequest.custodian(url: prepareEjectUrl, method: .post, payload: ["walletId": walletId])
           let prepareEjectResponse = try await requests.execute(request: prepareEjectRequest, mappingInResponse: String.self)
           self.logger.debug("FirebaseAuth.eject - Ethereum wallet ejectable until \(prepareEjectResponse)")
 
           if let walletIdEd25519 {
-            let prepareEjectEd25519Request = PortalAPIRequest(url: prepareEjectUrl, method: .post, payload: ["walletId": walletIdEd25519])
+            let prepareEjectEd25519Request = PortalAPIRequest.custodian(url: prepareEjectUrl, method: .post, payload: ["walletId": walletIdEd25519])
             let prepareEjectResponseEd25519 = try await requests.execute(request: prepareEjectEd25519Request, mappingInResponse: String.self)
             self.logger.debug("FirebaseAuth.eject - Solana wallet ejectable until \(prepareEjectResponseEd25519)")
           }

--- a/SPM Example/PortalSwift/MainViewController/ViewController.swift
+++ b/SPM Example/PortalSwift/MainViewController/ViewController.swift
@@ -219,7 +219,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
         let message: String?
       }
 
-      let request = PortalAPIRequest(url: url, method: .post, payload: payload)
+      let request = PortalAPIRequest.custodian(url: url, method: .post, payload: payload)
       let result = try await requests.execute(request: request, mappingInResponse: ResponseType.self)
       try await storageCallback()
 
@@ -277,7 +277,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
         throw URLError(.badURL)
       }
 
-      let cipherTextRequest = PortalAPIRequest(url: cipherTextUrl)
+      let cipherTextRequest = PortalAPIRequest.custodian(url: cipherTextUrl)
       let cipherTextResponse = try await requests.execute(request: cipherTextRequest, mappingInResponse: CipherTextResult.self)
       cipherText = cipherTextResponse.cipherText
 
@@ -287,7 +287,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
         throw URLError(.badURL)
       }
 
-      let organizationBackupShareRequest = PortalAPIRequest(url: organizationBackupShareUrl)
+      let organizationBackupShareRequest = PortalAPIRequest.custodian(url: organizationBackupShareUrl)
       let organizationBackupShareResponse = try await requests.execute(request: organizationBackupShareRequest, mappingInResponse: OrgShareResult.self)
 
       organizationShare = organizationBackupShareResponse.orgShare
@@ -313,7 +313,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
         throw URLError(.badURL)
       }
 
-      let prepareEjectRequest = PortalAPIRequest(url: prepareEjectUrl, method: .post, payload: ["walletId": walletId])
+      let prepareEjectRequest = PortalAPIRequest.custodian(url: prepareEjectUrl, method: .post, payload: ["walletId": walletId])
       let prepareEjectResponse = try await requests.execute(request: prepareEjectRequest, mappingInResponse: String.self)
 
       print("Ethereum Wallet ejectable until \(prepareEjectResponse)")
@@ -359,7 +359,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
         throw URLError(.badURL)
       }
 
-      let cipherTextRequest = PortalAPIRequest(url: cipherTextUrl)
+      let cipherTextRequest = PortalAPIRequest.custodian(url: cipherTextUrl)
       let cipherTextResponse = try await requests.execute(request: cipherTextRequest, mappingInResponse: CipherTextResult.self)
 
       cipherText = cipherTextResponse.cipherText
@@ -369,7 +369,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
       ) else {
         throw URLError(.badURL)
       }
-      let organizationBackupShareRequest = PortalAPIRequest(url: organizationBackupShareUrl)
+      let organizationBackupShareRequest = PortalAPIRequest.custodian(url: organizationBackupShareUrl)
       let organizationBackupShareResponse = try await requests.execute(request: organizationBackupShareRequest, mappingInResponse: OrgShareResult.self)
 
       organizationShare = organizationBackupShareResponse.orgShare
@@ -379,7 +379,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
       ) else {
         throw URLError(.badURL)
       }
-      let organizationSolanaBackupShareRequest = PortalAPIRequest(url: organizationSolanaBackupShareUrl)
+      let organizationSolanaBackupShareRequest = PortalAPIRequest.custodian(url: organizationSolanaBackupShareUrl)
       let organizationSolanaBackupShareResponse = try? await requests.execute(request: organizationSolanaBackupShareRequest, mappingInResponse: OrgShareResult.self)
       if let organizationSolanaBackupShareResponse {
         organizationSolanaShare = organizationSolanaBackupShareResponse.orgShare
@@ -413,13 +413,13 @@ class ViewController: UIViewController, UITextFieldDelegate {
       guard let prepareEjectUrl = URL(string: "\(config.custodianServerUrl)/mobile/\(user.exchangeUserId)/prepare-eject") else {
         throw URLError(.badURL)
       }
-      let prepareEjectRequest = PortalAPIRequest(url: prepareEjectUrl, method: .post, payload: ["walletId": walletId])
+      let prepareEjectRequest = PortalAPIRequest.custodian(url: prepareEjectUrl, method: .post, payload: ["walletId": walletId])
       let prepareEjectResponse = try await requests.execute(request: prepareEjectRequest, mappingInResponse: String.self)
 
       print("Ethereum Wallet ejectable until \(prepareEjectResponse)")
 
       if let walletIdEd25519 {
-        let prepareEjectEd25519Request = PortalAPIRequest(url: prepareEjectUrl, method: .post, payload: ["walletId": walletIdEd25519])
+        let prepareEjectEd25519Request = PortalAPIRequest.custodian(url: prepareEjectUrl, method: .post, payload: ["walletId": walletIdEd25519])
         let prepareEjectResponseEd25519 = try await requests.execute(request: prepareEjectEd25519Request, mappingInResponse: String.self)
 
         print("Solana Wallet ejectable until \(prepareEjectResponseEd25519)")
@@ -573,7 +573,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
       guard let url = URL(string: "\(config.custodianServerUrl)/mobile/\(userId)/cipher-text/fetch?backupMethod=\(withBackupMethod.rawValue)") else {
         throw URLError(.badURL)
       }
-      let request = PortalAPIRequest(url: url)
+      let request = PortalAPIRequest.custodian(url: url)
       let response = try await requests.execute(request: request, mappingInResponse: CipherTextResult.self)
       cipherText = response.cipherText
     }
@@ -799,7 +799,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
       if let url = URL(string: "\(config.custodianServerUrl)/mobile/login") {
         let payload = ["username": username]
 
-        let request = PortalAPIRequest(url: url, method: .post, payload: payload)
+        let request = PortalAPIRequest.custodian(url: url, method: .post, payload: payload)
         let user = try await requests.execute(request: request, mappingInResponse: UserResult.self)
 
         self.user = user
@@ -824,7 +824,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
           payload["isAccountAbstracted"] = AnyCodable(true)
         }
 
-        let request = PortalAPIRequest(url: url, method: .post, payload: payload)
+        let request = PortalAPIRequest.custodian(url: url, method: .post, payload: payload)
         let user = try await requests.execute(request: request, mappingInResponse: UserResult.self)
 
         self.user = user
@@ -1531,7 +1531,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
       "cipherText": generateSolanaResult.cipherText
     ]
 
-    let request = PortalAPIRequest(url: url, method: .post, payload: payload)
+    let request = PortalAPIRequest.custodian(url: url, method: .post, payload: payload)
     let result = try await requests.execute(request: request, mappingInResponse: String.self)
 
     try await generateSolanaResult.storageCallback()
@@ -1577,7 +1577,7 @@ class ViewController: UIViewController, UITextFieldDelegate {
       ]
 
     do {
-      let request = PortalAPIRequest(url: url, method: .post, payload: payload)
+      let request = PortalAPIRequest.custodian(url: url, method: .post, payload: payload)
       let jsonDictionary = try await requests.execute(request: request, mappingInResponse: [String: String].self)
       guard let txnHash = jsonDictionary["txHash"] else {
         self.logger.error("ViewController.sendSepoliaTransaction() - ❌ Invalid response type for request.")

--- a/SPM Example/PortalSwift/Settings/PortalAPIRequest+Custodian.swift
+++ b/SPM Example/PortalSwift/Settings/PortalAPIRequest+Custodian.swift
@@ -10,7 +10,7 @@ import Foundation
 import PortalSwift
 
 /// Header the PortalEx custodian server expects on every request.
-let CUSTODIAN_API_KEY_HEADER = "x-api-key"
+private let CUSTODIAN_API_KEY_HEADER = "x-api-key"
 
 extension PortalAPIRequest {
   /// Builds a request for the PortalEx custodian server, stamping the environment-specific

--- a/SPM Example/PortalSwift/Settings/PortalAPIRequest+Custodian.swift
+++ b/SPM Example/PortalSwift/Settings/PortalAPIRequest+Custodian.swift
@@ -1,0 +1,37 @@
+//
+//  PortalAPIRequest+Custodian.swift
+//  SPM Example
+//
+//  Created by Ahmed Ragab on 12/08/2026.
+//  Copyright © 2026 Portal. All rights reserved.
+//
+
+import Foundation
+import PortalSwift
+
+/// Header the PortalEx custodian server expects on every request.
+let CUSTODIAN_API_KEY_HEADER = "x-api-key"
+
+extension PortalAPIRequest {
+  /// Builds a request for the PortalEx custodian server, stamping the environment-specific
+  /// `x-api-key` header the custodian requires.
+  ///
+  /// Use this instead of `PortalAPIRequest(url:method:payload:)` for every request to
+  /// `ApplicationConfiguration.custodianServerUrl`. Requests to the Portal API itself must keep
+  /// using the plain initializer, as they authenticate with a bearer token instead.
+  static func custodian(
+    url: URL,
+    method: HttpMethod = .get,
+    payload: (any Codable)? = nil
+  ) -> PortalAPIRequest {
+    let request = PortalAPIRequest(url: url, method: method, payload: payload)
+
+    // Empty for `.localHost`, which runs a custodian server that doesn't check the key.
+    // For production and staging, `Settings.requireSecret` guarantees this is non-empty.
+    if let custodianApiKey = Settings.shared.portalConfig.appConfig?.custodianApiKey, !custodianApiKey.isEmpty {
+      request.headers[CUSTODIAN_API_KEY_HEADER] = custodianApiKey
+    }
+
+    return request
+  }
+}

--- a/SPM Example/PortalSwift/Settings/Settings.swift
+++ b/SPM Example/PortalSwift/Settings/Settings.swift
@@ -14,6 +14,9 @@ struct ApplicationConfiguration {
   let alchemyApiKey: String
   let apiUrl: String
   let custodianServerUrl: String
+  /// API key sent as the `x-api-key` header on every custodian server request.
+  /// Empty means no header is sent, which is the case for `.localHost`.
+  let custodianApiKey: String
   let googleClientId: String
   let mpcUrl: String
   let webAuthnHost: String
@@ -83,16 +86,20 @@ extension Settings {
         throw PortalExampleAppError.environmentNotSet()
       }
 
+      let isBackupWithPortal = BACKUP_WITH_PORTAL == "true"
+
       switch portalConfig.environment {
       case .production:
         logger.info("Settings - configuring for production")
 
-        let custodianServerUrl = BACKUP_WITH_PORTAL == "true" ? "https://prod-portalex-backup-with-portal.onrender.com" : "https://portalex-mpc.portalhq.io"
+        let custodianServerUrl = isBackupWithPortal ? "https://prod-portalex-backup-with-portal.onrender.com" : "https://portalex-mpc.portalhq.io"
+        let custodianApiKey = try requireSecret(isBackupWithPortal ? "PORTAL_EX_BACKUP_WITH_PORTAL_PROD_API_KEY" : "PORTAL_EX_PROD_API_KEY", from: infoDictionary)
 
         portalConfig.appConfig = ApplicationConfiguration(
           alchemyApiKey: ALCHEMY_API_KEY,
           apiUrl: "api.portalhq.io",
           custodianServerUrl: custodianServerUrl,
+          custodianApiKey: custodianApiKey,
           googleClientId: GOOGLE_CLIENT_ID,
           mpcUrl: "mpc.portalhq.io",
           webAuthnHost: "backup.web.portalhq.io",
@@ -102,12 +109,14 @@ extension Settings {
       case .staging:
         logger.info("Settings - configuring for staging")
 
-        let custodianServerUrl = BACKUP_WITH_PORTAL == "true" ? "https://staging-portalex-backup-with-portal.onrender.com" : "https://staging-portalex-mpc-service.onrender.com"
+        let custodianServerUrl = isBackupWithPortal ? "https://staging-portalex-backup-with-portal.onrender.com" : "https://staging-portalex-mpc-service.onrender.com"
+        let custodianApiKey = try requireSecret(isBackupWithPortal ? "PORTAL_EX_BACKUP_WITH_PORTAL_STAGING_API_KEY" : "PORTAL_EX_STAGING_API_KEY", from: infoDictionary)
 
         portalConfig.appConfig = ApplicationConfiguration(
           alchemyApiKey: ALCHEMY_API_KEY,
           apiUrl: "api.portalhq.dev",
           custodianServerUrl: custodianServerUrl,
+          custodianApiKey: custodianApiKey,
           googleClientId: GOOGLE_CLIENT_ID,
           mpcUrl: "mpc.portalhq.dev",
           webAuthnHost: "backup.portalhq.dev",
@@ -121,6 +130,7 @@ extension Settings {
           alchemyApiKey: ALCHEMY_API_KEY,
           apiUrl: "localhost:3001",
           custodianServerUrl: "http://localhost:3010",
+          custodianApiKey: "",
           googleClientId: GOOGLE_CLIENT_ID,
           mpcUrl: "localhost:3002",
           webAuthnHost: "localhost:8080",
@@ -132,5 +142,19 @@ extension Settings {
     } catch {
       self.logger.error("Settings - Error loading application config: \(error)")
     }
+  }
+
+  /// Reads a required value from the Info.plist.
+  ///
+  /// Note the `isEmpty` check: Xcode expands an undefined `$(VAR)` to an empty string, so the
+  /// Info.plist key still exists and a plain `as? String` cast would succeed. Without this check a
+  /// missing Secrets.xcconfig entry would silently produce `""` instead of an error.
+  private func requireSecret(_ key: String, from infoDictionary: [String: Any]) throws -> String {
+    guard let value: String = infoDictionary[key] as? String, !value.trimmingCharacters(in: .whitespaces).isEmpty else {
+      self.logger.error("Settings - Error: Do you have `\(key)=<your key>` in your Secrets.xcconfig, and `\(key)=$(\(key))` referenced in your App's info.plist?")
+      throw PortalExampleAppError.environmentNotSet()
+    }
+
+    return value
   }
 }

--- a/SPM Example/PortalSwift/Settings/Settings.swift
+++ b/SPM Example/PortalSwift/Settings/Settings.swift
@@ -64,6 +64,32 @@ class Settings: ObservableObject {
   var usePreGeneratedWallet: Bool = true
 }
 
+// MARK: - Custodian Server Configuration
+
+/// Environment-specific values for the PortalEx custodian server.
+///
+/// These live here rather than inline in `loadApplicationConfig()` so every URL and Secrets key
+/// name has a single home.
+private enum CustodianServer {
+  /// Base URL of the custodian server backing each environment.
+  enum Url {
+    static let production = "https://portalex-mpc.portalhq.io"
+    static let productionBackupWithPortal = "https://prod-portalex-backup-with-portal.onrender.com"
+    static let staging = "https://staging-portalex-mpc-service.onrender.com"
+    static let stagingBackupWithPortal = "https://staging-portalex-backup-with-portal.onrender.com"
+    static let localHost = "http://localhost:3010"
+  }
+
+  /// Info.plist keys (fed from Secrets.xcconfig) holding the `x-api-key` for each environment.
+  /// `.localHost` has none: the custodian server it runs doesn't check the header.
+  enum ApiKeyPlistKey {
+    static let production = "PORTAL_EX_PROD_API_KEY"
+    static let productionBackupWithPortal = "PORTAL_EX_BACKUP_WITH_PORTAL_PROD_API_KEY"
+    static let staging = "PORTAL_EX_STAGING_API_KEY"
+    static let stagingBackupWithPortal = "PORTAL_EX_BACKUP_WITH_PORTAL_STAGING_API_KEY"
+  }
+}
+
 // MARK: - App Configuration
 
 extension Settings {
@@ -92,8 +118,9 @@ extension Settings {
       case .production:
         logger.info("Settings - configuring for production")
 
-        let custodianServerUrl = isBackupWithPortal ? "https://prod-portalex-backup-with-portal.onrender.com" : "https://portalex-mpc.portalhq.io"
-        let custodianApiKey = try requireSecret(isBackupWithPortal ? "PORTAL_EX_BACKUP_WITH_PORTAL_PROD_API_KEY" : "PORTAL_EX_PROD_API_KEY", from: infoDictionary)
+        let custodianServerUrl = isBackupWithPortal ? CustodianServer.Url.productionBackupWithPortal : CustodianServer.Url.production
+        let custodianApiKeyPlistKey = isBackupWithPortal ? CustodianServer.ApiKeyPlistKey.productionBackupWithPortal : CustodianServer.ApiKeyPlistKey.production
+        let custodianApiKey = try requireSecret(custodianApiKeyPlistKey, from: infoDictionary)
 
         portalConfig.appConfig = ApplicationConfiguration(
           alchemyApiKey: ALCHEMY_API_KEY,
@@ -109,8 +136,9 @@ extension Settings {
       case .staging:
         logger.info("Settings - configuring for staging")
 
-        let custodianServerUrl = isBackupWithPortal ? "https://staging-portalex-backup-with-portal.onrender.com" : "https://staging-portalex-mpc-service.onrender.com"
-        let custodianApiKey = try requireSecret(isBackupWithPortal ? "PORTAL_EX_BACKUP_WITH_PORTAL_STAGING_API_KEY" : "PORTAL_EX_STAGING_API_KEY", from: infoDictionary)
+        let custodianServerUrl = isBackupWithPortal ? CustodianServer.Url.stagingBackupWithPortal : CustodianServer.Url.staging
+        let custodianApiKeyPlistKey = isBackupWithPortal ? CustodianServer.ApiKeyPlistKey.stagingBackupWithPortal : CustodianServer.ApiKeyPlistKey.staging
+        let custodianApiKey = try requireSecret(custodianApiKeyPlistKey, from: infoDictionary)
 
         portalConfig.appConfig = ApplicationConfiguration(
           alchemyApiKey: ALCHEMY_API_KEY,
@@ -129,7 +157,7 @@ extension Settings {
         portalConfig.appConfig = ApplicationConfiguration(
           alchemyApiKey: ALCHEMY_API_KEY,
           apiUrl: "localhost:3001",
-          custodianServerUrl: "http://localhost:3010",
+          custodianServerUrl: CustodianServer.Url.localHost,
           custodianApiKey: "",
           googleClientId: GOOGLE_CLIENT_ID,
           mpcUrl: "localhost:3002",
@@ -144,13 +172,18 @@ extension Settings {
     }
   }
 
-  /// Reads a required value from the Info.plist.
+  /// Reads a required value from the Info.plist, trimmed of surrounding whitespace.
   ///
   /// Note the `isEmpty` check: Xcode expands an undefined `$(VAR)` to an empty string, so the
   /// Info.plist key still exists and a plain `as? String` cast would succeed. Without this check a
   /// missing Secrets.xcconfig entry would silently produce `""` instead of an error.
+  ///
+  /// The trimmed value is what gets returned, so a stray space in Secrets.xcconfig can't leak into
+  /// a request header and cause an authentication failure that's hard to trace back to here.
   private func requireSecret(_ key: String, from infoDictionary: [String: Any]) throws -> String {
-    guard let value: String = infoDictionary[key] as? String, !value.trimmingCharacters(in: .whitespaces).isEmpty else {
+    let value = (infoDictionary[key] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    guard let value, !value.isEmpty else {
       self.logger.error("Settings - Error: Do you have `\(key)=<your key>` in your Secrets.xcconfig, and `\(key)=$(\(key))` referenced in your App's info.plist?")
       throw PortalExampleAppError.environmentNotSet()
     }

--- a/SPM Example/SPM Example.xcodeproj/project.pbxproj
+++ b/SPM Example/SPM Example.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		D8A2B4FD2D0229B300890CDA /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				"PortalAPIRequest+Custodian.swift",
 				Settings.swift,
 				SettingsView.swift,
 			);


### PR DESCRIPTION
## Summary
Send `x-api-key` header on SPM Example custodian requests

> **Copilot Review:** GitHub Copilot will automatically post a review below. Check its comments for additional context and suggestions.
